### PR TITLE
Add OpenSpec-native bootstrap mode guidance and compatibility docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ AI Factory-only mode follows the Node/runtime support of AI Factory and upstream
 
 OpenSpec can be initialized without tool integrations using `openspec init --tools none`, but this extension does not require running that during install.
 
+`/aif-analyze` supports an explicit OpenSpec-native bootstrap mode. Use it only when a project requests OpenSpec-native artifacts or already has `aifhub.artifactProtocol: openspec`; otherwise the legacy AI Factory-only config remains the default. In OpenSpec-native mode, canonical plan/change artifacts map to `openspec/changes`, specs map to `openspec/specs`, and runtime AI Factory output stays under `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`.
+
 See [OpenSpec Compatibility](docs/openspec-compatibility.md) for install/upgrade notes and the capability flags planned for runtime detection.
 
 ## Quick Start
@@ -70,7 +72,7 @@ Optional explicit AIFHub finalizer after passing verification:
 
 ## What This Extension Adds
 
-- `aif-analyze` remains extension-owned and bootstraps `.ai-factory/config.yaml` plus `rules/base.md`.
+- `aif-analyze` remains extension-owned and bootstraps `.ai-factory/config.yaml` plus `rules/base.md`; it can also prepare explicit OpenSpec-native config without installing OpenSpec skills.
 - `aif-done` is an explicit extension-owned AIFHub/Handoff finalizer that archives verified plans, drafts commit/PR summaries, and drives evidence-backed governance and evolution follow-ups.
 - `aif-plan`, `aif-explore`, `aif-improve`, `aif-implement`, `aif-verify`, `aif-fix`, `aif-roadmap`, and `aif-evolve` remain upstream skills with extension injections.
 - Full-mode plans use a dual artifact model:

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -18,6 +18,9 @@ Responsibilities:
 - create or update `.ai-factory/config.yaml`
 - create or update `.ai-factory/rules/base.md`
 - support migration and bootstrap compatibility
+- support explicit OpenSpec-native bootstrap when requested or when config already has `aifhub.artifactProtocol: openspec`
+
+In OpenSpec-native bootstrap mode, `aif-analyze` may set `paths.plans` to `openspec/changes`, `paths.specs` to `openspec/specs`, and runtime/generated paths to `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`. This changes where consumers resolve canonical plan/change and spec artifacts, but it does not install OpenSpec skills or make later OpenSpec-native workflow stages complete.
 
 Bootstrap lookup order follows `aif-analyze`: `.ai-factory/config.yaml`, then `AGENTS.md`, then `CLAUDE.md`, then `.ai-factory/RULES.md`. Legacy bridge files (`AGENTS.md`, `CLAUDE.md`) могут читаться только как migration inputs, если уже существуют, но extension не создаёт новые bridge files. Каноническими bootstrap-результатами остаются `.ai-factory/config.yaml` и `.ai-factory/rules/base.md`.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -2,7 +2,7 @@
 
 # OpenSpec Compatibility
 
-OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This page records the supported baseline, runtime detection surface, and expected degraded behavior; it does not implement OpenSpec-native artifacts or OpenSpec skill/command installation.
+OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This page records the supported baseline, bootstrap/config behavior, runtime detection surface, and expected degraded behavior; it does not implement later OpenSpec-native `/aif-plan`, verification, archive, migration, or OpenSpec skill/command installation.
 
 ## Supported Versions
 
@@ -22,6 +22,39 @@ openspec init --tools none
 ```
 
 The AIFHub extension does not require this command during install.
+
+## OpenSpec-Native Bootstrap Mode
+
+`/aif-analyze` supports an explicit OpenSpec-native bootstrap/config mode. The mode is selected only when the user asks for `openspec-native` or when existing config already has:
+
+```yaml
+aifhub:
+  artifactProtocol: openspec
+```
+
+In that mode, `.ai-factory/config.yaml` can include:
+
+```yaml
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    root: openspec
+    installSkills: false
+    validateOnPlan: true
+    validateOnVerify: true
+    archiveOnDone: true
+
+paths:
+  plans: openspec/changes
+  specs: openspec/specs
+  state: .ai-factory/state
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated
+```
+
+OpenSpec-native bootstrap verifies or creates `openspec/config.yaml`, `openspec/specs/`, `openspec/changes/`, `.ai-factory/state/`, `.ai-factory/qa/`, and `.ai-factory/rules/generated/`. If a compatible OpenSpec CLI is present, the skill may use or recommend `openspec init --tools none`; if the CLI is missing or unsupported, bootstrap continues with manual skeleton behavior and degraded capability flags.
+
+OpenSpec skills and slash commands are not installed by this extension.
 
 ## Install And Upgrade Notes
 
@@ -53,4 +86,4 @@ openspec:
   versionSupported: boolean
 ```
 
