### PR TITLE
Add OpenSpec CLI runner and capability detection

### DIFF
--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -2,7 +2,7 @@
 
 # OpenSpec Compatibility
 
-OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This policy update records the supported baseline and expected degraded behavior only; it does not implement OpenSpec CLI detection, a CLI runner, OpenSpec-native artifacts, or OpenSpec skill/command installation.
+OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This page records the supported baseline, runtime detection surface, and expected degraded behavior; it does not implement OpenSpec-native artifacts or OpenSpec skill/command installation.
 
 ## Supported Versions
 
@@ -37,9 +37,9 @@ When a compatible OpenSpec CLI is missing:
 
 OpenSpec skills and slash commands are not installed by this extension in v1.
 
-## Planned Capability Flags
+## Runtime Capability Flags
 
-Issue #38 will own runtime detection and command integration. Future commands should expose capability metadata equivalent to:
+Issue #38 adds the shared runner in `scripts/openspec-runner.mjs` for OpenSpec CLI detection and normalized command execution. Future OpenSpec-aware commands should consume capability metadata equivalent to:
 
 ```yaml
 openspec:
@@ -49,6 +49,8 @@ openspec:
   version: string | null
   supportedRange: ">=1.3.1 <2.0.0"
   requiresNode: ">=20.19.0"
+  nodeSupported: boolean
+  versionSupported: boolean
 ```
 
-These flags are documented here for compatibility policy only. Runtime detection and CLI execution are intentionally out of scope for this issue.
+The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap, planning, verification, archive integration, migration, generated rules, and prompt rewrites remain separate follow-up work.

--- a/scripts/openspec-runner.mjs
+++ b/scripts/openspec-runner.mjs
@@ -402,11 +402,11 @@ function extractOpenSpecVersion(output) {
     return null;
   }
 
