### PR TITLE
Add OpenSpec-native artifact protocol ADR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ OpenSpec compatibility is tracked as optional adapter metadata, not as a hard ex
 | [Handoff Naming](handoff.md) | Stage vocabulary versus current public commands and future mapping constraints |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context contract, ownership boundaries, and artifact rules |
 | [OpenSpec Compatibility](openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
+| [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) | v1 source-of-truth contract for OpenSpec canonical artifacts and AI Factory runtime state |
 
 ## Recommended Reading Order
 
@@ -34,6 +35,7 @@ OpenSpec compatibility is tracked as optional adapter metadata, not as a hard ex
 3. Read [Handoff Naming](handoff.md) for current manual stages versus future mapping.
 4. Read [Context Loading Policy](context-loading-policy.md) for ownership and runtime path rules.
 5. Read [OpenSpec Compatibility](openspec-compatibility.md) for optional OpenSpec CLI adapter policy and degraded-mode behavior.
+6. Read [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership contract.
 
 ## Scope
 
@@ -54,4 +56,5 @@ Project-level AI Factory planning and archived specs remain under `.ai-factory/`
 - [Handoff Naming](handoff.md) - current manual stages and future stage-agent mapping constraints
 - [Context Loading Policy](context-loading-policy.md) - context-loading and ownership rules
 - [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter policy and future capability flags
+- [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) - canonical OpenSpec artifacts and runtime AI Factory state
 - [Project README](../README.md) - landing page and quick start

--- a/docs/adr/0001-openspec-native-artifact-protocol.md
+++ b/docs/adr/0001-openspec-native-artifact-protocol.md
@@ -1,0 +1,140 @@
+[Back to Documentation](../README.md)
+
+# ADR 0001: OpenSpec-native artifact protocol
+
+## Status
+
+Accepted for v1 planning
+
+## Context
+
+AIFHub Extension v1 keeps the AI Factory user experience and command vocabulary while moving canonical change and specification artifacts to an OpenSpec-compatible layout.
+
+Issue #25 and PR #40 established that OpenSpec is an optional CLI adapter, not a required extension dependency. The supported OpenSpec range is `>=1.3.1 <2.0.0`; OpenSpec validation and archive require Node `>=20.19.0`; AIFHub Extension does not install OpenSpec skills or commands; and a missing OpenSpec CLI means degraded AI Factory-only mode, not install failure.
+
+Before runtime code is added, the project needs a stable ownership contract that separates canonical requirements and change intent from runtime execution state.
+
+## Decision
+
+The v1 artifact protocol uses OpenSpec artifacts as the canonical source of truth for requirements, proposed changes, design intent, task plans, and delta specs.
+
+AI Factory artifacts under `.ai-factory/` are runtime, QA, or generated state used to execute and verify work. They are not canonical requirements unless an artifact explicitly says otherwise.
+
+Future AIFHub-owned artifacts under `.aifhub/` are reserved for later registry, evaluation, context, and knowledge-base work. They are outside the v1 OpenSpec-native artifact protocol implementation.
+
+## Artifact ownership
+
+Canonical OpenSpec artifacts:
+
+```text
+openspec/specs/
+openspec/changes/<change-id>/
+  proposal.md
+  design.md
+  tasks.md
+  specs/**/spec.md
+```
+
+These files are the source of truth for accepted specs, proposed changes, design decisions, task plans, and change-local spec deltas.
+
+Runtime AI Factory artifacts:
+
+```text
+.ai-factory/state/<change-id>/
+.ai-factory/qa/<change-id>/
+```
+
+These files store execution progress, working notes, QA evidence, verifier findings, and implementation state. They can be deleted or regenerated unless a future ADR or file-local metadata explicitly documents stronger retention semantics.
+
+Generated AI Factory artifacts:
+
+```text
+.ai-factory/rules/generated/
+```
+
+Generated rules are derived from OpenSpec specs and change specs. They are not canonical requirements and must be recoverable from canonical OpenSpec artifacts.
+
+Future-reserved AIFHub artifacts:
+
+```text
+.aifhub/
+  cache/
+  context/
+  kb/
+  skill-runs/
+```
+
+These paths are reserved names only in v1. Their detailed behavior is out of scope for this artifact protocol.
+
+## Command read/write matrix
+
+| Command | Canonical reads | Canonical writes | Runtime writes | Notes |
+|---|---|---|---|---|
+| `/aif-analyze` | project metadata, existing config | optional `openspec/` skeleton only when configured | capability/config reports | Must not install OpenSpec skills |
+| `/aif-plan` | `openspec/specs`, project context | `openspec/changes/<id>/*` | optional `.ai-factory/state/<id>/*` | Creates OpenSpec-native change in v1 |
+| `/aif-explore` | project context, optional `openspec/specs` | none by default | `.ai-factory/state/<id>/explore.md` or equivalent | Research is not canonical unless promoted into OpenSpec artifacts |
+| `/aif-improve` | `openspec/changes/<id>/*`, `openspec/specs` | `openspec/changes/<id>/*` | patch summary if needed | Must preserve user edits |
+| `/aif-implement` | `openspec/specs`, `openspec/changes/<id>/*`, generated rules | none | `.ai-factory/state/<id>/*` | Execution state is runtime-only |
+| `/aif-fix` | same as implement plus QA reports | none | `.ai-factory/state/<id>/*` | Fixes implementation, not specs unless explicitly requested |
+| `/aif-verify` | `openspec/*`, generated rules | none | `.ai-factory/qa/<id>/*` | Must not archive |
+| `/aif-rules-check` | `openspec/specs`, `openspec/changes/<id>/specs` | none | reports and/or `.ai-factory/rules/generated/*` | Generated rules are derived |
+| `/aif-done` | `openspec/changes/<id>/*`, QA state | `openspec/specs/*` via OpenSpec archive | final summary/state | Only finalizer may archive |
+
+## Generated rules policy
+
+Generated rules are derived from canonical OpenSpec specs and change-local specs. They are not independent requirements.
+
+The generated rules directory is safe to delete and regenerate. If generated rules are missing or stale, the compiler must rebuild them from:
+
+```text
+openspec/specs/
+openspec/changes/<change-id>/specs/
+```
+
+Generated rule output may guide implementation and review, but conflict resolution must defer to canonical OpenSpec artifacts.
+
+## OpenSpec CLI policy
+
+The OpenSpec CLI is optional for extension install and AI Factory-only workflows.
+
+The OpenSpec CLI is required for OpenSpec validate and archive capabilities. The v1 supported range is `>=1.3.1 <2.0.0`, and OpenSpec validate/archive requires Node `>=20.19.0`.
+
+AIFHub Extension must not install OpenSpec skills or commands. If a compatible OpenSpec CLI is missing, OpenSpec-aware commands must degrade gracefully by reporting unavailable validate/archive capabilities instead of failing extension install.
+
+## Legacy artifact policy
+
+Legacy `.ai-factory/plans` artifacts are pre-migration planning and execution records. Before migration is implemented, commands may read them as compatibility inputs and migration sources.
+
+Legacy plan artifacts are not the v1 canonical source of truth once OpenSpec-native artifacts exist for the same change. Any future migration must preserve user edits and avoid silently overwriting canonical OpenSpec artifacts.
+
+This ADR defines policy only; it does not implement migration.
+
+## Out of scope
+
+- OpenSpec CLI runner implementation
+- OpenSpec-native `/aif-plan`
+- migration implementation
+- generated rules compiler implementation
+- TOON/context/KB
+- AIFHub registry/evals
+- OpenSpec capability detection
+- bootstrap changes
+- active-change resolver
+- prompt, skill, or injection rewrites
+
+## Consequences
+
+Benefits:
+
+- Gives v1 a single canonical location for requirements and change intent.
+- Keeps AI Factory execution state useful without making it authoritative.
+- Allows runtime state, QA evidence, and generated rules to be regenerated safely.
+- Preserves degraded AI Factory-only mode when the OpenSpec CLI is unavailable.
+- Prevents accidental OpenSpec skill or command installation by this extension.
+
+Tradeoffs:
+
+- Commands must distinguish canonical writes from runtime writes.
+- Legacy `.ai-factory/plans` consumers need migration or compatibility logic later.
+- Generated rules need a compiler in a later issue before they can be relied on operationally.
+- OpenSpec validate/archive remains unavailable until a compatible external CLI is present.


### PR DESCRIPTION
## Summary
- Add ADR 0001 defining the v1 OpenSpec-native artifact ownership contract
- Mark `openspec/specs` and `openspec/changes` as canonical, with `.ai-factory/state`, `.ai-factory/qa`, and generated rules as runtime or derived artifacts
- Document the `/aif-*` read/write matrix, OpenSpec CLI policy, legacy artifact handling, and future-reserved `.aifhub/*` paths
- Link the ADR from the docs index

## Testing
- Local validation passed with `npm run validate`
- Local test suite passed with `npm test`
- Additional doc-content checks passed for ADR coverage and links