-The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap, planning, verification, archive integration, migration, generated rules, and prompt rewrites remain separate follow-up work.
+The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap consumes this capability shape; planning, verification, archive integration, migration, generated rules, and broader prompt rewrites remain separate follow-up work.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 
 | Skill | Type | Purpose |
 |-------|------|---------|
-| `/aif-analyze` | Extension skill | Bootstrap `.ai-factory/config.yaml` and `rules/base.md` |
+| `/aif-analyze` | Extension skill | Bootstrap `.ai-factory/config.yaml` and `rules/base.md`; explicit OpenSpec-native config is supported |
 | `/aif-rules-check` | Extension skill (temporary gate) | Read-only rule compliance check against rules hierarchy |
 | `/aif-explore` | Built-in + injection | Explore ideas and persist only `.ai-factory/RESEARCH.md` |
 | `/aif-plan` | Built-in + injection | Create the companion plan file + plan folder pair |
@@ -135,6 +135,16 @@ Notes:
 Creates or updates:
 - `.ai-factory/config.yaml`
 - `.ai-factory/rules/base.md`
+
+For OpenSpec-native bootstrap, explicitly request `openspec-native` or start from a config that already contains `aifhub.artifactProtocol: openspec`. The skill then completes the OpenSpec-native config shape, maps canonical changes to `openspec/changes`, maps specs to `openspec/specs`, prepares `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`, and reports OpenSpec CLI capabilities through `scripts/openspec-runner.mjs` when available. Missing OpenSpec CLI remains degraded mode, not bootstrap failure.
+
+Compatible OpenSpec CLI environments may use or receive this recommendation:
+
+```bash
+openspec init --tools none
+```
+
+The extension does not install OpenSpec skills or slash commands.
 
 `/aif-analyze` завершает bootstrap. После него canonical public workflow начинается с `/aif-explore` или сразу с `/aif-plan full`.
 

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -1,0 +1,97 @@
+// aif-analyze-openspec-bootstrap.test.mjs - instruction-level OpenSpec bootstrap contract tests
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+async function readRepoFile(relativePath) {
+  return readFile(join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function assertIncludes(source, expected, filePath) {
+  assert.ok(
+    source.includes(expected),
+    `${filePath} should include ${JSON.stringify(expected)}`
+  );
+}
+
+describe('aif-analyze OpenSpec-native bootstrap contract', () => {
+  it('documents explicit mode selection and preserves legacy default config', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+    const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
+
+    assertIncludes(skill, '### Step 2.5: Resolve Bootstrap Mode', 'skills/aif-analyze/SKILL.md');
+    assertIncludes(skill, 'Use `openspec-native` mode when the user explicitly asks', 'skills/aif-analyze/SKILL.md');
+    assertIncludes(skill, 'aifhub.artifactProtocol: openspec', 'skills/aif-analyze/SKILL.md');
+    assertIncludes(skill, 'Do not silently migrate a legacy AI Factory-only project', 'skills/aif-analyze/SKILL.md');
+    assertIncludes(template, 'artifactProtocol: ai-factory', 'skills/aif-analyze/references/config-template.yaml');
+  });
+
+  it('defines the OpenSpec-native config shape and canonical runtime paths', async () => {
+    const combined = [
+      await readRepoFile('skills/aif-analyze/SKILL.md'),
+      await readRepoFile('skills/aif-analyze/references/config-template.yaml')
+    ].join('\n');
+
+    for (const expected of [
+      'artifactProtocol: openspec',
+      'root: openspec',
+      'installSkills: false',
+      'validateOnPlan: true',
+      'validateOnVerify: true',
+      'archiveOnDone: true',
+      'openspec/changes',
+      'openspec/specs',
+      '.ai-factory/state',
+      '.ai-factory/qa',
+      '.ai-factory/rules/generated'
+    ]) {
+      assertIncludes(combined, expected, 'aif-analyze OpenSpec bootstrap artifacts');
+    }
+  });
+
+  it('requires detectOpenSpec capability reporting and degraded missing-CLI behavior', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+
+    for (const expected of [
+      'detectOpenSpec()',
+      'scripts/openspec-runner.mjs',
+      'available: boolean',
+      'canValidate: boolean',
+      'canArchive: boolean',
+      'version: string | null',
+      'supportedRange: ">=1.3.1 <2.0.0"',
+      'requiresNode: ">=20.19.0"',
+      'nodeSupported: boolean',
+      'versionSupported: boolean',
+      'Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure'
+    ]) {
+      assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md');
+    }
+  });
+
+  it('documents compatible CLI initialization, manual skeletons, and no skill installation', async () => {
+    const combined = [
+      await readRepoFile('skills/aif-analyze/SKILL.md'),
+      await readRepoFile('docs/openspec-compatibility.md'),
+      await readRepoFile('docs/usage.md')
+    ].join('\n');
+
+    for (const expected of [
+      'openspec init --tools none',
+      'openspec/config.yaml',
+      'openspec/specs/',
+      'openspec/changes/',
+      '.ai-factory/state/',
+      '.ai-factory/qa/',
+      '.ai-factory/rules/generated/',
+      'OpenSpec skills and slash commands are not installed by this extension'
+    ]) {
+      assertIncludes(combined, expected, 'OpenSpec bootstrap docs');
+    }
+  });
+});

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -104,13 +104,87 @@ Do not rewrite or delete those folders automatically in this skill.
 - Prefer direct evidence from manifests, source layout, config files, and project docs.
 - Note the tech stack for rules/base.md generation.
 
