### PR TITLE
Update OpenSpec compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ Extension for [ai-factory 2.x](https://github.com/lee-to/ai-factory) CLI that ke
 
 `baselineVersion` фиксирует историческую upstream-базу этой модели extension. Актуальные ожидания по поддержке и установке всегда определяются `compat.ai-factory`.
 
+### OpenSpec compatibility
+
+OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol.
+
+| Capability | Requirement |
+|---|---|
+| AI Factory-only extension install/use | `ai-factory >=2.10.0 <3.0.0` |
+| OpenSpec-native validation/archive | OpenSpec CLI `>=1.3.1 <2.0.0` |
+| OpenSpec CLI runtime | Node `>=20.19.0` |
+| OpenSpec skills/commands | Not installed by this extension |
+
+When the OpenSpec CLI is unavailable, the extension remains usable in degraded AI Factory-only mode. OpenSpec validation/archive capabilities are disabled until a compatible `openspec` CLI is available.
+
+AI Factory-only mode follows the Node/runtime support of AI Factory and upstream. OpenSpec-native validation/archive requires Node `>=20.19.0` because that is the OpenSpec CLI runtime requirement.
+
+OpenSpec can be initialized without tool integrations using `openspec init --tools none`, but this extension does not require running that during install.
+
+See [OpenSpec Compatibility](docs/openspec-compatibility.md) for install/upgrade notes and the capability flags planned for runtime detection.
+
 ## Quick Start
 
 ```bash
@@ -90,6 +109,7 @@ aif-explore -> aif-plan -> aif-improve -> aif-implement -> aif-verify
 | [Claude Agents](docs/claude-agents.md) | Namespaced Claude subagents, `.claude/agents/` install target, and handoff limitations |
 | [Handoff Naming](docs/handoff.md) | Терминология `Explore / New / Apply / Done` без возврата legacy commands в public path |
 | [Context Loading Policy](docs/context-loading-policy.md) | Runtime context contract and ownership rules |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
 
 ## Validation
 
@@ -105,6 +125,9 @@ npm test           # все тесты
 ## Requirements
 
 - `ai-factory CLI >=2.10.0 <3.0.0`
+- Optional OpenSpec-native validation/archive: `openspec CLI >=1.3.1 <2.0.0` on Node `>=20.19.0`
+- OpenSpec skills/commands are not installed by this extension.
+- Missing OpenSpec CLI is degraded AI Factory-only mode, not an extension install failure.
 
 Отслеживание совместимости ведётся в `extension.json`:
 
@@ -112,6 +135,7 @@ npm test           # все тесты
 - `sources.ai-factory.version`: последняя проверенная upstream-версия
 - `sources.ai-factory.baselineVersion`: исторический baseline исходной модели extension
 - `sources.ai-factory.notes`: причина текущей минимально поддерживаемой версии
+- `sources.openspec`: optional OpenSpec CLI adapter baseline, supported range, Node requirement, and degraded-mode policy
 
 ## Update Behavior
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Detailed documentation for the AIFHub extension.
 
 Для решений о поддержке ориентируйтесь на `compat.ai-factory`. `baselineVersion` нужен только как исторический контекст.
 
+OpenSpec compatibility is tracked as optional adapter metadata, not as a hard extension requirement. See [OpenSpec Compatibility](openspec-compatibility.md) for the supported CLI range, Node policy, degraded mode, and future capability flags.
+
 ## Guides
 
 | Guide | Description |
@@ -23,6 +25,7 @@ Detailed documentation for the AIFHub extension.
 | [Claude Agents](claude-agents.md) | Namespaced Claude subagents, `.claude/agents/` install target, and handoff limitations |
 | [Handoff Naming](handoff.md) | Stage vocabulary versus current public commands and future mapping constraints |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context contract, ownership boundaries, and artifact rules |
+| [OpenSpec Compatibility](openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
 
 ## Recommended Reading Order
 
@@ -30,6 +33,7 @@ Detailed documentation for the AIFHub extension.
 2. Read [Codex Agents](codex-agents.md) or [Claude Agents](claude-agents.md) for the runtime-specific subagent contract you need.
 3. Read [Handoff Naming](handoff.md) for current manual stages versus future mapping.
 4. Read [Context Loading Policy](context-loading-policy.md) for ownership and runtime path rules.
+5. Read [OpenSpec Compatibility](openspec-compatibility.md) for optional OpenSpec CLI adapter policy and degraded-mode behavior.
 
 ## Scope
 
@@ -38,6 +42,7 @@ This docs set covers:
 - public workflow for the extension
 - companion plan-file plus plan-folder model
 - runtime-контекст, границы владения и проверенный контракт совместимости
+- optional OpenSpec CLI adapter baseline and degraded-mode policy
 
 Project-level AI Factory planning and archived specs remain under `.ai-factory/` and are not duplicated here.
 
@@ -48,4 +53,5 @@ Project-level AI Factory planning and archived specs remain under `.ai-factory/`
 - [Claude Agents](claude-agents.md) - runtime-managed Claude agent files and `.claude/agents/` behavior
 - [Handoff Naming](handoff.md) - current manual stages and future stage-agent mapping constraints
 - [Context Loading Policy](context-loading-policy.md) - context-loading and ownership rules
+- [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter policy and future capability flags
 - [Project README](../README.md) - landing page and quick start

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -1,0 +1,54 @@
+[Back to Documentation](README.md)
+
+# OpenSpec Compatibility
+
+OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This policy update records the supported baseline and expected degraded behavior only; it does not implement OpenSpec CLI detection, a CLI runner, OpenSpec-native artifacts, or OpenSpec skill/command installation.
+
+## Supported Versions
+
+| Capability | Requirement |
+|---|---|
+| AI Factory-only extension install/use | `ai-factory >=2.10.0 <3.0.0` |
+| OpenSpec-native validation/archive | OpenSpec CLI `>=1.3.1 <2.0.0` |
+| OpenSpec CLI runtime | Node `>=20.19.0` |
+| OpenSpec skills/commands | Not installed by this extension |
+
+AI Factory-only mode follows the Node/runtime support of AI Factory and upstream. OpenSpec-native validation and archive require Node `>=20.19.0`, matching the OpenSpec CLI runtime requirement.
+
+OpenSpec can be initialized without tool integrations using:
+
+```bash
+openspec init --tools none
+```
+
+The AIFHub extension does not require this command during install.
+
+## Install And Upgrade Notes
+
+This change only updates extension policy, metadata, and documentation. OpenSpec remains an optional external CLI adapter and is not added to `dependencies` or `devDependencies`.
+
+When a compatible OpenSpec CLI is missing:
+
+- extension install remains valid
+- AI Factory bootstrap/config workflows may still run in AI Factory-only mode
+- OpenSpec-native validation is unavailable
+- OpenSpec-native archive is unavailable
+- future OpenSpec-aware commands should report capability flags instead of failing extension install
+
+OpenSpec skills and slash commands are not installed by this extension in v1.
+
+## Planned Capability Flags
+
+Issue #38 will own runtime detection and command integration. Future commands should expose capability metadata equivalent to:
+
+```yaml
+openspec:
+  available: boolean
+  canValidate: boolean
+  canArchive: boolean
+  version: string | null
+  supportedRange: ">=1.3.1 <2.0.0"
+  requiresNode: ">=20.19.0"
+```
+
+These flags are documented here for compatibility policy only. Runtime detection and CLI execution are intentionally out of scope for this issue.

--- a/extension.json
+++ b/extension.json
@@ -15,9 +15,13 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "v0.23.0",
-      "lastSync": "2026-03-26",
-      "notes": "init"
+      "version": "1.3.1",
+      "supportedRange": ">=1.3.1 <2.0.0",
+      "lastSync": "2026-04-25",
+      "optional": true,
+      "requiresNode": ">=20.19.0",
+      "mode": "optional-cli-adapter",
+      "notes": "OpenSpec is used as an optional artifact protocol and CLI validation/archive adapter for v1. OpenSpec skills are not installed by this extension. AI Factory-only mode remains supported without the OpenSpec CLI."
     }
   },
   "skills": [


### PR DESCRIPTION
## Summary
- Update `extension.json` to record the OpenSpec `1.3.1` baseline, supported range, optional adapter mode, and Node requirement
- Document OpenSpec as an optional CLI adapter in `README.md` and `docs/README.md`
- Add `docs/openspec-compatibility.md` with degraded-mode behavior and planned capability flags for issue #38

## Testing
- `npm run validate` passed
- `npm test` passed