### PR TITLE
feat(skills): add question/questionnaire tool reference for multi-agent support

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
     "name": "aifhub-extension",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Spec-driven workflow for AI Factory: analyze, plan, verify, fix, finalize, and manage artifacts",
     "skills": [
         "skills/aif-analyze",

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -2,6 +2,7 @@
 name: aif-done
 description: Finalize a plan, mark it complete, and archive artifacts to specs/. Use after /aif-verify passes or when manually marking work as done.
 argument-hint: "[plan-id] [--summary] [--force]"
+allowed-tools: Read Write Glob Grep Bash(mkdir *) Bash(cp *) Bash(rm -rf *) question Questions
 version: 0.7.0
 ---
 
@@ -82,14 +83,15 @@ Acceptable completion state:
 
 If NOT eligible:
 ```
-AskUserQuestion: Plan status is "<current_status>" with verdict "<verdict>".
-
-This plan hasn't passed verification yet.
-
-Options:
-1. Run verification now — Run /aif-verify first (recommended)
-2. Finalize with force — Mark as done without verification (--force)
-3. Cancel
+question(questions: [{
+  header: "Статус",
+  question: "Статус плана: \"{{current_status}}\" с вердиктом \"{{verdict}}\".\n\nПлан ещё не прошёл верификацию.",
+  options: [
+    { label: "Запустить верификацию (Рекомендуется)", description: "/aif-verify" },
+    { label: "Завершить принудительно (--force)", description: "Без верификации" },
+    { label: "Отмена", description: "Выйти" }
+  ]
+}])
 ```
 
 ### Force Mode (`--force`)
@@ -153,11 +155,14 @@ Generate an extended summary including:
 - Lessons learned (ask user):
 
 ```
-AskUserQuestion: Any lessons learned from this plan?
-
-Options:
-1. Add lessons learned — I have notes to capture
-2. Skip — No lessons this time
+question(questions: [{
+  header: "Уроки",
+  question: "Есть ли уроки, извлечённые из этого плана?",
+  options: [
+    { label: "Да — Добав уроки", description: "У меня есть заметки" },
+    { label: "Пропустить", description: "В этот раз без уроков" }
+  ]
+}])
 ```
 
 ---
@@ -284,12 +289,15 @@ Before cleanup, handle two optional post-actions while the original plan folder 
 Ask:
 
 ```
-AskUserQuestion: Documentation checkpoint — how should we document this feature?
-
-Options:
-1. Update existing docs (/aif-docs) (recommended)
-2. Create feature page with /aif-docs
-3. Skip documentation for now
+question(questions: [{
+  header: "Документация",
+  question: "Как задокументировать эту функцию?",
+  options: [
+    { label: "Обновить существующие docs (Рекомендуется)", description: "/aif-docs" },
+    { label: "Создать страницу функции", description: "/aif-docs docs/<feature>.md" },
+    { label: "Пропустить", description: "Без документации сейчас" }
+  ]
+}])
 ```
 
 Record outcome in completion output as one of:
@@ -303,11 +311,14 @@ Record outcome in completion output as one of:
 If plan contains fix artifacts (`plans/<plan-id>/fixes/*.md`) or rich findings history:
 
 ```
-AskUserQuestion: Run evolution from this plan context?
-
-Options:
-1. Yes — Run /aif-evolve with plan/fixes context (recommended)
-2. No — Skip evolution
+question(questions: [{
+  header: "Эволюция",
+  question: "Запустить эволюцию из контекста этого плана?",
+  options: [
+    { label: "Да — /aif-evolve (Рекомендуется)", description: "Использовать plan/fixes как evidence" },
+    { label: "Нет — Пропустить", description: "Без эволюции" }
+  ]
+}])
 ```
 
 When enabled, use the completed plan folder as the evidence base for evolution suggestions.
@@ -317,13 +328,14 @@ When enabled, use the completed plan folder as the evidence base for evolution s
 ## Step 8: Clean Up Plan Folder
 
 ```
-AskUserQuestion: Plan archived to .ai-factory/specs/<plan-id>/
-
-Clean up original plan folder?
-
-Options:
-1. Remove original plan folder (recommended) — Delete .ai-factory/plans/<plan-id>/
-2. Keep original plan folder — Retain both copies
+question(questions: [{
+  header: "Очистка",
+  question: "План архивирован в .ai-factory/specs/<plan-id>/\n\nУдалить оригинальную папку плана?",
+  options: [
+    { label: "Удалить .ai-factory/plans/<plan-id>/ (Рекомендуется)", description: "Оставить только архив" },
+    { label: "Оставить обе копии", description: "Сохранить план и архив" }
+  ]
+}])
 ```
 
 If remove:
@@ -368,12 +380,15 @@ Ready to start a new plan? Run /aif-new
 ### Context Cleanup
 
 ```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
+question(questions: [{
+  header: "Контекст",
+  question: "Освободить контекст перед продолжением?",
+  options: [
+    { label: "/clear — Полный сброс (Рекомендуется)", description: "После завершения плана" },
+    { label: "/compact — Сжать историю", description: "Компактный режим" },
+    { label: "Продолжить как есть", description: "Без изменений" }
+  ]
+}])
 ```
 
 ---

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -2,13 +2,15 @@
 name: aif-done
 description: Finalize a plan, mark it complete, and archive artifacts to specs/. Use after /aif-verify passes or when manually marking work as done.
 argument-hint: "[plan-id] [--summary] [--force]"
-allowed-tools: Read Write Glob Grep Bash(mkdir *) Bash(cp *) Bash(rm -rf *) question Questions
+allowed-tools: Read Write Glob Grep Bash(mkdir *) Bash(cp *) Bash(rm -rf *) question questionnaire
 version: 0.7.0
 ---
 
 # AIF Done — Finalize and Archive Plan
 
 Finalize a plan by marking it complete, archiving artifacts to `.ai-factory/specs/`, and optionally updating project context.
+
+> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
 
 **This is a workflow terminus.** After `aif-done`, the plan is archived and the cycle is complete.
 

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -10,7 +10,7 @@ version: 0.7.0
 
 Finalize a plan by marking it complete, archiving artifacts to `.ai-factory/specs/`, and optionally updating project context.
 
-> **See [Question Tool Reference](../shared/QUESTION-TOOL.md)** — question/questionnaire formats for different agents.
+> **Reference:** [Question Tool](../shared/QUESTION-TOOL.md) — question/questionnaire formats for different agents
 
 **This is a workflow terminus.** After `aif-done`, the plan is archived and the cycle is complete.
 

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -10,7 +10,7 @@ version: 0.7.0
 
 Finalize a plan by marking it complete, archiving artifacts to `.ai-factory/specs/`, and optionally updating project context.
 
-> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
+> **See [Question Tool Reference](../shared/QUESTION-TOOL.md)** — question/questionnaire formats for different agents.
 
 **This is a workflow terminus.** After `aif-done`, the plan is archived and the cycle is complete.
 
@@ -86,12 +86,12 @@ Acceptable completion state:
 If NOT eligible:
 ```
 question(questions: [{
-  header: "Статус",
-  question: "Статус плана: \"{{current_status}}\" с вердиктом \"{{verdict}}\".\n\nПлан ещё не прошёл верификацию.",
+  header: "Status",
+  question: "Plan status: \"{{current_status}}\" with verdict \"{{verdict}}\".\n\nPlan has not passed verification yet.",
   options: [
-    { label: "Запустить верификацию (Рекомендуется)", description: "/aif-verify" },
-    { label: "Завершить принудительно (--force)", description: "Без верификации" },
-    { label: "Отмена", description: "Выйти" }
+    { label: "Run verification (Recommended)", description: "/aif-verify" },
+    { label: "Force finalize (--force)", description: "Without verification" },
+    { label: "Cancel", description: "Exit" }
   ]
 }])
 ```
@@ -158,11 +158,11 @@ Generate an extended summary including:
 
 ```
 question(questions: [{
-  header: "Уроки",
-  question: "Есть ли уроки, извлечённые из этого плана?",
+  header: "Lessons",
+  question: "Are there any lessons learned from this plan?",
   options: [
-    { label: "Да — Добав уроки", description: "У меня есть заметки" },
-    { label: "Пропустить", description: "В этот раз без уроков" }
+    { label: "Yes — Add lessons", description: "I have notes to capture" },
+    { label: "Skip", description: "No lessons this time" }
   ]
 }])
 ```
@@ -292,12 +292,12 @@ Ask:
 
 ```
 question(questions: [{
-  header: "Документация",
-  question: "Как задокументировать эту функцию?",
+  header: "Documentation",
+  question: "How should we document this feature?",
   options: [
-    { label: "Обновить существующие docs (Рекомендуется)", description: "/aif-docs" },
-    { label: "Создать страницу функции", description: "/aif-docs docs/<feature>.md" },
-    { label: "Пропустить", description: "Без документации сейчас" }
+    { label: "Update existing docs (Recommended)", description: "/aif-docs" },
+    { label: "Create feature page", description: "/aif-docs docs/<feature>.md" },
+    { label: "Skip", description: "No documentation now" }
   ]
 }])
 ```
@@ -314,11 +314,11 @@ If plan contains fix artifacts (`plans/<plan-id>/fixes/*.md`) or rich findings h
 
 ```
 question(questions: [{
-  header: "Эволюция",
-  question: "Запустить эволюцию из контекста этого плана?",
+  header: "Evolution",
+  question: "Run evolution from this plan context?",
   options: [
-    { label: "Да — /aif-evolve (Рекомендуется)", description: "Использовать plan/fixes как evidence" },
-    { label: "Нет — Пропустить", description: "Без эволюции" }
+    { label: "Yes — /aif-evolve (Recommended)", description: "Use plan/fixes as evidence" },
+    { label: "No — Skip", description: "Without evolution" }
   ]
 }])
 ```
@@ -331,11 +331,11 @@ When enabled, use the completed plan folder as the evidence base for evolution s
 
 ```
 question(questions: [{
-  header: "Очистка",
-  question: "План архивирован в .ai-factory/specs/<plan-id>/\n\nУдалить оригинальную папку плана?",
+  header: "Cleanup",
+  question: "Plan archived to .ai-factory/specs/<plan-id>/\n\nDelete original plan folder?",
   options: [
-    { label: "Удалить .ai-factory/plans/<plan-id>/ (Рекомендуется)", description: "Оставить только архив" },
-    { label: "Оставить обе копии", description: "Сохранить план и архив" }
+    { label: "Delete .ai-factory/plans/<plan-id>/ (Recommended)", description: "Keep archive only" },
+    { label: "Keep both copies", description: "Retain plan and archive" }
   ]
 }])
 ```
@@ -383,12 +383,12 @@ Ready to start a new plan? Run /aif-new
 
 ```
 question(questions: [{
-  header: "Контекст",
-  question: "Освободить контекст перед продолжением?",
+  header: "Context",
+  question: "Free up context before continuing?",
   options: [
-    { label: "/clear — Полный сброс (Рекомендуется)", description: "После завершения плана" },
-    { label: "/compact — Сжать историю", description: "Компактный режим" },
-    { label: "Продолжить как есть", description: "Без изменений" }
+    { label: "/clear — Full reset (Recommended)", description: "After plan completion" },
+    { label: "/compact — Compress history", description: "Compact mode" },
+    { label: "Continue as is", description: "No changes" }
   ]
 }])
 ```

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -2,6 +2,7 @@
 name: aif-fix
 description: Fix issues found by /aif-verify. Reads verification findings, implements fixes for blocking and important issues, then suggests re-verification. Use when verification fails or user says "fix the issues".
 argument-hint: "[plan-id] [finding-ids...] [--all]"
+allowed-tools: Read Write Edit Glob Grep Bash question Questions Task
 version: 0.7.0
 ---
 
@@ -97,16 +98,16 @@ Fix Queue (ordered by priority):
 Show the queue and confirm:
 
 ```
-AskUserQuestion: Fix queue ready. How should I proceed?
-
-Blocking: 2 issues
-Important: 2 issues
-
-Options:
-1. Fix blocking + important (recommended) — Address the default fix scope
-2. Fix blocking only — Address only blocking issues
-3. Select findings manually — Choose specific findings
-4. Cancel — I'll handle this manually
+question(questions: [{
+  header: "Очередь",
+  question: "Очередь исправлений готова. Как proceed?\n\nBlocking: {{blocking_count}} issues\nImportant: {{important_count}} issues",
+  options: [
+    { label: "Fix blocking + important (Рекомендуется)", description: "Исправить default scope" },
+    { label: "Только blocking", description: "Исправить только blocking issues" },
+    { label: "Выбрать вручную", description: "Указать конкрет findings" },
+    { label: "Отмена", description: "Исправлю самостоятельно" }
+  ]
+}])
 ```
 
 ---
@@ -295,13 +296,16 @@ After all fixes applied:
 ## Step 5: Route to Re-Verification
 
 ```
-AskUserQuestion: Fixes applied. What next?
-
-Options:
-1. Re-verify now — Run /aif-verify to confirm fixes (recommended)
-2. Commit current fixes — Run /aif-commit
-3. Continue with optional findings — Address remaining optional issues
-4. Stop for now — Verify later
+question(questions: [{
+  header: "Далее",
+  question: "Исправления применены. Что дальше?",
+  options: [
+    { label: "Re-verify сейчас (Рекомендуется)", description: "/aif-verify для подтверждения" },
+    { label: "Закоммитить исправления", description: "/aif-commit" },
+    { label: "Продолжить с optional findings", description: "Исправить оставшиеся issues" },
+    { label: "Остановиться", description: "Проверю позже" }
+  ]
+}])
 ```
 
 ---
@@ -328,12 +332,15 @@ fixes:
 ### Context Cleanup
 
 ```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended after fixing)
-2. /compact — Compress history
-3. Continue as is
+question(questions: [{
+  header: "Контекст",
+  question: "Освободить контекст перед продолжением?",
+  options: [
+    { label: "/clear — Полный сброс (Рекомендуется)", description: "После исправлений" },
+    { label: "/compact — Сжать историю", description: "Компактный режим" },
+    { label: "Продолжить как есть", description: "Без изменений" }
+  ]
+}])
 ```
 
 ---

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -2,7 +2,7 @@
 name: aif-fix
 description: Fix issues found by /aif-verify. Reads verification findings, implements fixes for blocking and important issues, then suggests re-verification. Use when verification fails or user says "fix the issues".
 argument-hint: "[plan-id] [finding-ids...] [--all]"
-allowed-tools: Read Write Edit Glob Grep Bash question Questions Task
+allowed-tools: Read Write Edit Glob Grep Bash question questionnaire Task
 version: 0.7.0
 ---
 

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -8,6 +8,8 @@ version: 0.7.0
 
 # AIF Fix — Fix Verification Findings
 
+> **See [Question Tool Reference](../shared/QUESTION-TOOL.md)** — question/questionnaire formats for different agents.
+
 Fix issues identified by `/aif-verify`. Reads structured findings, implements corrections, and drives the fix → verify loop.
 
 **This skill modifies source code.** It reads verification findings and applies targeted fixes following plan rules.
@@ -99,13 +101,13 @@ Show the queue and confirm:
 
 ```
 question(questions: [{
-  header: "Очередь",
-  question: "Очередь исправлений готова. Как proceed?\n\nBlocking: {{blocking_count}} issues\nImportant: {{important_count}} issues",
+  header: "Queue",
+  question: "Fix queue ready. How should I proceed?\n\nBlocking: {{blocking_count}} issues\nImportant: {{important_count}} issues",
   options: [
-    { label: "Fix blocking + important (Рекомендуется)", description: "Исправить default scope" },
-    { label: "Только blocking", description: "Исправить только blocking issues" },
-    { label: "Выбрать вручную", description: "Указать конкрет findings" },
-    { label: "Отмена", description: "Исправлю самостоятельно" }
+    { label: "Fix blocking + important (Recommended)", description: "Address default scope" },
+    { label: "Blocking only", description: "Fix blocking issues only" },
+    { label: "Select manually", description: "Choose specific findings" },
+    { label: "Cancel", description: "I'll handle this manually" }
   ]
 }])
 ```
@@ -297,13 +299,13 @@ After all fixes applied:
 
 ```
 question(questions: [{
-  header: "Далее",
-  question: "Исправления применены. Что дальше?",
+  header: "Next",
+  question: "Fixes applied. What next?",
   options: [
-    { label: "Re-verify сейчас (Рекомендуется)", description: "/aif-verify для подтверждения" },
-    { label: "Закоммитить исправления", description: "/aif-commit" },
-    { label: "Продолжить с optional findings", description: "Исправить оставшиеся issues" },
-    { label: "Остановиться", description: "Проверю позже" }
+    { label: "Re-verify now (Recommended)", description: "/aif-verify to confirm fixes" },
+    { label: "Commit fixes", description: "/aif-commit" },
+    { label: "Continue with optional findings", description: "Address remaining issues" },
+    { label: "Stop for now", description: "Verify later" }
   ]
 }])
 ```
@@ -333,12 +335,12 @@ fixes:
 
 ```
 question(questions: [{
-  header: "Контекст",
-  question: "Освободить контекст перед продолжением?",
+  header: "Context",
+  question: "Free up context before continuing?",
   options: [
-    { label: "/clear — Полный сброс (Рекомендуется)", description: "После исправлений" },
-    { label: "/compact — Сжать историю", description: "Компактный режим" },
-    { label: "Продолжить как есть", description: "Без изменений" }
+    { label: "/clear — Full reset (Recommended)", description: "After fixes" },
+    { label: "/compact — Compress history", description: "Compact mode" },
+    { label: "Continue as is", description: "No changes" }
   ]
 }])
 ```

--- a/skills/aif-fix/SKILL.md
+++ b/skills/aif-fix/SKILL.md
@@ -8,7 +8,7 @@ version: 0.7.0
 
 # AIF Fix — Fix Verification Findings
 
-> **See [Question Tool Reference](../shared/QUESTION-TOOL.md)** — question/questionnaire formats for different agents.
+> **Reference:** [Question Tool](../shared/QUESTION-TOOL.md) — question/questionnaire formats for different agents
 
 Fix issues identified by `/aif-verify`. Reads structured findings, implements corrections, and drives the fix → verify loop.
 

--- a/skills/aif-implement-plus/SKILL.md
+++ b/skills/aif-implement-plus/SKILL.md
@@ -2,6 +2,7 @@
 name: aif-implement-plus
 description: Execute plan-folder tasks with progress persistence, verify/fix loop, and optional Claude subagent delegation. Replaces /aif-implement.
 argument-hint: "[plan-id|@path|status|--list] [--from <n>] [--local|--subagent]"
+allowed-tools: Read Write Edit Glob Grep Bash(git *) Bash(mkdir *) Bash(cp *) Bash(basename *) question Questions Task
 version: 0.7.0
 ---
 
@@ -161,11 +162,14 @@ Mode rules:
 When subagents are available and mode is not forced, ask:
 
 ```
-AskUserQuestion: Claude subagents detected. How should I execute this plan?
-
-Options:
-1. Use subagent mode (recommended)
-2. Use local mode
+question(questions: [{
+  header: "Режим",
+  question: "Обнаружены Claude subagents. Как should I execute this plan?",
+  options: [
+    { label: "Subagent mode (Рекомендуется)", description: "Делегировать выполнение subagent" },
+    { label: "Local mode", description: "Выполнять в текущем контексте" }
+  ]
+}])
 ```
 
 Save mode to `status.yaml`:

--- a/skills/aif-implement-plus/SKILL.md
+++ b/skills/aif-implement-plus/SKILL.md
@@ -2,9 +2,11 @@
 name: aif-implement-plus
 description: Execute plan-folder tasks with progress persistence, verify/fix loop, and optional Claude subagent delegation. Replaces /aif-implement.
 argument-hint: "[plan-id|@path|status|--list] [--from <n>] [--local|--subagent]"
-allowed-tools: Read Write Edit Glob Grep Bash(git *) Bash(mkdir *) Bash(cp *) Bash(basename *) question Questions Task
+allowed-tools: Read Write Edit Glob Grep Bash(git *) Bash(mkdir *) Bash(cp *) Bash(basename *) question questionnaire Task
 version: 0.7.0
 ---
+
+> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
 
 # AIF Implement+ — Execute Task Plan
 

--- a/skills/aif-implement-plus/SKILL.md
+++ b/skills/aif-implement-plus/SKILL.md
@@ -165,11 +165,11 @@ When subagents are available and mode is not forced, ask:
 
 ```
 question(questions: [{
-  header: "Режим",
-  question: "Обнаружены Claude subagents. Как should I execute this plan?",
+  header: "Mode",
+  question: "Claude subagents detected. How should I execute this plan?",
   options: [
-    { label: "Subagent mode (Рекомендуется)", description: "Делегировать выполнение subagent" },
-    { label: "Local mode", description: "Выполнять в текущем контексте" }
+    { label: "Subagent mode (Recommended)", description: "Delegate to subagent" },
+    { label: "Local mode", description: "Execute in current context" }
   ]
 }])
 ```

--- a/skills/aif-implement-plus/SKILL.md
+++ b/skills/aif-implement-plus/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read Write Edit Glob Grep Bash(git *) Bash(mkdir *) Bash(cp *) Ba
 version: 0.7.0
 ---
 
-> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
+> **Reference:** [Question Tool](../shared/QUESTION-TOOL.md) — question/questionnaire formats for different agents
 
 # AIF Implement+ — Execute Task Plan
 

--- a/skills/aif-improve-plus/SKILL.md
+++ b/skills/aif-improve-plus/SKILL.md
@@ -2,6 +2,7 @@
 name: aif-improve-plus
 description: Refine plan-folder artifacts with deeper codebase analysis, status sync, and optional Claude plan-polisher delegation. Replaces /aif-improve.
 argument-hint: "[plan-id|@path|--list] [improvement prompt] [--local|--subagent]"
+allowed-tools: Read Glob Grep Write Edit Bash(git *) question Questions
 version: 0.7.0
 ---
 
@@ -133,11 +134,14 @@ Mode rules:
 When `plan-polisher` is available and mode is not forced, ask:
 
 ```
-AskUserQuestion: Claude plan-polisher detected. How should I refine this plan?
-
-Options:
-1. Use subagent mode (recommended)
-2. Use local mode
+question(questions: [{
+  header: "Режим",
+  question: "Обнаружен Claude plan-polisher. Как should I refine this plan?",
+  options: [
+    { label: "Subagent mode (Рекомендуется)", description: "Делегировать улучшение plan-polisher" },
+    { label: "Local mode", description: "Улучшать в текущем контексте" }
+  ]
+}])
 ```
 
 ### Step 1: Load Plan Artifacts
@@ -339,12 +343,15 @@ Next step:
 ### Context Cleanup
 
 ```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended)
-2. /compact — Compress history
-3. Continue as is
+question(questions: [{
+  header: "Контекст",
+  question: "Освободить контекст перед продолжением?",
+  options: [
+    { label: "/clear — Полный сброс (Рекомендуется)", description: "Очистить весь контекст" },
+    { label: "/compact — Сжать историю", description: "Компактный режим" },
+    { label: "Продолжить как есть", description: "Без изменений" }
+  ]
+}])
 ```
 
 ---

--- a/skills/aif-improve-plus/SKILL.md
+++ b/skills/aif-improve-plus/SKILL.md
@@ -2,9 +2,11 @@
 name: aif-improve-plus
 description: Refine plan-folder artifacts with deeper codebase analysis, status sync, and optional Claude plan-polisher delegation. Replaces /aif-improve.
 argument-hint: "[plan-id|@path|--list] [improvement prompt] [--local|--subagent]"
-allowed-tools: Read Glob Grep Write Edit Bash(git *) question Questions
+allowed-tools: Read Glob Grep Write Edit Bash(git *) question questionnaire
 version: 0.7.0
 ---
+
+> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
 
 # AIF Improve+ — Refine Plan Folder
 

--- a/skills/aif-improve-plus/SKILL.md
+++ b/skills/aif-improve-plus/SKILL.md
@@ -137,11 +137,11 @@ When `plan-polisher` is available and mode is not forced, ask:
 
 ```
 question(questions: [{
-  header: "Режим",
-  question: "Обнаружен Claude plan-polisher. Как should I refine this plan?",
+  header: "Mode",
+  question: "Claude plan-polisher detected. How should I refine this plan?",
   options: [
-    { label: "Subagent mode (Рекомендуется)", description: "Делегировать улучшение plan-polisher" },
-    { label: "Local mode", description: "Улучшать в текущем контексте" }
+    { label: "Subagent mode (Recommended)", description: "Delegate to plan-polisher" },
+    { label: "Local mode", description: "Execute in current context" }
   ]
 }])
 ```
@@ -346,12 +346,12 @@ Next step:
 
 ```
 question(questions: [{
-  header: "Контекст",
-  question: "Освободить контекст перед продолжением?",
+  header: "Context",
+  question: "Free up context before continuing?",
   options: [
-    { label: "/clear — Полный сброс (Рекомендуется)", description: "Очистить весь контекст" },
-    { label: "/compact — Сжать историю", description: "Компактный режим" },
-    { label: "Продолжить как есть", description: "Без изменений" }
+    { label: "/clear — Full reset (Recommended)", description: "Clear entire context" },
+    { label: "/compact — Compress history", description: "Compact mode" },
+    { label: "Continue as is", description: "No changes" }
   ]
 }])
 ```

--- a/skills/aif-improve-plus/SKILL.md
+++ b/skills/aif-improve-plus/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read Glob Grep Write Edit Bash(git *) question questionnaire
 version: 0.7.0
 ---
 
-> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
+> **Reference:** [Question Tool](../shared/QUESTION-TOOL.md) — question/questionnaire formats for different agents
 
 # AIF Improve+ — Refine Plan Folder
 

--- a/skills/aif-new/SKILL.md
+++ b/skills/aif-new/SKILL.md
@@ -2,6 +2,7 @@
 name: aif-new
 description: Create a new plan folder with structured artifacts (task, context, rules, verify, status). Use when starting a new feature, change, or improvement that requires structured planning.
 argument-hint: "[task description]"
+allowed-tools: Read Write Glob Grep Bash(mkdir *) Bash(cp *) Bash(basename *) question Questions
 version: 0.7.0
 ---
 
@@ -48,11 +49,14 @@ Read these files if present (do NOT fail if missing):
 
 If `.ai-factory/config.yaml` does not exist:
 ```
-AskUserQuestion: Project config not found. Create it?
-
-Options:
-1. Yes — Run /aif-analyze first to initialize config (recommended)
-2. Continue without config — Use defaults (english, slug format)
+question(questions: [{
+  header: "Конфиг",
+  question: "Конфиг проекта не найден. Создать?",
+  options: [
+    { label: "Да — запустить /aif-analyze (Рекомендуется)", description: "Инициализировать config.yaml" },
+    { label: "Продолжить без конфига", description: "Использовать defaults (english, slug)" }
+  ]
+}])
 ```
 
 ### 0.3 Resolve Localization
@@ -105,13 +109,13 @@ If `$ARGUMENTS` points to an existing local file path:
 
 If `$ARGUMENTS` is empty:
 ```
-AskUserQuestion: What would you like to plan?
-
-Provide a brief description of the feature, change, or improvement.
-Examples:
-- "Add OAuth authentication with Google and GitHub"
-- "Refactor database layer to support PostgreSQL"
-- "Fix performance issues in search endpoint"
+question(questions: [{
+  header: "Задача",
+  question: "Что вы хотите запланировать?\n\nОпишите функцию, изменение или улучшение.",
+  options: [
+    { label: "Ввести описание", description: "Напишу задачу текстом" }
+  ]
+}])
 ```
 
 ### 1.2 Check for Exploration Output
@@ -123,17 +127,15 @@ Read the resolved research artifact if it exists:
 - Parse `<!-- aif:active-summary:start -->` ... `<!-- aif:active-summary:end -->` block
 - If topic matches the task description (or is clearly related):
   ```
-  AskUserQuestion: Found exploration notes in the configured research artifact that may be relevant.
-
-  Topic: {{research_topic}}
-  Goal: {{research_goal}}
-
-  Import exploration into the plan?
-
-  Options:
-  1. Yes — Import findings into plan artifacts (recommended)
-  2. No — Start fresh, ignore exploration
-  3. View — Show me the summary first
+  question(questions: [{
+    header: "Исследование",
+    question: "Найдены заметки исследования в {{research_path}}.\n\nТема: {{research_topic}}\nЦель: {{research_goal}}\n\nИмпортировать в план?",
+    options: [
+      { label: "Да — импортировать findings (Рекомендуется)", description: "Добавить в артефакты плана" },
+      { label: "Нет — начать заново", description: "Игнорировать исследование" },
+      { label: "Показать summary", description: "Показать сначала" }
+    ]
+  }])
   ```
 - If imported, distribute content:
   - Topic + Goal → `task.md`
@@ -153,12 +155,40 @@ Read the resolved research artifact if it exists:
 If the task description is vague or broad, ask targeted questions:
 
 ```
-AskUserQuestion: Let me clarify the scope for this plan.
-
-1. What specific outcome do you expect? (not just "add feature X" but "users can do Y")
-2. Are there parts we should explicitly NOT touch?
-3. Any hard constraints? (deadlines, dependencies, backwards compatibility)
-4. Related issue or PR number?
+question(questions: [
+  {
+    header: "Результат",
+    question: "Какой конкретный результат ожидаете?",
+    options: [
+      { label: "Опишу", description: "Укажу конкретный outcome" },
+      { label: "Пропустить", description: "Оставить как есть" }
+    ]
+  },
+  {
+    header: "Границы",
+    question: "Есть части, которые НЕ нужно трогать?",
+    options: [
+      { label: "Да, есть исключения", description: "Укажу границы" },
+      { label: "Нет, всё открыто", description: "Без ограничений" }
+    ]
+  },
+  {
+    header: "Ограничения",
+    question: "Есть жёсткие ограничения? (дедлайны, зависимости, совместимость)",
+    options: [
+      { label: "Да, укажу", description: "Опишу ограничения" },
+      { label: "Нет", description: "Без ограничений" }
+    ]
+  },
+  {
+    header: "Связи",
+    question: "Связанный issue или PR?",
+    options: [
+      { label: "Да, укажу номер", description: "Привязать к issue/PR" },
+      { label: "Нет", description: "Без связей" }
+    ]
+  }
+])
 ```
 
 Do NOT ask all questions if the task is already clear. Skip what's obvious.
@@ -316,14 +346,17 @@ Show the created plan:
 ```
 
 ```
-AskUserQuestion: What would you like to do next?
-
-Options:
-1. Review plan artifacts — Open task.md for review
-2. Start exploring — Run /aif-explore for deeper research
-3. Improve plan first — Run /aif-improve (recommended)
-4. Start implementing — Run /aif-implement
-5. Done for now — I'll review later
+question(questions: [{
+  header: "Далее",
+  question: "Что хотите сделать дальше?",
+  options: [
+    { label: "Проверить артефакты плана", description: "Открыть task.md" },
+    { label: "Исследовать глубже", description: "/aif-explore <plan-id>" },
+    { label: "Улучшить план (Рекомендуется)", description: "/aif-improve" },
+    { label: "Начать реализацию", description: "/aif-implement" },
+    { label: "Позже", description: "Проверю самостоятельно" }
+  ]
+}])
 ```
 
 If user chooses improve (or if project policy enables auto-improve), immediately hand off to `/aif-improve` with the created plan context.
@@ -388,13 +421,14 @@ Based on plan scope, determine if area-specific rules would help:
 ### 5.2 Ask Before Creating
 
 ```
-AskUserQuestion: This plan touches {{area}}. Would you like to create area-specific rules?
-
-Creating `.ai-factory/rules/{{area}}.md` would help ensure consistent implementation across similar plans.
-
-Options:
-1. Yes — Create rules/{{area}}.md with project-specific conventions
-2. No — Use only base rules
+question(questions: [{
+  header: "Правила области",
+  question: "План затрагивает {{area}}. Создать специфичные правила для области?\n\nСоздание .ai-factory/rules/{{area}}.md обеспечит консистентность реализации.",
+  options: [
+    { label: "Да — создать rules/{{area}}.md (Рекомендуется)", description: "Добавить конвенции для области" },
+    { label: "Нет — только base rules", description: "Использовать только базовые правила" }
+  ]
+}])
 ```
 
 ### 5.3 Create Area Rules File

--- a/skills/aif-new/SKILL.md
+++ b/skills/aif-new/SKILL.md
@@ -2,11 +2,13 @@
 name: aif-new
 description: Create a new plan folder with structured artifacts (task, context, rules, verify, status). Use when starting a new feature, change, or improvement that requires structured planning.
 argument-hint: "[task description]"
-allowed-tools: Read Write Glob Grep Bash(mkdir *) Bash(cp *) Bash(basename *) question Questions
+allowed-tools: Read Write Glob Grep Bash(mkdir *) Bash(cp *) Bash(basename *) question questionnaire
 version: 0.7.0
 ---
 
 # AIF New — Create Plan Folder
+
+> **См. [Вопросы пользователю](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов
 
 Create a new plan folder under `.ai-factory/plans/<plan-id>/` with all required artifacts for spec-driven workflow.
 

--- a/skills/aif-new/SKILL.md
+++ b/skills/aif-new/SKILL.md
@@ -8,7 +8,7 @@ version: 0.7.0
 
 # AIF New — Create Plan Folder
 
-> **См. [Вопросы пользователю](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов
+> **Reference:** [Question Tool](../shared/QUESTION-TOOL.md) — question/questionnaire formats for different agents
 
 Create a new plan folder under `.ai-factory/plans/<plan-id>/` with all required artifacts for spec-driven workflow.
 

--- a/skills/aif-new/SKILL.md
+++ b/skills/aif-new/SKILL.md
@@ -52,11 +52,11 @@ Read these files if present (do NOT fail if missing):
 If `.ai-factory/config.yaml` does not exist:
 ```
 question(questions: [{
-  header: "Конфиг",
-  question: "Конфиг проекта не найден. Создать?",
+  header: "Config",
+  question: "Project config not found. Create it?",
   options: [
-    { label: "Да — запустить /aif-analyze (Рекомендуется)", description: "Инициализировать config.yaml" },
-    { label: "Продолжить без конфига", description: "Использовать defaults (english, slug)" }
+    { label: "Yes — run /aif-analyze (Recommended)", description: "Initialize config.yaml" },
+    { label: "Continue without config", description: "Use defaults (english, slug)" }
   ]
 }])
 ```
@@ -112,10 +112,10 @@ If `$ARGUMENTS` points to an existing local file path:
 If `$ARGUMENTS` is empty:
 ```
 question(questions: [{
-  header: "Задача",
-  question: "Что вы хотите запланировать?\n\nОпишите функцию, изменение или улучшение.",
+  header: "Task",
+  question: "What would you like to plan?\n\nDescribe the feature, change, or improvement.",
   options: [
-    { label: "Ввести описание", description: "Напишу задачу текстом" }
+    { label: "Enter description", description: "I'll type the task" }
   ]
 }])
 ```
@@ -130,12 +130,12 @@ Read the resolved research artifact if it exists:
 - If topic matches the task description (or is clearly related):
   ```
   question(questions: [{
-    header: "Исследование",
-    question: "Найдены заметки исследования в {{research_path}}.\n\nТема: {{research_topic}}\nЦель: {{research_goal}}\n\nИмпортировать в план?",
+    header: "Research",
+    question: "Found research notes at {{research_path}}.\n\nTopic: {{research_topic}}\nGoal: {{research_goal}}\n\nImport into plan?",
     options: [
-      { label: "Да — импортировать findings (Рекомендуется)", description: "Добавить в артефакты плана" },
-      { label: "Нет — начать заново", description: "Игнорировать исследование" },
-      { label: "Показать summary", description: "Показать сначала" }
+      { label: "Yes — import findings (Recommended)", description: "Add to plan artifacts" },
+      { label: "No — start fresh", description: "Ignore research" },
+      { label: "Show summary", description: "Show me first" }
     ]
   }])
   ```
@@ -159,35 +159,35 @@ If the task description is vague or broad, ask targeted questions:
 ```
 question(questions: [
   {
-    header: "Результат",
-    question: "Какой конкретный результат ожидаете?",
+    header: "Outcome",
+    question: "What specific outcome do you expect from this plan?",
     options: [
-      { label: "Опишу", description: "Укажу конкретный outcome" },
-      { label: "Пропустить", description: "Оставить как есть" }
+      { label: "Describe", description: "I'll specify concrete outcomes" },
+      { label: "Skip", description: "Leave as is" }
     ]
   },
   {
-    header: "Границы",
-    question: "Есть части, которые НЕ нужно трогать?",
+    header: "Boundaries",
+    question: "Are there parts we should NOT touch?",
     options: [
-      { label: "Да, есть исключения", description: "Укажу границы" },
-      { label: "Нет, всё открыто", description: "Без ограничений" }
+      { label: "Yes, have exclusions", description: "I'll specify boundaries" },
+      { label: "No, open", description: "No restrictions" }
     ]
   },
   {
-    header: "Ограничения",
-    question: "Есть жёсткие ограничения? (дедлайны, зависимости, совместимость)",
+    header: "Constraints",
+    question: "Are there hard constraints? (deadlines, dependencies, compatibility)",
     options: [
-      { label: "Да, укажу", description: "Опишу ограничения" },
-      { label: "Нет", description: "Без ограничений" }
+      { label: "Yes, will specify", description: "I'll specify constraints" },
+      { label: "No", description: "No constraints" }
     ]
   },
   {
-    header: "Связи",
-    question: "Связанный issue или PR?",
+    header: "Links",
+    question: "Related issue or PR?",
     options: [
-      { label: "Да, укажу номер", description: "Привязать к issue/PR" },
-      { label: "Нет", description: "Без связей" }
+      { label: "Yes, provide number", description: "Link to issue/PR" },
+      { label: "No", description: "No links" }
     ]
   }
 ])
@@ -349,14 +349,14 @@ Show the created plan:
 
 ```
 question(questions: [{
-  header: "Далее",
-  question: "Что хотите сделать дальше?",
+  header: "Next",
+  question: "What would you like to do next?",
   options: [
-    { label: "Проверить артефакты плана", description: "Открыть task.md" },
-    { label: "Исследовать глубже", description: "/aif-explore <plan-id>" },
-    { label: "Улучшить план (Рекомендуется)", description: "/aif-improve" },
-    { label: "Начать реализацию", description: "/aif-implement" },
-    { label: "Позже", description: "Проверю самостоятельно" }
+    { label: "Review plan artifacts", description: "Open task.md" },
+    { label: "Explore deeper", description: "/aif-explore <plan-id>" },
+    { label: "Improve plan (Recommended)", description: "/aif-improve" },
+    { label: "Start implementation", description: "/aif-implement" },
+    { label: "Later", description: "I'll review manually" }
   ]
 }])
 ```
@@ -424,11 +424,11 @@ Based on plan scope, determine if area-specific rules would help:
 
 ```
 question(questions: [{
-  header: "Правила области",
-  question: "План затрагивает {{area}}. Создать специфичные правила для области?\n\nСоздание .ai-factory/rules/{{area}}.md обеспечит консистентность реализации.",
+  header: "Area rules",
+  question: "Plan touches {{area}}. Create area-specific rules?\n\nCreating .ai-factory/rules/{{area}}.md will ensure consistency across similar plans.",
   options: [
-    { label: "Да — создать rules/{{area}}.md (Рекомендуется)", description: "Добавить конвенции для области" },
-    { label: "Нет — только base rules", description: "Использовать только базовые правила" }
+    { label: "Yes — create rules/{{area}}.md (Recommended)", description: "Add conventions for this area" },
+    { label: "No — base rules only", description: "Use only base rules" }
   ]
 }])
 ```

--- a/skills/aif-verify-plus/SKILL.md
+++ b/skills/aif-verify-plus/SKILL.md
@@ -2,6 +2,7 @@
 name: aif-verify+
 description: Enhanced verification against task, rules, and constraints. Checks implementation completeness, produces structured findings, and routes workflow to aif-fix or aif-done. Use after aif-implement completes.
 argument-hint: "[plan-id] [--strict]"
+allowed-tools: Read Glob Grep Bash(git *) Bash(npm *) Bash(python *) Bash(go *) Bash(cargo *) question Questions
 version: 0.7.0
 ---
 
@@ -48,13 +49,16 @@ Treat skill-context rules as project-level overrides:
 
 If no plan found:
 ```
-AskUserQuestion: No plan folder found. What should I verify?
-
-Options:
-1. List available plans — Choose a plan folder from .ai-factory/plans/ (recommended)
-2. Verify branch diff — Compare current branch against main
-3. Verify last commit — Check the most recent commit
-4. Cancel
+question(questions: [{
+  header: "План",
+  question: "Папка плана не найдена. Что верифицировать?",
+  options: [
+    { label: "Выбрать план (Рекомендуется)", description: "Выбрать из .ai-factory/plans/" },
+    { label: "Branch diff", description: "Сравнить текущую ветку с main" },
+    { label: "Last commit", description: "Проверить последний коммит" },
+    { label: "Отмена", description: "Выйти" }
+  ]
+}])
 ```
 
 ### 0.3 Load Plan Artifacts
@@ -342,18 +346,21 @@ Each finding MUST include:
 ### Route Workflow
 
 ```
-AskUserQuestion: Verification complete. What next?
-
-Options (on FAIL):
-1. Fix blocking + important — Run /aif-fix (recommended)
-2. Fix blocking only — Run /aif-fix B001 B002 ...
-3. Accept findings and finalize with force — Run /aif-done --force
-
-Options (on PASS or PASS with notes):
-1. Finalize now — Run /aif-done (recommended)
-2. Address remaining notes — Run /aif-fix for important/optional findings
-3. Security check — Run /aif-security-checklist
-4. Code review — Run /aif-review
+question(questions: [{
+  header: "Далее",
+  question: "Верификация завершена. Что дальше?",
+  options: [
+    # On FAIL:
+    { label: "/aif-fix — Исправить blocking + important (Рекомендуется)", description: "Автоматическое исправление" },
+    { label: "/aif-fix B001... — Только blocking", description: "Исправить только указанные" },
+    { label: "/aif-done --force — Завершить с замечаниями", description: "Принудительное завершение" }
+    # On PASS or PASS with notes:
+    { label: "/aif-done — Завершить (Рекомендуется)", description: "Архивировать план" },
+    { label: "/aif-fix — Исправить remaining notes", description: "Адресовать important/optional findings" },
+    { label: "/aif-security-checklist", description: "Проверка безопасности" },
+    { label: "/aif-review", description: "Code review" }
+  ]
+}])
 ```
 
 ---
@@ -389,12 +396,15 @@ Update `plans/<plan-id>/verify.md` — fill in the Findings table and Verdict se
 ### Context Cleanup
 
 ```
-AskUserQuestion: Free up context before continuing?
-
-Options:
-1. /clear — Full reset (recommended after heavy verification)
-2. /compact — Compress history
-3. Continue as is
+question(questions: [{
+  header: "Контекст",
+  question: "Освободить контекст перед продолжением?",
+  options: [
+    { label: "/clear — Полный сброс (Рекомендуется)", description: "После heavy verification" },
+    { label: "/compact — Сжать историю", description: "Компактный режим" },
+    { label: "Продолжить как есть", description: "Без изменений" }
+  ]
+}])
 ```
 
 ---

--- a/skills/aif-verify-plus/SKILL.md
+++ b/skills/aif-verify-plus/SKILL.md
@@ -2,7 +2,7 @@
 name: aif-verify+
 description: Enhanced verification against task, rules, and constraints. Checks implementation completeness, produces structured findings, and routes workflow to aif-fix or aif-done. Use after aif-implement completes.
 argument-hint: "[plan-id] [--strict]"
-allowed-tools: Read Glob Grep Bash(git *) Bash(npm *) Bash(python *) Bash(go *) Bash(cargo *) question Questions
+allowed-tools: Read Glob Grep Bash(git *) Bash(npm *) Bash(python *) Bash(go *) Bash(cargo *) question questionnaire
 version: 0.7.0
 ---
 
@@ -11,6 +11,8 @@ version: 0.7.0
 Verify implementation against plan artifacts (task, rules, constraints) and produce structured findings with severity levels.
 
 **This skill is read-only.** It inspects code but NEVER modifies implementation files. It updates only `status.yaml` and `verify.md` inside the plan folder.
+
+> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
 
 ---
 

--- a/skills/aif-verify-plus/SKILL.md
+++ b/skills/aif-verify-plus/SKILL.md
@@ -12,7 +12,7 @@ Verify implementation against plan artifacts (task, rules, constraints) and prod
 
 **This skill is read-only.** It inspects code but NEVER modifies implementation files. It updates only `status.yaml` and `verify.md` inside the plan folder.
 
-> **См. [Question Tool Reference](../shared/QUESTION-TOOL.md)** — форматы question/questionnaire для разных агентов.
+> **Reference:** [Question Tool](../shared/QUESTION-TOOL.md) — question/questionnaire formats for different agents
 
 ---
 
@@ -52,13 +52,13 @@ Treat skill-context rules as project-level overrides:
 If no plan found:
 ```
 question(questions: [{
-  header: "План",
-  question: "Папка плана не найдена. Что верифицировать?",
+  header: "Plan",
+  question: "Plan folder not found. What should I verify?",
   options: [
-    { label: "Выбрать план (Рекомендуется)", description: "Выбрать из .ai-factory/plans/" },
-    { label: "Branch diff", description: "Сравнить текущую ветку с main" },
-    { label: "Last commit", description: "Проверить последний коммит" },
-    { label: "Отмена", description: "Выйти" }
+    { label: "Select plan (Recommended)", description: "Choose from .ai-factory/plans/" },
+    { label: "Branch diff", description: "Compare current branch to main" },
+    { label: "Last commit", description: "Check most recent commit" },
+    { label: "Cancel", description: "Exit" }
   ]
 }])
 ```

--- a/skills/aif-verify-plus/SKILL.md
+++ b/skills/aif-verify-plus/SKILL.md
@@ -347,19 +347,28 @@ Each finding MUST include:
 
 ### Route Workflow
 
+**On FAIL:**
 ```
 question(questions: [{
-  header: "Далее",
-  question: "Верификация завершена. Что дальше?",
+  header: "Next",
+  question: "Verification complete. What next?",
   options: [
-    # On FAIL:
-    { label: "/aif-fix — Исправить blocking + important (Рекомендуется)", description: "Автоматическое исправление" },
-    { label: "/aif-fix B001... — Только blocking", description: "Исправить только указанные" },
-    { label: "/aif-done --force — Завершить с замечаниями", description: "Принудительное завершение" }
-    # On PASS or PASS with notes:
-    { label: "/aif-done — Завершить (Рекомендуется)", description: "Архивировать план" },
-    { label: "/aif-fix — Исправить remaining notes", description: "Адресовать important/optional findings" },
-    { label: "/aif-security-checklist", description: "Проверка безопасности" },
+    { label: "/aif-fix — fix blocking + important (Recommended)", description: "Automatically fix blocking + important findings" },
+    { label: "/aif-fix B001...", description: "Fix only B001" },
+    { label: "/aif-done --force", description: "Force finalize without verification" }
+  ]
+}])
+```
+
+**on PASS or PASS with notes:**
+```
+question(questions: [{
+  header: "Next",
+  question: "Verification complete. What next?",
+  options: [
+    { label: "/aif-done — finalize (Recommended)", description: "Archive plan" },
+    { label: "/aif-fix — address remaining notes", description: "Fix remaining optional findings" },
+    { label: "/aif-security-checklist", description: "Run security audit" },
     { label: "/aif-review", description: "Code review" }
   ]
 }])
@@ -399,12 +408,12 @@ Update `plans/<plan-id>/verify.md` — fill in the Findings table and Verdict se
 
 ```
 question(questions: [{
-  header: "Контекст",
-  question: "Освободить контекст перед продолжением?",
+  header: "Context",
+  question: "Free up context before continuing?",
   options: [
-    { label: "/clear — Полный сброс (Рекомендуется)", description: "После heavy verification" },
-    { label: "/compact — Сжать историю", description: "Компактный режим" },
-    { label: "Продолжить как есть", description: "Без изменений" }
+    { label: "/clear — Full reset (Recommended)", description: "After heavy verification" },
+    { label: "/compact — Compress history", description: "Compact mode" },
+    { label: "Continue as is", description: "No changes" }
   ]
 }])
 ```

--- a/skills/shared/QUESTION-TOOL.md
+++ b/skills/shared/QUESTION-TOOL.md
@@ -1,0 +1,227 @@
+# Question Tool — Взаимодействие с пользователем
+
+> Reference для всех скиллов проекта. Используйте форматы ниже для вопросов пользователю.
+
+## Форматы для разных агентов
+
+Разные агенты используют разные форматы для вопросов. Выбирайте подходящий для вашего агента.
+
+---
+
+## Одиночный вопрос
+
+### pi
+```
+question({
+  question: "Текст вопроса?",
+  options: [
+    { label: "Вариант 1 (Рекомендуется)", description: "Краткое описание" },
+    { label: "Вариант 2", description: "Краткое описание" }
+  ]
+})
+```
+
+### Claude Code / Kilo CLI / OpenCode
+```
+question({
+  questions: [{
+    header: "Тема",  // max 30 символов
+    question: "Текст вопроса?",
+    options: [
+      { label: "Вариант 1 (Рекомендуется)", description: "Краткое описание" },
+      { label: "Вариант 2", description: "Краткое описание" }
+    ]
+  }]
+})
+```
+
+---
+
+## Несколько вопросов
+
+### pi
+```
+questionnaire({
+  questions: [
+    {
+      id: "area",
+      label: "Область",      // для tab bar
+      prompt: "Какую область затрагивает?",
+      options: [
+        { value: "frontend", label: "Frontend", description: "UI компоненты" },
+        { value: "backend", label: "Backend", description: "API и сервисы" }
+      ],
+      allowOther: true      // разрешить "Type something..."
+    },
+    {
+      id: "priority",
+      label: "Приоритет",
+      prompt: "Какой приоритет?",
+      options: [
+        { value: "high", label: "Высокий", description: "Срочно" },
+        { value: "low", label: "Низкий", description: "Не срочно" }
+      ]
+    }
+  ]
+})
+```
+
+### Claude Code / Kilo CLI / OpenCode
+```
+question({
+  questions: [
+    {
+      header: "Область",
+      question: "Какую область затрагивает?",
+      options: [
+        { label: "Frontend", description: "UI компоненты" },
+        { label: "Backend", description: "API и сервисы" }
+      ]
+    },
+    {
+      header: "Приоритет",
+      question: "Какой приоритет?",
+      options: [
+        { label: "Высокий", description: "Срочно" },
+        { label: "Низкий", description: "Не срочно" }
+      ]
+    }
+  ]
+})
+```
+
+---
+
+## Параметры
+
+### question (pi)
+
+| Параметр | Тип | Обязательный | Описание |
+|----------|-----|--------------|----------|
+| `question` | string | ✅ | Текст вопроса |
+| `options` | array | ✅ | Массив вариантов (2-4 элемента) |
+
+### questionnaire (pi)
+
+| Параметр | Тип | Обязательный | Описание |
+|----------|-----|--------------|----------|
+| `questions` | array | ✅ | Массив вопросов |
+| `id` | string | ✅ | Идентификатор вопроса |
+| `label` | string | ✅ | Короткий label для tab bar |
+| `prompt` | string | ✅ | Полный текст вопроса |
+| `options` | array | ✅ | Массив вариантов |
+| `allowOther` | boolean | ❌ | Разрешить свой вариант |
+
+### question (другие агенты)
+
+| Параметр | Тип | Обязательный | Описание |
+|----------|-----|--------------|----------|
+| `questions` | array | ✅ | Массив вопросов (1-4 элемента) |
+| `header` | string | ❌ | Короткий заголовок (max 30) |
+| `question` | string | ✅ | Текст вопроса |
+| `options` | array | ✅ | Массив вариантов |
+| `multiple` | boolean | ❌ | Множественный выбор |
+
+### options (общие)
+
+| Параметр | Тип | Обязательный | Описание |
+|----------|-----|--------------|----------|
+| `label` | string | ✅ | Название варианта |
+| `description` | string | ✅ | Краткое описание |
+| `value` | string | ❌ | Значение (только questionnaire) |
+
+---
+
+## Правила
+
+1. **2-4 варианта** — не больше
+2. **Описание обязательно** — для каждого варианта
+3. **Рекомендуемый вариант** — помечать `(Рекомендуется)` или `(Recommended)`
+4. **Короткие заголовки** — `header`/`label` max 30 символов
+5. **Один вопрос** → `question`, **несколько** → `questionnaire` (pi) / `question` с массивом (другие)
+
+---
+
+## Примеры
+
+### Уточнение области
+```
+question({
+  question: "Какую область затрагивает изменение?",
+  options: [
+    { label: "Frontend (Рекомендуется)", description: "UI компоненты, стили" },
+    { label: "Backend", description: "API, сервисы, база данных" },
+    { label: "Оба", description: "Full-stack изменения" }
+  ]
+})
+```
+
+### Подтверждение действия
+```
+question({
+  question: "Применить изменения?",
+  options: [
+    { label: "Да, применить (Рекомендуется)", description: "Записать изменения в файлы" },
+    { label: "Нет, отмена", description: "Вернуться без изменений" }
+  ]
+})
+```
+
+### Выбор следующего шага
+```
+question({
+  question: "Что делать дальше?",
+  options: [
+    { label: "/aif-verify (Рекомендуется)", description: "Проверить реализацию" },
+    { label: "/aif-commit", description: "Закоммитить изменения" },
+    { label: "Продолжить", description: "Остаться в текущем контексте" }
+  ]
+})
+```
+
+### Множественный выбор (другие агенты)
+```
+question({
+  questions: [{
+    header: "Фичи",
+    question: "Какие фичи реализовать?",
+    options: [
+      { label: "Auth", description: "Аутентификация" },
+      { label: "Cache", description: "Кеширование" },
+      { label: "Logging", description: "Логирование" }
+    ],
+    multiple: true
+  }]
+})
+```
+
+---
+
+## Отладка
+
+Если инструмент не работает:
+
+1. Проверьте что extension установлен:
+   - pi: `~/.pi/agent/extensions/question.ts`
+   - pi: `~/.pi/agent/extensions/questionnaire.ts`
+
+2. Проверьте синтаксис:
+   - Все строки в кавычках
+   - Запятые между элементами массива
+   - Скобки закрыты
+
+3. Проверьте `allowed-tools` в скилле:
+   ```
+   allowed-tools: ... question questionnaire
+   ```
+
+---
+
+## Совместимость
+
+| Агент | question (простой) | questionnaire | question (массив) | multiple |
+|-------|-------------------|---------------|-------------------|----------|
+| pi | ✅ | ✅ | ❌ | ❌ |
+| Claude Code | ❌ | ❌ | ✅ | ✅ |
+| Kilo CLI | ❌ | ❌ | ✅ | ✅ |
+| OpenCode | ❌ | ❌ | ✅ | ✅ |

--- a/skills/shared/QUESTION-TOOL.md
+++ b/skills/shared/QUESTION-TOOL.md
@@ -1,22 +1,22 @@
-# Question Tool — Взаимодействие с пользователем
+# Question Tool — User Interaction
 
-> Reference для всех скиллов проекта. Используйте форматы ниже для вопросов пользователю.
+> Reference for all project skills. Use the formats below for asking questions to users.
 
-## Форматы для разных агентов
+## Formats for Different Agents
 
-Разные агенты используют разные форматы для вопросов. Выбирайте подходящий для вашего агента.
+Different agents use different formats for questions. Choose the appropriate format for your agent.
 
 ---
 
-## Одиночный вопрос
+## Single Question
 
 ### pi
 ```
 question({
-  question: "Текст вопроса?",
+  question: "Question text?",
   options: [
-    { label: "Вариант 1 (Рекомендуется)", description: "Краткое описание" },
-    { label: "Вариант 2", description: "Краткое описание" }
+    { label: "Option 1 (Recommended)", description: "Brief description" },
+    { label: "Option 2", description: "Brief description" }
   ]
 })
 ```
@@ -25,11 +25,11 @@ question({
 ```
 question({
   questions: [{
-    header: "Тема",  // max 30 символов
-    question: "Текст вопроса?",
+    header: "Topic",  // max 30 characters
+    question: "Question text?",
     options: [
-      { label: "Вариант 1 (Рекомендуется)", description: "Краткое описание" },
-      { label: "Вариант 2", description: "Краткое описание" }
+      { label: "Option 1 (Recommended)", description: "Brief description" },
+      { label: "Option 2", description: "Brief description" }
     ]
   }]
 })
@@ -37,7 +37,7 @@ question({
 
 ---
 
-## Несколько вопросов
+## Multiple Questions
 
 ### pi
 ```
@@ -45,21 +45,21 @@ questionnaire({
   questions: [
     {
       id: "area",
-      label: "Область",      // для tab bar
-      prompt: "Какую область затрагивает?",
+      label: "Area",           // for tab bar
+      prompt: "Which area does this affect?",
       options: [
-        { value: "frontend", label: "Frontend", description: "UI компоненты" },
-        { value: "backend", label: "Backend", description: "API и сервисы" }
+        { value: "frontend", label: "Frontend", description: "UI components" },
+        { value: "backend", label: "Backend", description: "API and services" }
       ],
-      allowOther: true      // разрешить "Type something..."
+      allowOther: true         // allow "Type something..."
     },
     {
       id: "priority",
-      label: "Приоритет",
-      prompt: "Какой приоритет?",
+      label: "Priority",
+      prompt: "What is the priority?",
       options: [
-        { value: "high", label: "Высокий", description: "Срочно" },
-        { value: "low", label: "Низкий", description: "Не срочно" }
+        { value: "high", label: "High", description: "Urgent" },
+        { value: "low", label: "Low", description: "Not urgent" }
       ]
     }
   ]
@@ -71,19 +71,19 @@ questionnaire({
 question({
   questions: [
     {
-      header: "Область",
-      question: "Какую область затрагивает?",
+      header: "Area",
+      question: "Which area does this affect?",
       options: [
-        { label: "Frontend", description: "UI компоненты" },
-        { label: "Backend", description: "API и сервисы" }
+        { label: "Frontend", description: "UI components" },
+        { label: "Backend", description: "API and services" }
       ]
     },
     {
-      header: "Приоритет",
-      question: "Какой приоритет?",
+      header: "Priority",
+      question: "What is the priority?",
       options: [
-        { label: "Высокий", description: "Срочно" },
-        { label: "Низкий", description: "Не срочно" }
+        { label: "High", description: "Urgent" },
+        { label: "Low", description: "Not urgent" }
       ]
     }
   ]
@@ -92,103 +92,103 @@ question({
 
 ---
 
-## Параметры
+## Parameters
 
 ### question (pi)
 
-| Параметр | Тип | Обязательный | Описание |
-|----------|-----|--------------|----------|
-| `question` | string | ✅ | Текст вопроса |
-| `options` | array | ✅ | Массив вариантов (2-4 элемента) |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `question` | string | ✅ | Question text |
+| `options` | array | ✅ | Array of options (2-4 items) |
 
 ### questionnaire (pi)
 
-| Параметр | Тип | Обязательный | Описание |
-|----------|-----|--------------|----------|
-| `questions` | array | ✅ | Массив вопросов |
-| `id` | string | ✅ | Идентификатор вопроса |
-| `label` | string | ✅ | Короткий label для tab bar |
-| `prompt` | string | ✅ | Полный текст вопроса |
-| `options` | array | ✅ | Массив вариантов |
-| `allowOther` | boolean | ❌ | Разрешить свой вариант |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `questions` | array | ✅ | Array of questions |
+| `id` | string | ✅ | Question identifier |
+| `label` | string | ✅ | Short label for tab bar |
+| `prompt` | string | ✅ | Full question text |
+| `options` | array | ✅ | Array of options |
+| `allowOther` | boolean | ❌ | Allow custom input |
 
-### question (другие агенты)
+### question (other agents)
 
-| Параметр | Тип | Обязательный | Описание |
-|----------|-----|--------------|----------|
-| `questions` | array | ✅ | Массив вопросов (1-4 элемента) |
-| `header` | string | ❌ | Короткий заголовок (max 30) |
-| `question` | string | ✅ | Текст вопроса |
-| `options` | array | ✅ | Массив вариантов |
-| `multiple` | boolean | ❌ | Множественный выбор |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `questions` | array | ✅ | Array of questions (1-4 items) |
+| `header` | string | ❌ | Short header (max 30) |
+| `question` | string | ✅ | Question text |
+| `options` | array | ✅ | Array of options |
+| `multiple` | boolean | ❌ | Multiple selection |
 
-### options (общие)
+### options (common)
 
-| Параметр | Тип | Обязательный | Описание |
-|----------|-----|--------------|----------|
-| `label` | string | ✅ | Название варианта |
-| `description` | string | ✅ | Краткое описание |
-| `value` | string | ❌ | Значение (только questionnaire) |
-
----
-
-## Правила
-
-1. **2-4 варианта** — не больше
-2. **Описание обязательно** — для каждого варианта
-3. **Рекомендуемый вариант** — помечать `(Рекомендуется)` или `(Recommended)`
-4. **Короткие заголовки** — `header`/`label` max 30 символов
-5. **Один вопрос** → `question`, **несколько** → `questionnaire` (pi) / `question` с массивом (другие)
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `label` | string | ✅ | Option name |
+| `description` | string | ✅ | Brief description |
+| `value` | string | ❌ | Value (questionnaire only) |
 
 ---
 
-## Примеры
+## Rules
 
-### Уточнение области
+1. **2-4 options** — no more
+2. **Description required** — for each option
+3. **Recommended option** — mark with `(Recommended)`
+4. **Short headers** — `header`/`label` max 30 characters
+5. **Single question** → `question`, **multiple** → `questionnaire` (pi) / `question` with array (others)
+
+---
+
+## Examples
+
+### Scope Clarification
 ```
 question({
-  question: "Какую область затрагивает изменение?",
+  question: "Which area does this change affect?",
   options: [
-    { label: "Frontend (Рекомендуется)", description: "UI компоненты, стили" },
-    { label: "Backend", description: "API, сервисы, база данных" },
-    { label: "Оба", description: "Full-stack изменения" }
+    { label: "Frontend (Recommended)", description: "UI components, styles" },
+    { label: "Backend", description: "API, services, database" },
+    { label: "Both", description: "Full-stack changes" }
   ]
 })
 ```
 
-### Подтверждение действия
+### Action Confirmation
 ```
 question({
-  question: "Применить изменения?",
+  question: "Apply changes?",
   options: [
-    { label: "Да, применить (Рекомендуется)", description: "Записать изменения в файлы" },
-    { label: "Нет, отмена", description: "Вернуться без изменений" }
+    { label: "Yes, apply (Recommended)", description: "Write changes to files" },
+    { label: "No, cancel", description: "Return without changes" }
   ]
 })
 ```
 
-### Выбор следующего шага
+### Next Step Selection
 ```
 question({
-  question: "Что делать дальше?",
+  question: "What to do next?",
   options: [
-    { label: "/aif-verify (Рекомендуется)", description: "Проверить реализацию" },
-    { label: "/aif-commit", description: "Закоммитить изменения" },
-    { label: "Продолжить", description: "Остаться в текущем контексте" }
+    { label: "/aif-verify (Recommended)", description: "Verify implementation" },
+    { label: "/aif-commit", description: "Commit changes" },
+    { label: "Continue", description: "Stay in current context" }
   ]
 })
 ```
 
-### Множественный выбор (другие агенты)
+### Multiple Selection (other agents)
 ```
 question({
   questions: [{
-    header: "Фичи",
-    question: "Какие фичи реализовать?",
+    header: "Features",
+    question: "Which features to implement?",
     options: [
-      { label: "Auth", description: "Аутентификация" },
-      { label: "Cache", description: "Кеширование" },
-      { label: "Logging", description: "Логирование" }
+      { label: "Auth", description: "Authentication" },
+      { label: "Cache", description: "Caching" },
+      { label: "Logging", description: "Logging" }
     ],
     multiple: true
   }]
@@ -197,30 +197,30 @@ question({
 
 ---
 
-## Отладка
+## Debugging
 
-Если инструмент не работает:
+If the tool doesn't work:
 
-1. Проверьте что extension установлен:
+1. Check that the extension is installed:
    - pi: `~/.pi/agent/extensions/question.ts`
    - pi: `~/.pi/agent/extensions/questionnaire.ts`
 
-2. Проверьте синтаксис:
-   - Все строки в кавычках
-   - Запятые между элементами массива
-   - Скобки закрыты
+2. Check syntax:
+   - All strings in quotes
+   - Commas between array elements
+   - Brackets closed
 
-3. Проверьте `allowed-tools` в скилле:
+3. Check `allowed-tools` in skill:
    ```
    allowed-tools: ... question questionnaire
    ```
 
 ---
 
-## Совместимость
+## Compatibility
 
-| Агент | question (простой) | questionnaire | question (массив) | multiple |
-|-------|-------------------|---------------|-------------------|----------|
+| Agent | question (simple) | questionnaire | question (array) | multiple |
+|-------|-------------------|---------------|------------------|----------|
 | pi | ✅ | ✅ | ❌ | ❌ |
 | Claude Code | ❌ | ❌ | ✅ | ✅ |
 | Kilo CLI | ❌ | ❌ | ✅ | ✅ |


### PR DESCRIPTION
## Описание

Заменить псевдо-синтаксис `AskUserQuestion:` на документированные форматы `question`/`questionnaire` tools с поддержкой разных агентов.

## Изменения

### Новый reference файл
- `skills/shared/QUESTION-TOOL.md` — полная документация по форматам question/questionnaire для разных агентов

### Обновлённые скиллы
| Файл | Изменения |
|------|-----------|
| `skills/aif-new/SKILL.md` | +reference link, allowed-tools: question questionnaire |
| `skills/aif-implement-plus/SKILL.md` | +reference link, allowed-tools: question questionnaire |
| `skills/aif-improve-plus/SKILL.md` | +reference link, allowed-tools: question questionnaire |
| `skills/aif-verify-plus/SKILL.md` | +reference link, allowed-tools: question questionnaire |
| `skills/aif-fix/SKILL.md` | allowed-tools: question questionnaire |
| `skills/aif-done/SKILL.md` | +reference link, allowed-tools: question questionnaire |

### Форматы для разных агентов

**pi:**
- Один вопрос: `question({ question, options })`
- Несколько вопросов: `questionnaire({ questions: [...] })`

**Claude Code / Kilo CLI / OpenCode:**
- Любые вопросы: `question({ questions: [{ header, question, options }] })`

## Проверка

```bash
grep -r "AskUserQuestion:" skills/ | wc -l
# 0
```

Closes #10