+### Step 2.5: Resolve Bootstrap Mode
+
+Resolve the bootstrap/config mode before creating directories:
+
+- Use `openspec-native` mode when the user explicitly asks for `openspec-native`, `OpenSpec-native`, or OpenSpec artifact protocol bootstrap.
+- Use `openspec-native` mode when an existing `.ai-factory/config.yaml` has `aifhub.artifactProtocol: openspec`.
+- Otherwise use legacy `ai-factory` mode.
+- Do not silently migrate a legacy AI Factory-only project to OpenSpec-native mode.
+- Preserve existing config values. Add only missing keys required by the resolved mode.
+- Record the resolved mode for the final handoff.
+
 ### Step 3: Create or Update config.yaml
 
 - If config.yaml is missing, create it with v1 schema.
 - If config.yaml exists, preserve existing values and add missing fields.
-- Keep schema consistent with nested sections: `language`, `paths`, `rules`, `workflow`.
+- Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `rules`, `workflow`.
+- In legacy `ai-factory` mode:
+  - Preserve the existing AI Factory-only path defaults.
+  - Keep `paths.plans` at `.ai-factory/plans` unless an existing value says otherwise.
+  - Keep `paths.specs` at `.ai-factory/specs` unless an existing value says otherwise.
+- In `openspec-native` mode:
+  - Ensure this config shape is present:
+
+```yaml
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    root: openspec
+    installSkills: false
+    validateOnPlan: true
+    validateOnVerify: true
+    archiveOnDone: true
+```
+
+  - Ensure canonical artifact paths are set or completed:
+
+```yaml
+paths:
+  plans: openspec/changes
+  specs: openspec/specs
+  state: .ai-factory/state
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated
+```
+
+  - Preserve `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.research`, and `paths.rules` unless they are missing.
+  - Do not install OpenSpec skills, slash commands, or dependencies.
 
 Use [references/config-template.yaml](references/config-template.yaml) as reference.
+
+### Step 3.5: Detect OpenSpec Capabilities
+
+Run this step only in `openspec-native` mode, after config mode is resolved and before directory creation.
+
+- If `scripts/openspec-runner.mjs` exists, use `detectOpenSpec()` from that file.
+- In Node-capable runtimes, a valid detection command is:
+
+```bash
+node --input-type=module -e "import { detectOpenSpec } from './scripts/openspec-runner.mjs'; console.log(JSON.stringify(await detectOpenSpec(), null, 2));"
+```
+
+- Report capability fields equivalent to:
+
+```yaml
+openspec:
+  available: boolean
+  canValidate: boolean
+  canArchive: boolean
+  version: string | null
+  supportedRange: ">=1.3.1 <2.0.0"
+  requiresNode: ">=20.19.0"
+  nodeSupported: boolean
+  versionSupported: boolean
+```
+
+- The runner may also return `nodeVersion`, `command`, `reason`, and `errors`; include those when useful for troubleshooting.
+- Do not print raw command output unless troubleshooting requires it.
+- If the OpenSpec CLI is compatible, prefer or recommend `openspec init --tools none`.
+- If the OpenSpec CLI is missing or unsupported, continue bootstrap with `canValidate: false` and `canArchive: false`.
+- Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure.
+- If `scripts/openspec-runner.mjs` is missing, report that capability detection is unavailable and continue with degraded capability values.
 
 ### Step 4: Create rules/base.md
 
@@ -129,10 +203,28 @@ Use [references/config-template.yaml](references/config-template.yaml) as refere
 
 ### Step 5: Ensure Directories Exist
 
-- Create directories from config paths if missing:
+- In legacy `ai-factory` mode, create directories from config paths if missing:
   - `paths.plans` (typically `.ai-factory/plans`)
   - `paths.specs` (typically `.ai-factory/specs`)
   - `paths.rules` (typically `.ai-factory/rules`)
