### PR TITLE
Add active change resolver and runtime state layout

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ OpenSpec compatibility is tracked as optional adapter metadata, not as a hard ex
 | [Handoff Naming](handoff.md) | Stage vocabulary versus current public commands and future mapping constraints |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context contract, ownership boundaries, and artifact rules |
 | [OpenSpec Compatibility](openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
+| [Active Change Resolver](active-change-resolver.md) | Shared active OpenSpec change selection, runtime paths, pointer behavior, and ambiguity diagnostics |
 | [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) | v1 source-of-truth contract for OpenSpec canonical artifacts and AI Factory runtime state |
 
 ## Recommended Reading Order
@@ -35,7 +36,8 @@ OpenSpec compatibility is tracked as optional adapter metadata, not as a hard ex
 3. Read [Handoff Naming](handoff.md) for current manual stages versus future mapping.
 4. Read [Context Loading Policy](context-loading-policy.md) for ownership and runtime path rules.
 5. Read [OpenSpec Compatibility](openspec-compatibility.md) for optional OpenSpec CLI adapter policy and degraded-mode behavior.
-6. Read [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership contract.
+6. Read [Active Change Resolver](active-change-resolver.md) for shared change selection and runtime state paths.
+7. Read [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership contract.
 
 ## Scope
 
@@ -56,5 +58,6 @@ Project-level AI Factory planning and archived specs remain under `.ai-factory/`
 - [Handoff Naming](handoff.md) - current manual stages and future stage-agent mapping constraints
 - [Context Loading Policy](context-loading-policy.md) - context-loading and ownership rules
 - [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter policy and future capability flags
+- [Active Change Resolver](active-change-resolver.md) - active change selection and runtime state layout
 - [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) - canonical OpenSpec artifacts and runtime AI Factory state
 - [Project README](../README.md) - landing page and quick start

--- a/docs/active-change-resolver.md
+++ b/docs/active-change-resolver.md
@@ -1,0 +1,114 @@
+[Back to Documentation](README.md)
+
+# Active Change Resolver
+
+`scripts/active-change-resolver.mjs` provides the shared dependency-free resolver for OpenSpec-native runtime flows. It selects one active change, returns machine-readable diagnostics, and computes AI Factory runtime paths without writing to canonical OpenSpec artifacts.
+
+## Precedence
+
+Resolution uses this order:
+
+1. Explicit `changeId`.
+2. Current working directory under `openspec/changes/<change-id>/`.
+3. Current git branch mapped to an existing active change.
+4. `.ai-factory/state/current.yaml`.
+5. A single active change under `openspec/changes/`.
+6. A structured failure with candidates when no unique change can be selected.
+
+Explicit IDs are authoritative. An invalid or missing explicit ID returns `invalid-change-id` or `explicit-change-not-found` and does not fall back to another source.
+
+Archived changes under `openspec/changes/archive/`, hidden directories, files, and unmarked directories are not active changes.
+
+## Result Shape
+
+Resolver results are stable objects:
+
+```js
+{
+  ok: true,
+  changeId: 'add-oauth',
+  source: 'explicit',
+  changePath: '/repo/openspec/changes/add-oauth',
+  statePath: '/repo/.ai-factory/state/add-oauth',
+  qaPath: '/repo/.ai-factory/qa/add-oauth',
+  candidates: ['add-oauth'],
+  warnings: [],
+  errors: []
+}
+```
+
+Failures keep the same top-level fields and set `ok: false`, `changeId: null`, `changePath: null`, `statePath: null`, and `qaPath: null`. Diagnostic entries always include stable `code` and `message` fields.
+
+Common failure codes:
+
+| Code | Meaning |
+|---|---|
+| `invalid-change-id` | The supplied ID is empty, absolute, contains path separators, contains `..`, or contains characters outside letters, numbers, `.`, `_`, and `-`. |
+| `explicit-change-not-found` | The explicit ID is safe but no matching active change directory exists. |
+| `ambiguous-branch-change` | The current branch maps to more than one active change. |
+| `current-pointer-not-found` | The current pointer references a missing or inactive change. |
+| `ambiguous-active-change` | More than one active change exists and no higher-precedence source selected one. |
+| `no-active-change` | No active change could be resolved. |
+| `filesystem-error` | The resolver could not inspect active change directories. |
+
+## Runtime Paths
+
+Runtime state is outside canonical OpenSpec changes:
+
+```text
+.ai-factory/state/<change-id>/
+.ai-factory/qa/<change-id>/
+.ai-factory/state/current.yaml
+```
+
+`resolveActiveChange()` computes `statePath` and `qaPath` on success but does not create directories. Use `ensureRuntimeLayout(changeId, options)` to create runtime directories. That helper returns absolute `statePath` and `qaPath` plus relative `created` and `preserved` arrays.
+
+The helper never creates `.ai-factory/plans/<change-id>` and never writes under `openspec/changes/<change-id>/`.
+
+## Current Pointer
+
+The pointer file is `.ai-factory/state/current.yaml` by default. The resolver reads these YAML keys:
+
+```yaml
+change_id: add-oauth
+changeId: add-oauth
+active_change: add-oauth
+activeChange: add-oauth
+```
+
+It also accepts equivalent JSON with one of those keys. `writeCurrentChangePointer()` writes the canonical YAML form:
+
+```yaml
+change_id: add-oauth
+```
+
+A stale pointer is an error and blocks fallback, so broken runtime state is visible instead of silently selecting another change.
+
+## Branch Mapping
+
+Branch mapping only selects existing active changes. For a branch such as `feat/add-oauth`, the resolver checks these variants against active change IDs:
+
+- `feat/add-oauth`
+- `add-oauth`
+- `feat-add-oauth`
+
+If exactly one variant matches, the source is `branch`. If multiple variants match, resolution fails with `ambiguous-branch-change`.
+
+## Configuration
+
+The resolver reads simple scalar path keys from `.ai-factory/config.yaml`:
+
+```yaml
+paths:
+  plans: openspec/changes
+  specs: openspec/specs
+  state: .ai-factory/state
+  qa: .ai-factory/qa
+```
+
+`paths.plans` maps to the OpenSpec changes directory only when it points at `openspec/changes`. Legacy `.ai-factory/plans` values are ignored for active OpenSpec change resolution.
+
+## See Also
+
+- [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md)
+- [OpenSpec Compatibility](openspec-compatibility.md)

--- a/scripts/active-change-resolver.mjs
+++ b/scripts/active-change-resolver.mjs
@@ -60,7 +60,7 @@ async function listActiveOpenSpecChangesWithDiagnostics(context) {
     const fallbackChangeIds = [];
 
     for (const entry of entries) {
-      if (!entry.isDirectory() || entry.name === 'archive' || entry.name.startsWith('.')) {
+      if (!entry.isDirectory() || !isSelectableChangeId(entry.name)) {
         continue;
       }
 
@@ -107,6 +107,10 @@ export async function ensureRuntimeLayout(changeId, options = {}) {
 
   for (const dirPath of [statePath, qaPath]) {
     if (await pathExists(dirPath)) {
+      if (!await isDirectory(dirPath)) {
+        throw new Error(`Runtime layout path exists but is not a directory: ${dirPath}`);
+      }
+
       preserved.push(path.relative(context.rootDir, dirPath));
       continue;
     }
@@ -206,7 +210,7 @@ async function resolveExplicitChange(input, context) {
   const changeId = normalized.changeId;
   const changePath = path.join(context.changesDir, changeId);
 
-  if (!await isDirectory(changePath)) {
+  if (!isSelectableChangeId(changeId) || !await isDirectory(changePath)) {
     const listed = await listActiveOpenSpecChangesWithDiagnostics(context);
 
     return createFailureResult({
@@ -523,6 +527,12 @@ function invalidChangeId(input) {
       message: `Invalid OpenSpec change id: ${JSON.stringify(input)}.`
     }
   };
+}
+
+function isSelectableChangeId(changeId) {
+  return normalizeChangeId(changeId).ok
+    && changeId !== 'archive'
+    && !changeId.startsWith('.');
 }
 
 async function hasActiveChangeMarker(changePath) {

--- a/scripts/active-change-resolver.mjs
+++ b/scripts/active-change-resolver.mjs
@@ -1,0 +1,600 @@
+// active-change-resolver.mjs - shared active OpenSpec change resolution utilities
+import { execFile } from 'node:child_process';
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_PATHS = {
+  changes: path.join('openspec', 'changes'),
+  specs: path.join('openspec', 'specs'),
+  state: path.join('.ai-factory', 'state'),
+  qa: path.join('.ai-factory', 'qa'),
+  currentPointer: path.join('.ai-factory', 'state', 'current.yaml')
+};
+
+const ACTIVE_CHANGE_MARKERS = ['proposal.md', 'design.md', 'tasks.md', 'specs'];
+const CURRENT_POINTER_KEYS = ['change_id', 'changeId', 'active_change', 'activeChange'];
+
+export async function resolveActiveChange(options = {}) {
+  const context = await createResolverContext(options);
+
+  if (options.changeId !== undefined && options.changeId !== null && String(options.changeId).length > 0) {
+    return resolveExplicitChange(options.changeId, context);
+  }
+
+  const cwdResult = await resolveCwdChange(context);
+
+  if (cwdResult !== null) {
+    return cwdResult;
+  }
+
+  const listed = await listActiveOpenSpecChangesWithDiagnostics(context);
+  const branchResult = await resolveBranchChange(context, listed.changeIds, listed.warnings);
+
+  if (branchResult !== null) {
+    return branchResult;
+  }
+
+  const pointerResult = await resolveCurrentPointer(context, listed.changeIds, listed.warnings);
+
+  if (pointerResult !== null) {
+    return pointerResult;
+  }
+
+  return resolveSingleActiveChange(context, listed.changeIds, listed.warnings);
+}
+
+export async function listActiveOpenSpecChanges(options = {}) {
+  const context = await createResolverContext(options);
+  const { changeIds } = await listActiveOpenSpecChangesWithDiagnostics(context);
+  return changeIds;
+}
+
+async function listActiveOpenSpecChangesWithDiagnostics(context) {
+  try {
+    const entries = await readdir(context.changesDir, { withFileTypes: true });
+    const markedChangeIds = [];
+    const fallbackChangeIds = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === 'archive' || entry.name.startsWith('.')) {
+        continue;
+      }
+
+      if (await hasActiveChangeMarker(path.join(context.changesDir, entry.name))) {
+        markedChangeIds.push(entry.name);
+      } else {
+        fallbackChangeIds.push(entry.name);
+      }
+    }
+
+    const changeIds = markedChangeIds.length > 0 ? markedChangeIds : fallbackChangeIds;
+
+    return {
+      changeIds: changeIds.sort((left, right) => left.localeCompare(right)),
+      warnings: []
+    };
+  } catch (err) {
+    return {
+      changeIds: [],
+      warnings: [
+        {
+          code: 'filesystem-error',
+          message: `Unable to list active OpenSpec changes in '${context.changesDir}'.`,
+          path: context.changesDir,
+          detail: err?.message ?? 'Unknown filesystem error.'
+        }
+      ]
+    };
+  }
+}
+
+export async function ensureRuntimeLayout(changeId, options = {}) {
+  const context = await createResolverContext(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error.message);
+  }
+
+  const statePath = path.join(context.stateDir, normalized.changeId);
+  const qaPath = path.join(context.qaDir, normalized.changeId);
+  const created = [];
+  const preserved = [];
+
+  for (const dirPath of [statePath, qaPath]) {
+    if (await pathExists(dirPath)) {
+      preserved.push(path.relative(context.rootDir, dirPath));
+      continue;
+    }
+
+    await mkdir(dirPath, { recursive: true });
+    created.push(path.relative(context.rootDir, dirPath));
+  }
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    statePath,
+    qaPath,
+    created,
+    preserved
+  };
+}
+
+export async function readCurrentChangePointer(options = {}) {
+  const context = await createResolverContext(options);
+
+  try {
+    const raw = await readFile(context.currentPointerPath, 'utf8');
+    return parseCurrentPointer(raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCurrentChangePointer(changeId, options = {}) {
+  const context = await createResolverContext(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error.message);
+  }
+
+  await mkdir(path.dirname(context.currentPointerPath), { recursive: true });
+  await writeFile(context.currentPointerPath, `change_id: ${normalized.changeId}\n`, 'utf8');
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    pointerPath: context.currentPointerPath
+  };
+}
+
+export function mapBranchToChangeCandidates(branchName, openChangeIds) {
+  const branch = String(branchName ?? '').trim();
+
+  if (branch.length === 0) {
+    return [];
+  }
+
+  const variants = createBranchVariants(branch);
+  return Array.from(new Set(openChangeIds.filter((changeId) => variants.has(changeId))))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function normalizeChangeId(input) {
+  if (typeof input !== 'string') {
+    return invalidChangeId(input);
+  }
+
+  const changeId = input.trim();
+
+  if (
+    changeId.length === 0
+    || path.isAbsolute(changeId)
+    || changeId.includes('/')
+    || changeId.includes('\\')
+    || changeId === '..'
+    || changeId.includes('..')
+    || !/^[A-Za-z0-9._-]+$/.test(changeId)
+  ) {
+    return invalidChangeId(input);
+  }
+
+  return {
+    ok: true,
+    changeId,
+    error: null
+  };
+}
+
+async function resolveExplicitChange(input, context) {
+  const normalized = normalizeChangeId(input);
+
+  if (!normalized.ok) {
+    return createFailureResult({
+      source: 'explicit',
+      candidates: [],
+      error: normalized.error
+    });
+  }
+
+  const changeId = normalized.changeId;
+  const changePath = path.join(context.changesDir, changeId);
+
+  if (!await isDirectory(changePath)) {
+    const listed = await listActiveOpenSpecChangesWithDiagnostics(context);
+
+    return createFailureResult({
+      source: 'explicit',
+      candidates: listed.changeIds,
+      warnings: listed.warnings,
+      error: {
+        code: 'explicit-change-not-found',
+        message: `OpenSpec change '${changeId}' was not found.`
+      }
+    });
+  }
+
+  return createSuccessResult({
+    changeId,
+    source: 'explicit',
+    changePath,
+    context,
+    candidates: [changeId]
+  });
+}
+
+async function resolveCwdChange(context) {
+  const relativeCwd = path.relative(context.changesDir, context.cwd);
+
+  if (
+    relativeCwd.length === 0
+    || relativeCwd.startsWith('..')
+    || path.isAbsolute(relativeCwd)
+  ) {
+    return null;
+  }
+
+  const [candidate] = relativeCwd.split(/[\\/]+/).filter(Boolean);
+
+  if (candidate === undefined || candidate === 'archive' || candidate.startsWith('.')) {
+    return null;
+  }
+
+  const normalized = normalizeChangeId(candidate);
+
+  if (!normalized.ok) {
+    return null;
+  }
+
+  const changeId = normalized.changeId;
+  const changePath = path.join(context.changesDir, changeId);
+
+  if (!await isDirectory(changePath)) {
+    return null;
+  }
+
+  return createSuccessResult({
+    changeId,
+    source: 'cwd',
+    changePath,
+    context,
+    candidates: [changeId]
+  });
+}
+
+async function resolveBranchChange(context, openChangeIds, inheritedWarnings = []) {
+  let branchName;
+
+  try {
+    branchName = await context.getCurrentBranch({ cwd: context.rootDir });
+  } catch (err) {
+    return nullWithWarning(inheritedWarnings, {
+      code: 'git-branch-detection-failed',
+      message: 'Unable to detect the current git branch.',
+      detail: err?.message ?? 'Unknown git branch detection error.'
+    });
+  }
+
+  if (typeof branchName !== 'string' || branchName.trim().length === 0) {
+    return null;
+  }
+
+  const candidates = mapBranchToChangeCandidates(branchName, openChangeIds);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  if (candidates.length > 1) {
+    return createFailureResult({
+      source: 'branch',
+      candidates,
+      warnings: inheritedWarnings,
+      error: {
+        code: 'ambiguous-branch-change',
+        message: `Git branch '${branchName}' maps to multiple active OpenSpec changes.`,
+        branch: branchName
+      }
+    });
+  }
+
+  const changeId = candidates[0];
+
+  return createSuccessResult({
+    changeId,
+    source: 'branch',
+    changePath: path.join(context.changesDir, changeId),
+    context,
+    candidates,
+    warnings: inheritedWarnings
+  });
+}
+
+async function resolveCurrentPointer(context, openChangeIds, inheritedWarnings = []) {
+  const pointer = await readCurrentChangePointer(context);
+
+  if (pointer === null) {
+    return null;
+  }
+
+  const normalized = normalizeChangeId(pointer);
+
+  if (!normalized.ok) {
+    return createFailureResult({
+      source: 'current-pointer',
+      candidates: openChangeIds,
+      warnings: inheritedWarnings,
+      error: {
+        code: 'current-pointer-invalid',
+        message: `Current change pointer '${pointer}' is not a safe OpenSpec change id.`
+      }
+    });
+  }
+
+  const changeId = normalized.changeId;
+  const changePath = path.join(context.changesDir, changeId);
+
+  if (!openChangeIds.includes(changeId) || !await isDirectory(changePath)) {
+    return createFailureResult({
+      source: 'current-pointer',
+      candidates: openChangeIds,
+      warnings: inheritedWarnings,
+      error: {
+        code: 'current-pointer-not-found',
+        message: `Current change pointer '${changeId}' does not reference an active OpenSpec change.`,
+        pointer: changeId
+      }
+    });
+  }
+
+  return createSuccessResult({
+    changeId,
+    source: 'current-pointer',
+    changePath,
+    context,
+    candidates: [changeId],
+    warnings: inheritedWarnings
+  });
+}
+
+function resolveSingleActiveChange(context, openChangeIds, inheritedWarnings = []) {
+  if (openChangeIds.length === 1) {
+    const changeId = openChangeIds[0];
+
+    return createSuccessResult({
+      changeId,
+      source: 'single-active-change',
+      changePath: path.join(context.changesDir, changeId),
+      context,
+      candidates: [changeId],
+      warnings: inheritedWarnings
+    });
+  }
+
+  if (openChangeIds.length > 1) {
+    return createFailureResult({
+      source: null,
+      candidates: openChangeIds,
+      warnings: inheritedWarnings,
+      error: {
+        code: 'ambiguous-active-change',
+        message: 'Multiple active OpenSpec changes are available; provide an explicit change id.'
+      }
+    });
+  }
+
+  return createFailureResult({
+    source: null,
+    candidates: [],
+    warnings: inheritedWarnings,
+    error: {
+      code: 'no-active-change',
+      message: 'No active OpenSpec change could be resolved.'
+    }
+  });
+}
+
+function nullWithWarning(inheritedWarnings, warning) {
+  inheritedWarnings.push(warning);
+  return null;
+}
+
+async function createResolverContext(options = {}) {
+  if (options.changesDir !== undefined && options.stateDir !== undefined && options.qaDir !== undefined) {
+    return options;
+  }
+
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const config = await readProjectConfig(rootDir);
+  const specsPath = config.paths.specs ?? DEFAULT_PATHS.specs;
+  const statePath = config.paths.state ?? DEFAULT_PATHS.state;
+  const qaPath = config.paths.qa ?? DEFAULT_PATHS.qa;
+  const configuredPlansPath = normalizePathSeparators(config.paths.plans);
+  const changesPath = configuredPlansPath === DEFAULT_PATHS.changes
+    ? config.paths.plans
+    : DEFAULT_PATHS.changes;
+  const stateDir = resolveFromRoot(rootDir, options.stateDir ?? statePath);
+
+  return {
+    rootDir,
+    cwd: path.resolve(options.cwd ?? process.cwd()),
+    changesDir: resolveFromRoot(rootDir, options.changesDir ?? changesPath),
+    specsDir: resolveFromRoot(rootDir, options.specsDir ?? specsPath),
+    stateDir,
+    qaDir: resolveFromRoot(rootDir, options.qaDir ?? qaPath),
+    currentPointerPath: resolveFromRoot(
+      rootDir,
+      options.currentPointerPath ?? path.join(path.relative(rootDir, stateDir), 'current.yaml')
+    ),
+    getCurrentBranch: options.getCurrentBranch ?? getCurrentBranch
+  };
+}
+
+async function readProjectConfig(rootDir) {
+  try {
+    const raw = await readFile(path.join(rootDir, '.ai-factory', 'config.yaml'), 'utf8');
+    return {
+      paths: parseSimplePathsConfig(raw)
+    };
+  } catch {
+    return {
+      paths: {}
+    };
+  }
+}
+
+function parseSimplePathsConfig(raw) {
+  const paths = {};
+  const lines = raw.split(/\r?\n/);
+  let inPaths = false;
+
+  for (const line of lines) {
+    if (/^paths:\s*$/.test(line)) {
+      inPaths = true;
+      continue;
+    }
+
+    if (inPaths && /^\S/.test(line)) {
+      inPaths = false;
+    }
+
+    if (!inPaths) {
+      continue;
+    }
+
+    const match = line.match(/^\s{2}([A-Za-z0-9_-]+):\s*["']?([^"'\r\n#]+?)["']?\s*(?:#.*)?$/);
+
+    if (match) {
+      paths[match[1]] = match[2].trim();
+    }
+  }
+
+  return paths;
+}
+
+function resolveFromRoot(rootDir, value) {
+  return path.resolve(rootDir, value);
+}
+
+function normalizePathSeparators(value) {
+  return String(value ?? '').replaceAll('\\', '/');
+}
+
+function createSuccessResult({ changeId, source, changePath, context, candidates, warnings = [] }) {
+  return {
+    ok: true,
+    changeId,
+    source,
+    changePath,
+    statePath: path.join(context.stateDir, changeId),
+    qaPath: path.join(context.qaDir, changeId),
+    candidates,
+    warnings,
+    errors: []
+  };
+}
+
+function createFailureResult({ source, candidates, error, warnings = [] }) {
+  return {
+    ok: false,
+    changeId: null,
+    source,
+    changePath: null,
+    statePath: null,
+    qaPath: null,
+    candidates,
+    warnings,
+    errors: [error]
+  };
+}
+
+function invalidChangeId(input) {
+  return {
+    ok: false,
+    changeId: null,
+    error: {
+      code: 'invalid-change-id',
+      message: `Invalid OpenSpec change id: ${JSON.stringify(input)}.`
+    }
+  };
+}
+
+async function hasActiveChangeMarker(changePath) {
+  for (const marker of ACTIVE_CHANGE_MARKERS) {
+    if (await pathExists(path.join(changePath, marker))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(targetPath) {
+  try {
+    const item = await stat(targetPath);
+    return item.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function parseCurrentPointer(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    for (const key of CURRENT_POINTER_KEYS) {
+      if (typeof parsed?.[key] === 'string') {
+        return parsed[key];
+      }
+    }
+  } catch {
+    // YAML fallback below.
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*):\s*["']?([^"'\r\n#]+?)["']?\s*(?:#.*)?$/);
+
+    if (match && CURRENT_POINTER_KEYS.includes(match[1])) {
+      return match[2].trim();
+    }
+  }
+
+  return null;
+}
+
+function createBranchVariants(branchName) {
+  const variants = new Set();
+  const normalized = branchName.replaceAll('\\', '/');
+  const parts = normalized.split('/').filter(Boolean);
+  const basename = parts.at(-1) ?? normalized;
+
+  variants.add(normalized);
+  variants.add(basename);
+  variants.add(normalized.replaceAll('/', '-'));
+
+  return variants;
+}
+
+async function getCurrentBranch(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd,
+    windowsHide: true
+  });
+
+  return stdout.trim();
+}

--- a/scripts/active-change-resolver.test.mjs
+++ b/scripts/active-change-resolver.test.mjs
@@ -165,6 +165,20 @@ describe('change id normalization and active listing', () => {
     assert.deepEqual(result, ['alpha-change', 'beta-change']);
   });
 
+  it('excludes unsafe marker-bearing and fallback-only change directory names', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'valid-change', ['proposal.md']);
+    await createChange(rootDir, 'bad name', ['proposal.md']);
+
+    assert.deepEqual(await listActiveOpenSpecChanges({ rootDir }), ['valid-change']);
+
+    const fallbackOnlyRoot = await createTempRoot();
+    await createChange(fallbackOnlyRoot, 'safe-draft', []);
+    await createChange(fallbackOnlyRoot, 'bad name', []);
+
+    assert.deepEqual(await listActiveOpenSpecChanges({ rootDir: fallbackOnlyRoot }), ['safe-draft']);
+  });
+
   it('reports filesystem diagnostics through resolution when active listing fails', async () => {
     const rootDir = await createTempRoot();
 
@@ -209,6 +223,21 @@ describe('explicit and cwd resolution', () => {
     assert.equal(result.ok, false);
     assert.equal(result.source, 'explicit');
     assert.deepEqual(result.candidates, ['fallback-change']);
+    assert.equal(result.errors[0].code, 'explicit-change-not-found');
+  });
+
+  it('rejects the reserved archive directory as an explicit active change', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'archive', ['proposal.md']);
+
+    const result = await resolveActiveChange({
+      rootDir,
+      changeId: 'archive'
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, 'explicit');
+    assert.equal(result.changeId, null);
     assert.equal(result.errors[0].code, 'explicit-change-not-found');
   });
 
@@ -463,6 +492,28 @@ describe('runtime state and QA layout', () => {
 
     assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'state')), false);
     assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'qa')), false);
+  });
+
+  it('rejects existing runtime layout paths that are files', async () => {
+    const rootDir = await createTempRoot();
+    const stateFile = path.join(rootDir, '.ai-factory', 'state', 'file-collision');
+    await mkdir(path.dirname(stateFile), { recursive: true });
+    await writeFile(stateFile, 'not a directory\n', 'utf8');
+
+    await assert.rejects(
+      () => ensureRuntimeLayout('file-collision', { rootDir }),
+      /Runtime layout path exists but is not a directory/
+    );
+
+    const qaRoot = await createTempRoot();
+    const qaFile = path.join(qaRoot, '.ai-factory', 'qa', 'file-collision');
+    await mkdir(path.dirname(qaFile), { recursive: true });
+    await writeFile(qaFile, 'not a directory\n', 'utf8');
+
+    await assert.rejects(
+      () => ensureRuntimeLayout('file-collision', { rootDir: qaRoot }),
+      /Runtime layout path exists but is not a directory/
+    );
   });
 
   it('does not create plan folders or write under OpenSpec change artifacts', async () => {

--- a/scripts/active-change-resolver.test.mjs
+++ b/scripts/active-change-resolver.test.mjs
@@ -1,0 +1,478 @@
+// active-change-resolver.test.mjs - tests for shared active OpenSpec change resolution
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  ensureRuntimeLayout,
+  listActiveOpenSpecChanges,
+  mapBranchToChangeCandidates,
+  normalizeChangeId,
+  readCurrentChangePointer,
+  resolveActiveChange,
+  writeCurrentChangePointer
+} from './active-change-resolver.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-active-change-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function createChange(rootDir, changeId, files = ['proposal.md']) {
+  const changeDir = path.join(rootDir, 'openspec', 'changes', changeId);
+  await mkdir(changeDir, { recursive: true });
+
+  for (const file of files) {
+    if (file.endsWith('/')) {
+      await mkdir(path.join(changeDir, file), { recursive: true });
+    } else {
+      await writeFile(path.join(changeDir, file), `# ${changeId}\n`, 'utf8');
+    }
+  }
+
+  return changeDir;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('active change resolver API', () => {
+  it('exports the required resolver functions', () => {
+    assert.equal(typeof resolveActiveChange, 'function');
+    assert.equal(typeof listActiveOpenSpecChanges, 'function');
+    assert.equal(typeof ensureRuntimeLayout, 'function');
+    assert.equal(typeof readCurrentChangePointer, 'function');
+    assert.equal(typeof writeCurrentChangePointer, 'function');
+    assert.equal(typeof mapBranchToChangeCandidates, 'function');
+    assert.equal(typeof normalizeChangeId, 'function');
+  });
+
+  it('returns a stable explicit success result with default runtime paths', async () => {
+    const rootDir = await createTempRoot();
+    const changePath = await createChange(rootDir, 'add-oauth');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      changeId: 'add-oauth',
+      getCurrentBranch: async () => 'ignored'
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      changeId: 'add-oauth',
+      source: 'explicit',
+      changePath,
+      statePath: path.join(rootDir, '.ai-factory', 'state', 'add-oauth'),
+      qaPath: path.join(rootDir, '.ai-factory', 'qa', 'add-oauth'),
+      candidates: ['add-oauth'],
+      warnings: [],
+      errors: []
+    });
+  });
+
+  it('uses OpenSpec-aware config paths and keeps legacy plans out of change resolution', async () => {
+    const rootDir = await createTempRoot();
+    const changePath = await createChange(rootDir, 'configured-change');
+    await mkdir(path.join(rootDir, '.ai-factory'), { recursive: true });
+    await writeFile(
+      path.join(rootDir, '.ai-factory', 'config.yaml'),
+      [
+        'paths:',
+        '  plans: .ai-factory/plans',
+        '  specs: openspec/specs',
+        '  state: .custom-state',
+        '  qa: .custom-qa'
+      ].join('\n'),
+      'utf8'
+    );
+
+    const result = await resolveActiveChange({
+      rootDir,
+      changeId: 'configured-change'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changePath, changePath);
+    assert.equal(result.statePath, path.join(rootDir, '.custom-state', 'configured-change'));
+    assert.equal(result.qaPath, path.join(rootDir, '.custom-qa', 'configured-change'));
+  });
+});
+
+describe('change id normalization and active listing', () => {
+  it('normalizes safe change ids without modifying valid slug characters', () => {
+    for (const input of ['add-oauth', 'feature_1', 'v1.2.3', 'ABC-123_value']) {
+      assert.deepEqual(normalizeChangeId(input), {
+        ok: true,
+        changeId: input,
+        error: null
+      });
+    }
+  });
+
+  it('rejects unsafe or traversal-like change ids', () => {
+    for (const input of ['', ' ', '../escape', 'nested/change', 'nested\\change', '/absolute', 'C:\\absolute', '..', 'safe..unsafe', 'not allowed']) {
+      const result = normalizeChangeId(input);
+      assert.equal(result.ok, false);
+      assert.equal(result.changeId, null);
+      assert.equal(result.error.code, 'invalid-change-id');
+    }
+  });
+
+  it('lists stable active OpenSpec change ids and excludes archives, hidden directories, files, and unmarked directories', async () => {
+    const rootDir = await createTempRoot();
+    const changesDir = path.join(rootDir, 'openspec', 'changes');
+    await createChange(rootDir, 'zeta-change', ['specs/']);
+    await createChange(rootDir, 'add-oauth', ['proposal.md']);
+    await createChange(rootDir, '.hidden-change', ['proposal.md']);
+    await createChange(rootDir, 'unmarked-change', []);
+    await mkdir(path.join(changesDir, 'archive', 'old-change'), { recursive: true });
+    await writeFile(path.join(changesDir, 'not-a-change.md'), '# file\n', 'utf8');
+
+    const result = await listActiveOpenSpecChanges({ rootDir });
+
+    assert.deepEqual(result, ['add-oauth', 'zeta-change']);
+  });
+
+  it('falls back to safe unmarked change directories when no marker-bearing changes exist', async () => {
+    const rootDir = await createTempRoot();
+    const changesDir = path.join(rootDir, 'openspec', 'changes');
+    await createChange(rootDir, 'beta-change', []);
+    await createChange(rootDir, 'alpha-change', []);
+    await createChange(rootDir, '.hidden-change', []);
+    await mkdir(path.join(changesDir, 'archive', 'old-change'), { recursive: true });
+    await writeFile(path.join(changesDir, 'not-a-change.md'), '# file\n', 'utf8');
+
+    const result = await listActiveOpenSpecChanges({ rootDir });
+
+    assert.deepEqual(result, ['alpha-change', 'beta-change']);
+  });
+
+  it('reports filesystem diagnostics through resolution when active listing fails', async () => {
+    const rootDir = await createTempRoot();
+
+    const result = await resolveActiveChange({
+      rootDir,
+      changeId: 'missing-change'
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errors[0].code, 'explicit-change-not-found');
+    assert.deepEqual(result.candidates, []);
+    assert.equal(result.warnings[0].code, 'filesystem-error');
+    assert.match(result.warnings[0].message, /Unable to list active OpenSpec changes/);
+  });
+});
+
+describe('explicit and cwd resolution', () => {
+  it('rejects invalid explicit ids without falling back to another active change', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'fallback-change');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      changeId: '../fallback-change'
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, 'explicit');
+    assert.deepEqual(result.candidates, []);
+    assert.equal(result.errors[0].code, 'invalid-change-id');
+  });
+
+  it('returns explicit missing without falling back to an available active change', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'fallback-change');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      changeId: 'missing-change'
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, 'explicit');
+    assert.deepEqual(result.candidates, ['fallback-change']);
+    assert.equal(result.errors[0].code, 'explicit-change-not-found');
+  });
+
+  it('resolves cwd nested inside an active OpenSpec change', async () => {
+    const rootDir = await createTempRoot();
+    const changePath = await createChange(rootDir, 'nested-change');
+    const nestedCwd = path.join(changePath, 'specs', 'feature');
+    await mkdir(nestedCwd, { recursive: true });
+
+    const result = await resolveActiveChange({
+      rootDir,
+      cwd: nestedCwd,
+      getCurrentBranch: async () => null
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, 'nested-change');
+    assert.equal(result.source, 'cwd');
+    assert.equal(result.changePath, changePath);
+    assert.deepEqual(result.candidates, ['nested-change']);
+  });
+
+  it('does not resolve cwd inside archived OpenSpec changes', async () => {
+    const rootDir = await createTempRoot();
+    const archivePath = path.join(rootDir, 'openspec', 'changes', 'archive', 'old-change');
+    await mkdir(archivePath, { recursive: true });
+    await writeFile(path.join(archivePath, 'proposal.md'), '# old\n', 'utf8');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      cwd: archivePath,
+      getCurrentBranch: async () => null
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, null);
+    assert.equal(result.errors[0].code, 'no-active-change');
+  });
+});
+
+describe('branch-derived resolution', () => {
+  it('maps common feature branch names to existing active changes', () => {
+    assert.deepEqual(
+      mapBranchToChangeCandidates('feat/add-oauth', ['add-oauth', 'other-change']),
+      ['add-oauth']
+    );
+    assert.deepEqual(
+      mapBranchToChangeCandidates('feat/add-oauth', ['feat-add-oauth', 'other-change']),
+      ['feat-add-oauth']
+    );
+  });
+
+  it('resolves exactly one branch-derived active change', async () => {
+    const rootDir = await createTempRoot();
+    const changePath = await createChange(rootDir, 'add-oauth');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => 'feat/add-oauth'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, 'add-oauth');
+    assert.equal(result.source, 'branch');
+    assert.equal(result.changePath, changePath);
+    assert.deepEqual(result.candidates, ['add-oauth']);
+  });
+
+  it('fails when a branch maps to multiple active changes', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'add-oauth');
+    await createChange(rootDir, 'feat-add-oauth');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => 'feat/add-oauth'
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, 'branch');
+    assert.deepEqual(result.candidates, ['add-oauth', 'feat-add-oauth']);
+    assert.equal(result.errors[0].code, 'ambiguous-branch-change');
+  });
+
+  it('keeps branch detection errors as non-fatal warnings', async () => {
+    const rootDir = await createTempRoot();
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => {
+        throw new Error('git unavailable');
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errors[0].code, 'no-active-change');
+    assert.equal(result.warnings[0].code, 'filesystem-error');
+    assert.equal(result.warnings[1].code, 'git-branch-detection-failed');
+  });
+});
+
+describe('current pointer and fallback resolution', () => {
+  it('reads current pointer files from supported YAML and JSON keys', async () => {
+    const rootDir = await createTempRoot();
+    const pointerPath = path.join(rootDir, '.ai-factory', 'state', 'current.yaml');
+    await mkdir(path.dirname(pointerPath), { recursive: true });
+
+    for (const [key, value] of [
+      ['change_id', 'yaml-snake'],
+      ['changeId', 'yaml-camel'],
+      ['active_change', 'active-snake'],
+      ['activeChange', 'active-camel']
+    ]) {
+      await writeFile(pointerPath, `${key}: ${value}\n`, 'utf8');
+      assert.equal(await readCurrentChangePointer({ rootDir }), value);
+    }
+
+    await writeFile(pointerPath, '{"activeChange":"json-change"}', 'utf8');
+    assert.equal(await readCurrentChangePointer({ rootDir }), 'json-change');
+  });
+
+  it('writes the current pointer using the canonical change_id key', async () => {
+    const rootDir = await createTempRoot();
+
+    const result = await writeCurrentChangePointer('written-change', { rootDir });
+    const content = await readFile(result.pointerPath, 'utf8');
+
+    assert.deepEqual(result, {
+      ok: true,
+      changeId: 'written-change',
+      pointerPath: path.join(rootDir, '.ai-factory', 'state', 'current.yaml')
+    });
+    assert.equal(content, 'change_id: written-change\n');
+  });
+
+  it('resolves a valid current pointer after branch resolution misses', async () => {
+    const rootDir = await createTempRoot();
+    const changePath = await createChange(rootDir, 'pointer-change');
+    await writeCurrentChangePointer('pointer-change', { rootDir });
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => 'feat/no-match'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, 'pointer-change');
+    assert.equal(result.source, 'current-pointer');
+    assert.equal(result.changePath, changePath);
+    assert.deepEqual(result.candidates, ['pointer-change']);
+  });
+
+  it('fails on a stale current pointer instead of falling back', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'active-change');
+    await writeCurrentChangePointer('missing-change', { rootDir });
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => null
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, 'current-pointer');
+    assert.deepEqual(result.candidates, ['active-change']);
+    assert.equal(result.errors[0].code, 'current-pointer-not-found');
+  });
+
+  it('falls back to a single active OpenSpec change when no pointer exists', async () => {
+    const rootDir = await createTempRoot();
+    const changePath = await createChange(rootDir, 'single-change');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => null
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, 'single-change');
+    assert.equal(result.source, 'single-active-change');
+    assert.equal(result.changePath, changePath);
+    assert.deepEqual(result.candidates, ['single-change']);
+  });
+
+  it('fails with candidates when multiple active changes remain ambiguous', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'alpha-change');
+    await createChange(rootDir, 'beta-change');
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => null
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, null);
+    assert.deepEqual(result.candidates, ['alpha-change', 'beta-change']);
+    assert.equal(result.errors[0].code, 'ambiguous-active-change');
+  });
+
+  it('fails clearly when no active changes exist', async () => {
+    const rootDir = await createTempRoot();
+    await mkdir(path.join(rootDir, 'openspec', 'changes'), { recursive: true });
+
+    const result = await resolveActiveChange({
+      rootDir,
+      getCurrentBranch: async () => null
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.source, null);
+    assert.deepEqual(result.candidates, []);
+    assert.deepEqual(result.warnings, []);
+    assert.equal(result.errors[0].code, 'no-active-change');
+  });
+});
+
+describe('runtime state and QA layout', () => {
+  it('creates state and QA directories with relative created entries, then reports preserved entries', async () => {
+    const rootDir = await createTempRoot();
+
+    const first = await ensureRuntimeLayout('layout-change', { rootDir });
+
+    assert.equal(first.ok, true);
+    assert.equal(first.changeId, 'layout-change');
+    assert.equal(first.statePath, path.join(rootDir, '.ai-factory', 'state', 'layout-change'));
+    assert.equal(first.qaPath, path.join(rootDir, '.ai-factory', 'qa', 'layout-change'));
+    assert.deepEqual(first.created, [
+      path.join('.ai-factory', 'state', 'layout-change'),
+      path.join('.ai-factory', 'qa', 'layout-change')
+    ]);
+    assert.deepEqual(first.preserved, []);
+    assert.equal(await pathExists(first.statePath), true);
+    assert.equal(await pathExists(first.qaPath), true);
+
+    const second = await ensureRuntimeLayout('layout-change', { rootDir });
+
+    assert.deepEqual(second.created, []);
+    assert.deepEqual(second.preserved, [
+      path.join('.ai-factory', 'state', 'layout-change'),
+      path.join('.ai-factory', 'qa', 'layout-change')
+    ]);
+  });
+
+  it('rejects unsafe ids before creating runtime directories', async () => {
+    const rootDir = await createTempRoot();
+
+    await assert.rejects(
+      () => ensureRuntimeLayout('../escape', { rootDir }),
+      /Invalid OpenSpec change id/
+    );
+
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'state')), false);
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'qa')), false);
+  });
+
+  it('does not create plan folders or write under OpenSpec change artifacts', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'guard-change');
+
+    await ensureRuntimeLayout('guard-change', { rootDir });
+
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'plans', 'guard-change')), false);
+    assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'guard-change', '.ai-factory')), false);
+    assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'guard-change', 'qa')), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared dependency-free active change resolver for OpenSpec-native flows
- Support explicit, cwd, branch, current-pointer, and single-active resolution with structured failures
- Create runtime layout helpers for `.ai-factory/state/<change-id>` and `.ai-factory/qa/<change-id>`
- Add focused docs and link them from the docs index
- Cover precedence, ambiguity, pointer handling, and runtime layout with deterministic unit tests

## Testing
- `npm run validate` passed
- `npm test` passed with the new resolver suite and existing repository tests