-  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+  return formatSemver(parsed);
 }
 
 function parseSemver(version) {
-  const match = String(version).match(/(?:^|[^\d])(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?/);
+  const match = String(version).match(/(?:^|[^\d])(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?/);
 
   if (!match) {
     return null;
@@ -415,8 +415,24 @@ function parseSemver(version) {
   return {
     major: Number.parseInt(match[1], 10),
     minor: Number.parseInt(match[2], 10),
-    patch: Number.parseInt(match[3], 10)
+    patch: Number.parseInt(match[3], 10),
+    prerelease: match[4] ?? null,
+    build: match[5] ?? null
   };
+}
+
+function formatSemver(version) {
+  let result = `${version.major}.${version.minor}.${version.patch}`;
+
+  if (version.prerelease !== null) {
+    result += `-${version.prerelease}`;
+  }
+
+  if (version.build !== null) {
+    result += `+${version.build}`;
+  }
+
+  return result;
 }
 
 function compareSemver(a, b) {
@@ -437,20 +453,95 @@ function compareSemver(a, b) {
     }
   }
 
+  const prereleaseComparison = comparePrerelease(left.prerelease, right.prerelease);
+
+  if (prereleaseComparison !== 0) {
+    return prereleaseComparison;
+  }
+
   return 0;
 }
 
+function comparePrerelease(left, right) {
+  if (left === null && right === null) {
+    return 0;
+  }
+
+  if (left === null) {
+    return 1;
+  }
+
+  if (right === null) {
+    return -1;
+  }
+
+  const leftParts = left.split('.');
+  const rightParts = right.split('.');
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+
+  for (let i = 0; i < maxLength; i += 1) {
+    const leftPart = leftParts[i];
+    const rightPart = rightParts[i];
+
+    if (leftPart === undefined) {
+      return -1;
+    }
+
+    if (rightPart === undefined) {
+      return 1;
+    }
+
+    const partComparison = comparePrereleasePart(leftPart, rightPart);
+
+    if (partComparison !== 0) {
+      return partComparison;
+    }
+  }
+
+  return 0;
+}
+
+function comparePrereleasePart(left, right) {
+  const leftNumeric = isNumericIdentifier(left);
+  const rightNumeric = isNumericIdentifier(right);
+
+  if (leftNumeric && rightNumeric) {
+    return Number(left) - Number(right);
+  }
+
+  if (leftNumeric) {
+    return -1;
+  }
+
+  if (rightNumeric) {
+    return 1;
+  }
+
+  return left.localeCompare(right);
+}
+
+function isNumericIdentifier(value) {
+  return /^(0|[1-9]\d*)$/.test(value);
+}
+
 function satisfiesGteLt(version, min, max) {
+  const parsed = parseSemver(version);
   const minComparison = compareSemver(version, min);
   const maxComparison = compareSemver(version, max);
 
-  return minComparison !== null
+  return parsed !== null
+    && parsed.prerelease === null
+    && minComparison !== null
     && maxComparison !== null
     && minComparison >= 0
     && maxComparison < 0;
 }
 
 function satisfiesGte(version, min) {
+  const parsed = parseSemver(version);
   const comparison = compareSemver(version, min);
-  return comparison !== null && comparison >= 0;
+  return parsed !== null
+    && parsed.prerelease === null
+    && comparison !== null
+    && comparison >= 0;
 }

--- a/scripts/openspec-runner.mjs
+++ b/scripts/openspec-runner.mjs
@@ -1,0 +1,456 @@
+// openspec-runner.mjs - shared OpenSpec CLI runner and capability detection
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+export const OPENSPEC_SUPPORTED_RANGE = '>=1.3.1 <2.0.0';
+export const OPENSPEC_NODE_RANGE = '>=20.19.0';
+
+const execFileAsync = promisify(execFile);
+const OPENSPEC_MIN_VERSION = '1.3.1';
+const OPENSPEC_MAX_VERSION = '2.0.0';
+const NODE_MIN_VERSION = '20.19.0';
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+const ERRORS = {
+  invalidJson: {
+    code: 'invalid-json',
+    message: 'OpenSpec command returned invalid JSON.'
+  },
+  missingCli: {
+    code: 'missing-cli',
+    message: 'OpenSpec CLI is not available on PATH.'
+  },
+  nonZeroExit(exitCode) {
+    return {
+      code: 'non-zero-exit',
+      message: `OpenSpec command failed with exit code ${exitCode}.`
+    };
+  },
+  unsupportedNode(nodeVersion) {
+    return {
+      code: 'unsupported-node',
+      message: `Node ${nodeVersion} does not satisfy OpenSpec requirement ${OPENSPEC_NODE_RANGE}.`
+    };
+  },
+  unsupportedVersion(version) {
+    return {
+      code: 'unsupported-version',
+      message: `OpenSpec CLI version ${version} is outside supported range ${OPENSPEC_SUPPORTED_RANGE}.`
+    };
+  },
+  versionDetectionFailed: {
+    code: 'version-detection-failed',
+    message: 'OpenSpec version detection failed.'
+  }
+};
+
+export async function detectOpenSpec(options = {}) {
+  const {
+    command = 'openspec',
+    cwd = process.cwd(),
+    env = process.env,
+    executor = defaultExecutor,
+    nodeVersion = process.versions.node
+  } = options;
+
+  const nodeSupported = satisfiesGte(nodeVersion, NODE_MIN_VERSION);
+  const versionResult = await runOpenSpec(['--version'], {
+    command,
+    cwd,
+    env,
+    executor,
+    expectJson: false
+  });
+
+  if (versionResult.error?.code === 'missing-cli') {
+    return createDetectionResult({
+      available: false,
+      command,
+      nodeVersion,
+      nodeSupported,
+      reason: 'missing-cli',
+      errors: [ERRORS.missingCli]
+    });
+  }
+
+  if (!versionResult.ok) {
+    return createDetectionResult({
+      available: true,
+      command,
+      nodeVersion,
+      nodeSupported,
+      reason: 'version-detection-failed',
+      errors: [ERRORS.versionDetectionFailed]
+    });
+  }
+
+  const version = extractOpenSpecVersion(`${versionResult.stdout}\n${versionResult.stderr}`);
+
+  if (version === null) {
+    return createDetectionResult({
+      available: true,
+      command,
+      nodeVersion,
+      nodeSupported,
+      reason: 'version-detection-failed',
+      errors: [ERRORS.versionDetectionFailed]
+    });
+  }
+
+  const versionSupported = satisfiesGteLt(version, OPENSPEC_MIN_VERSION, OPENSPEC_MAX_VERSION);
+  const errors = [];
+
+  if (!nodeSupported) {
+    errors.push(ERRORS.unsupportedNode(nodeVersion));
+  }
+
+  if (!versionSupported) {
+    errors.push(ERRORS.unsupportedVersion(version));
+  }
+
+  const capabilitiesEnabled = errors.length === 0;
+
+  return createDetectionResult({
+    available: true,
+    canValidate: capabilitiesEnabled,
+    canArchive: capabilitiesEnabled,
+    version,
+    command,
+    nodeVersion,
+    nodeSupported,
+    versionSupported,
+    reason: capabilitiesEnabled ? null : errors[0].code,
+    errors
+  });
+}
+
+export async function runOpenSpec(args, options = {}) {
+  const {
+    command = 'openspec',
+    cwd = process.cwd(),
+    env = process.env,
+    executor = defaultExecutor,
+    expectJson = false
+  } = options;
+
+  const normalizedArgs = Array.from(args ?? []);
+  const base = {
+    ok: false,
+    exitCode: null,
+    command,
+    args: normalizedArgs,
+    cwd,
+    stdout: '',
+    stderr: '',
+    json: null,
+    jsonParseError: null,
+    error: null
+  };
+
+  let execution;
+
+  try {
+    execution = await executor({
+      command,
+      args: normalizedArgs,
+      cwd,
+      env
+    });
+  } catch (err) {
+    return {
+      ...base,
+      ...normalizeThrownExecutionError(err)
+    };
+  }
+
+  const exitCode = execution.exitCode ?? 0;
+  const stdout = normalizeOutput(execution.stdout);
+  const stderr = normalizeOutput(execution.stderr);
+
+  if (exitCode !== 0) {
+    return {
+      ...base,
+      exitCode,
+      stdout,
+      stderr,
+      error: ERRORS.nonZeroExit(exitCode)
+    };
+  }
+
+  if (expectJson) {
+    try {
+      return {
+        ...base,
+        ok: true,
+        exitCode,
+        stdout,
+        stderr,
+        json: JSON.parse(stdout),
+        error: null
+      };
+    } catch {
+      return {
+        ...base,
+        exitCode,
+        stdout,
+        stderr,
+        jsonParseError: ERRORS.invalidJson,
+        error: ERRORS.invalidJson
+      };
+    }
+  }
+
+  return {
+    ...base,
+    ok: true,
+    exitCode,
+    stdout,
+    stderr,
+    error: null
+  };
+}
+
+export async function validateOpenSpecChange(changeId, options = {}) {
+  return runOpenSpec([
+    'validate',
+    changeId,
+    '--type',
+    'change',
+    '--strict',
+    '--json',
+    '--no-interactive',
+    '--no-color'
+  ], {
+    ...options,
+    expectJson: true
+  });
+}
+
+export async function getOpenSpecStatus(changeId, options = {}) {
+  return runOpenSpec([
+    'status',
+    '--change',
+    changeId,
+    '--json',
+    '--no-color'
+  ], {
+    ...options,
+    expectJson: true
+  });
+}
+
+export async function showOpenSpecItem(itemName, options = {}) {
+  const { type, deltasOnly = false, ...runOptions } = options;
+  const args = ['show', itemName];
+
+  if (type !== undefined) {
+    args.push('--type', type);
+  }
+
+  if (deltasOnly) {
+    args.push('--deltas-only');
+  }
+
+  args.push('--json', '--no-interactive', '--no-color');
+
+  return runOpenSpec(args, {
+    ...runOptions,
+    expectJson: true
+  });
+}
+
+export async function getOpenSpecInstructions(artifact, options = {}) {
+  const { change, ...runOptions } = options;
+  const args = ['instructions', artifact];
+
+  if (change !== undefined) {
+    args.push('--change', change);
+  }
+
+  args.push('--json', '--no-color');
+
+  return runOpenSpec(args, {
+    ...runOptions,
+    expectJson: true
+  });
+}
+
+export async function archiveOpenSpecChange(changeId, options = {}) {
+  const {
+    skipSpecs = false,
+    noValidate = false,
+    ...runOptions
+  } = options;
+  const args = ['archive', changeId, '--yes'];
+
+  if (skipSpecs) {
+    args.push('--skip-specs');
+  }
+
+  if (noValidate) {
+    args.push('--no-validate');
+  }
+
+  args.push('--no-color');
+
+  return runOpenSpec(args, {
+    ...runOptions,
+    expectJson: false
+  });
+}
+
+async function defaultExecutor({ command, args, cwd, env }) {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, {
+      cwd,
+      env,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+      windowsHide: true
+    });
+
+    return {
+      exitCode: 0,
+      stdout,
+      stderr
+    };
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw err;
+    }
+
+    const exitCode = getExitCode(err);
+
+    if (exitCode !== null) {
+      return {
+        exitCode,
+        stdout: err.stdout,
+        stderr: err.stderr
+      };
+    }
+
+    throw err;
+  }
+}
+
+function createDetectionResult(overrides = {}) {
+  const version = overrides.version ?? null;
+  const versionSupported = overrides.versionSupported ?? false;
+  const nodeVersion = overrides.nodeVersion ?? process.versions.node;
+  const nodeSupported = overrides.nodeSupported ?? satisfiesGte(nodeVersion, NODE_MIN_VERSION);
+
+  return {
+    available: overrides.available ?? false,
+    canValidate: overrides.canValidate ?? false,
+    canArchive: overrides.canArchive ?? false,
+    version,
+    supportedRange: OPENSPEC_SUPPORTED_RANGE,
+    versionSupported,
+    requiresNode: OPENSPEC_NODE_RANGE,
+    nodeVersion,
+    nodeSupported,
+    command: overrides.command ?? 'openspec',
+    reason: overrides.reason ?? null,
+    errors: overrides.errors ?? []
+  };
+}
+
+function normalizeThrownExecutionError(err) {
+  if (err?.code === 'ENOENT') {
+    return {
+      error: ERRORS.missingCli
+    };
+  }
+
+  return {
+    stdout: normalizeOutput(err?.stdout),
+    stderr: normalizeOutput(err?.stderr),
+    error: {
+      code: err?.code ?? 'execution-failed',
+      message: err?.message ?? 'OpenSpec command execution failed.'
+    }
+  };
+}
+
+function normalizeOutput(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function getExitCode(err) {
+  if (Number.isInteger(err?.code)) {
+    return err.code;
+  }
+
+  if (Number.isInteger(err?.exitCode)) {
+    return err.exitCode;
+  }
+
+  if (Number.isInteger(err?.status)) {
+    return err.status;
+  }
+
+  return null;
+}
+
+function extractOpenSpecVersion(output) {
+  const parsed = parseSemver(output);
+
+  if (parsed === null) {
+    return null;
+  }
+
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
+
+function parseSemver(version) {
+  const match = String(version).match(/(?:^|[^\d])(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10)
+  };
+}
+
+function compareSemver(a, b) {
+  const left = parseSemver(a);
+  const right = parseSemver(b);
+
+  if (left === null || right === null) {
+    return null;
+  }
+
+  for (const key of ['major', 'minor', 'patch']) {
+    if (left[key] > right[key]) {
+      return 1;
+    }
+
+    if (left[key] < right[key]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function satisfiesGteLt(version, min, max) {
+  const minComparison = compareSemver(version, min);
+  const maxComparison = compareSemver(version, max);
+
+  return minComparison !== null
+    && maxComparison !== null
+    && minComparison >= 0
+    && maxComparison < 0;
+}
+
+function satisfiesGte(version, min) {
+  const comparison = compareSemver(version, min);
+  return comparison !== null && comparison >= 0;
+}

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -1,0 +1,351 @@
+// openspec-runner.test.mjs - tests for OpenSpec CLI runner and capability detection
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  archiveOpenSpecChange,
+  detectOpenSpec,
+  getOpenSpecInstructions,
+  getOpenSpecStatus,
+  runOpenSpec,
+  showOpenSpecItem,
+  validateOpenSpecChange
+} from './openspec-runner.mjs';
+
+function missingCliError() {
+  const err = new Error('spawn openspec ENOENT');
+  err.code = 'ENOENT';
+  return err;
+}
+
+function createRecordingExecutor(response) {
+  const calls = [];
+  const executor = async (call) => {
+    calls.push(call);
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  };
+  return { executor, calls };
+}
+
+describe('detectOpenSpec', () => {
+  it('returns available capabilities for version 1.3.1 on supported Node', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: 'openspec 1.3.1\n',
+      stderr: ''
+    });
+
+    const result = await detectOpenSpec({
+      executor,
+      nodeVersion: '20.19.0',
+      cwd: 'C:/repo'
+    });
+
+    assert.deepEqual(calls[0], {
+      command: 'openspec',
+      args: ['--version'],
+      cwd: 'C:/repo',
+      env: process.env
+    });
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.3.1');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.requiresNode, '>=20.19.0');
+    assert.equal(result.nodeVersion, '20.19.0');
+    assert.equal(result.nodeSupported, true);
+    assert.equal(result.command, 'openspec');
+    assert.equal(result.reason, null);
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('returns degraded capabilities when CLI is missing', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => {
+        throw missingCliError();
+      },
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, false);
+    assert.equal(result.canValidate, false);
+    assert.equal(result.canArchive, false);
+    assert.equal(result.version, null);
+    assert.equal(result.versionSupported, false);
+    assert.equal(result.nodeSupported, true);
+    assert.equal(result.reason, 'missing-cli');
+    assert.deepEqual(result.errors, [
+      {
+        code: 'missing-cli',
+        message: 'OpenSpec CLI is not available on PATH.'
+      }
+    ]);
+  });
+
+  it('returns unsupported-version for 1.2.0', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: '1.2.0', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, false);
+    assert.equal(result.canArchive, false);
+    assert.equal(result.version, '1.2.0');
+    assert.equal(result.versionSupported, false);
+    assert.equal(result.nodeSupported, true);
+    assert.equal(result.reason, 'unsupported-version');
+    assert.equal(result.errors[0].code, 'unsupported-version');
+  });
+
+  it('returns unsupported-node when injected Node version is below 20.19.0', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: '@fission-ai/openspec 1.3.1', stderr: '' }),
+      nodeVersion: '20.18.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, false);
+    assert.equal(result.canArchive, false);
+    assert.equal(result.version, '1.3.1');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.nodeSupported, false);
+    assert.equal(result.reason, 'unsupported-node');
+    assert.equal(result.errors[0].code, 'unsupported-node');
+  });
+
+  it('parses bare OpenSpec version output', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: '1.3.1', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.version, '1.3.1');
+    assert.equal(result.reason, null);
+  });
+});
+
+describe('runOpenSpec', () => {
+  it('parses valid JSON when expectJson is true', async () => {
+    const result = await runOpenSpec(['list', '--json'], {
+      expectJson: true,
+      executor: async () => ({
+        exitCode: 0,
+        stdout: '{"changes":["add-oauth"]}',
+        stderr: ''
+      })
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.json, { changes: ['add-oauth'] });
+    assert.equal(result.jsonParseError, null);
+    assert.equal(result.error, null);
+  });
+
+  it('reports invalid JSON when expectJson is true and stdout is not JSON', async () => {
+    const result = await runOpenSpec(['list', '--json'], {
+      expectJson: true,
+      executor: async () => ({
+        exitCode: 0,
+        stdout: 'not json',
+        stderr: ''
+      })
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, 'not json');
+    assert.equal(result.stderr, '');
+    assert.equal(result.json, null);
+    assert.deepEqual(result.jsonParseError, {
+      code: 'invalid-json',
+      message: 'OpenSpec command returned invalid JSON.'
+    });
+    assert.deepEqual(result.error, {
+      code: 'invalid-json',
+      message: 'OpenSpec command returned invalid JSON.'
+    });
+  });
+
+  it('preserves raw stdout and stderr on non-zero exit', async () => {
+    const result = await runOpenSpec(['validate', 'add-oauth'], {
+      expectJson: true,
+      executor: async () => ({
+        exitCode: 1,
+        stdout: '{"valid":false}',
+        stderr: 'failed validation'
+      })
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.stdout, '{"valid":false}');
+    assert.equal(result.stderr, 'failed validation');
+    assert.equal(result.json, null);
+    assert.equal(result.jsonParseError, null);
+    assert.deepEqual(result.error, {
+      code: 'non-zero-exit',
+      message: 'OpenSpec command failed with exit code 1.'
+    });
+  });
+
+  it('returns missing-cli when executor throws ENOENT', async () => {
+    const result = await runOpenSpec(['list'], {
+      executor: async () => {
+        throw missingCliError();
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, null);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, '');
+    assert.equal(result.json, null);
+    assert.equal(result.jsonParseError, null);
+    assert.deepEqual(result.error, {
+      code: 'missing-cli',
+      message: 'OpenSpec CLI is not available on PATH.'
+    });
+  });
+});
+
+describe('OpenSpec command wrappers', () => {
+  it('validateOpenSpecChange builds the expected args', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: '{"valid":true}',
+      stderr: ''
+    });
+
+    const result = await validateOpenSpecChange('add-oauth', { executor });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls[0].args, [
+      'validate',
+      'add-oauth',
+      '--type',
+      'change',
+      '--strict',
+      '--json',
+      '--no-interactive',
+      '--no-color'
+    ]);
+    assert.deepEqual(result.json, { valid: true });
+  });
+
+  it('getOpenSpecStatus builds the expected args', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: '{"change":"add-oauth"}',
+      stderr: ''
+    });
+
+    const result = await getOpenSpecStatus('add-oauth', { executor });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls[0].args, [
+      'status',
+      '--change',
+      'add-oauth',
+      '--json',
+      '--no-color'
+    ]);
+  });
+
+  it('showOpenSpecItem supports type and deltasOnly args', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: '{}',
+      stderr: ''
+    });
+
+    await showOpenSpecItem('add-oauth', {
+      type: 'change',
+      deltasOnly: true,
+      executor
+    });
+
+    assert.deepEqual(calls[0].args, [
+      'show',
+      'add-oauth',
+      '--type',
+      'change',
+      '--deltas-only',
+      '--json',
+      '--no-interactive',
+      '--no-color'
+    ]);
+  });
+
+  it('getOpenSpecInstructions builds the expected args', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: '{}',
+      stderr: ''
+    });
+
+    await getOpenSpecInstructions('apply', {
+      change: 'add-oauth',
+      executor
+    });
+
+    assert.deepEqual(calls[0].args, [
+      'instructions',
+      'apply',
+      '--change',
+      'add-oauth',
+      '--json',
+      '--no-color'
+    ]);
+  });
+
+  it('archiveOpenSpecChange builds expected args and does not require JSON', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: 'archived add-oauth',
+      stderr: ''
+    });
+
+    const result = await archiveOpenSpecChange('add-oauth', {
+      skipSpecs: true,
+      executor
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.json, null);
+    assert.deepEqual(calls[0].args, [
+      'archive',
+      'add-oauth',
+      '--yes',
+      '--skip-specs',
+      '--no-color'
+    ]);
+  });
+
+  it('archiveOpenSpecChange supports noValidate', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: 'archived add-oauth',
+      stderr: ''
+    });
+
+    await archiveOpenSpecChange('add-oauth', {
+      noValidate: true,
+      executor
+    });
+
+    assert.deepEqual(calls[0].args, [
+      'archive',
+      'add-oauth',
+      '--yes',
+      '--no-validate',
+      '--no-color'
+    ]);
+  });
+});

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -103,6 +103,22 @@ describe('detectOpenSpec', () => {
     assert.equal(result.errors[0].code, 'unsupported-version');
   });
 
+  it('returns unsupported-version for prerelease 1.3.1-beta.1', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.3.1-beta.1', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, false);
+    assert.equal(result.canArchive, false);
+    assert.equal(result.version, '1.3.1-beta.1');
+    assert.equal(result.versionSupported, false);
+    assert.equal(result.nodeSupported, true);
+    assert.equal(result.reason, 'unsupported-version');
+    assert.equal(result.errors[0].code, 'unsupported-version');
+  });
+
   it('returns unsupported-node when injected Node version is below 20.19.0', async () => {
     const result = await detectOpenSpec({
       executor: async () => ({ exitCode: 0, stdout: '@fission-ai/openspec 1.3.1', stderr: '' }),


### PR DESCRIPTION
## Summary
- Add a shared OpenSpec runner module with capability detection, semver checks, normalized command execution, and degraded-mode handling
- Provide wrappers for validate, status, show, instructions, and archive commands with exact argument contracts
- Add deterministic tests for available, missing, unsupported version, unsupported Node, JSON parsing, and wrapper behavior
- Update OpenSpec compatibility docs to reflect the new runtime detection surface

## Testing
- Added unit coverage for detection, JSON parsing, error normalization, and wrapper argument construction
- Local validation passed, including repository checks and the full test suite

closed #38 