+- In `openspec-native` mode:
+  - If compatible OpenSpec CLI capabilities are available, prefer or recommend:
+
+```bash
+openspec init --tools none
+```
+
+  - Verify or create the OpenSpec skeleton without installing tool integrations:
+    - `openspec/config.yaml`
+    - `openspec/specs/`
+    - `openspec/changes/`
+  - Preserve an existing `openspec/config.yaml`; do not overwrite it.
+  - Verify or create runtime/generated AI Factory directories:
+    - `.ai-factory/state/`
+    - `.ai-factory/qa/`
+    - `.ai-factory/rules/generated/`
+  - Do not install OpenSpec skills or slash commands.
+  - Record created versus preserved skeleton paths for the final handoff.
 
 ### Step 6: Check DESCRIPTION and Guide Core Skills
 
@@ -146,6 +238,10 @@ Use [references/config-template.yaml](references/config-template.yaml) as refere
 
 - Use the saved scope plus preferred language for the reply.
 - Mention created/updated files: `config.yaml`, `rules/base.md`, and artifact status (`DESCRIPTION.md`, `ARCHITECTURE.md`, `ROADMAP.md`).
+- Report the resolved bootstrap mode.
+- Report whether config values were created or preserved.
+- Report the active path set.
+- In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.
 - Report what was invoked automatically versus what remains as manual next command.
 - If DESCRIPTION is missing, first recommended command must be `/aif`.
 - После bootstrap описывай текущий public workflow как начинающийся с `/aif-explore` или `/aif-plan full`, а не с `/aif-new`.
@@ -161,6 +257,15 @@ language:
   artifacts: russian             # Generated artifacts language
   technical_terms: english       # Technical terms (always english)
 
+aifhub:
+  artifactProtocol: ai-factory   # ai-factory | openspec
+  openspec:
+    root: openspec
+    installSkills: false
+    validateOnPlan: true
+    validateOnVerify: true
+    archiveOnDone: true
+
 paths:
   description: .ai-factory/DESCRIPTION.md
   architecture: .ai-factory/ARCHITECTURE.md
@@ -169,6 +274,13 @@ paths:
   plans: .ai-factory/plans
   specs: .ai-factory/specs
   rules: .ai-factory/rules
+  state: .ai-factory/state
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated
+
+# OpenSpec-native path profile:
+# paths.plans: openspec/changes
+# paths.specs: openspec/specs
 
 workflow:
   auto_create_dirs: true
@@ -188,6 +300,10 @@ agent_profile: default
 
 - Use evidence over assumptions.
 - Create/update `config.yaml` and `rules/base.md` first.
+- Use OpenSpec-native mode only when explicitly requested or when existing config has `aifhub.artifactProtocol: openspec`.
+- In OpenSpec-native mode, use `detectOpenSpec()` from `scripts/openspec-runner.mjs` when available and treat missing or unsupported CLI as degraded capability, not failure.
+- In OpenSpec-native mode, use or recommend `openspec init --tools none` only for compatible CLI environments.
+- Never install OpenSpec skills, slash commands, dependencies, or manifest entries.
 - Never generate DESCRIPTION directly in this skill.
 - If DESCRIPTION is missing, suggest `/aif` first.
 - Follow workflow flags to suggest or initiate `/aif-architecture` and `/aif-roadmap`.

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -15,6 +15,24 @@ language:
   technical_terms: english
 
 # ============================================================================
+# AIFHUB ARTIFACT PROTOCOL
+# ============================================================================
+# Legacy default is AI Factory-only. Use artifactProtocol: openspec only when
+# the user explicitly requests OpenSpec-native mode or existing config already
+# uses aifhub.artifactProtocol: openspec.
+aifhub:
+  # ai-factory | openspec
+  artifactProtocol: ai-factory
+  # OpenSpec-native settings. Keep installSkills false; this extension never
+  # installs OpenSpec skills or slash commands.
+  openspec:
+    root: openspec
+    installSkills: false
+    validateOnPlan: true
+    validateOnVerify: true
+    archiveOnDone: true
+
+# ============================================================================
 # PATH CONFIGURATION
 # ============================================================================
 # All paths are relative to project root
@@ -28,6 +46,15 @@ paths:
   # Workflow directories
   plans: .ai-factory/plans
   specs: .ai-factory/specs
+
+  # Runtime/generated directories used by OpenSpec-native mode
+  state: .ai-factory/state
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated
+
+  # OpenSpec-native path profile when aifhub.artifactProtocol: openspec:
+  # plans: openspec/changes
+  # specs: openspec/specs
   
   # Rules directory (base.md required, area files optional)
   rules: .ai-factory/rules


### PR DESCRIPTION
## Summary
- Document OpenSpec-native bootstrap mode and the updated context-loading policy
- Clarify compatibility expectations and usage guidance across README and docs
- Add coverage for the aif-analyze bootstrap flow and refresh the related skill reference template

## Testing
- Added/updated automated test coverage for the bootstrap flow
- Not run (not requested)

closed #27 