### PR TITLE
Emit OpenSpec-native plan artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-When the OpenSpec CLI is unavailable, the extension remains usable in degraded AI Factory-only mode. OpenSpec validation/archive capabilities are disabled until a compatible `openspec` CLI is available.
+When the OpenSpec CLI is unavailable, the extension remains usable. OpenSpec validation/archive capabilities are disabled until a compatible `openspec` CLI is available, but OpenSpec-native planning can still generate structurally correct artifacts with degraded validation.
 
 AI Factory-only mode follows the Node/runtime support of AI Factory and upstream. OpenSpec-native validation/archive requires Node `>=20.19.0` because that is the OpenSpec CLI runtime requirement.
 
 OpenSpec can be initialized without tool integrations using `openspec init --tools none`, but this extension does not require running that during install.
 
 `/aif-analyze` supports an explicit OpenSpec-native bootstrap mode. Use it only when a project requests OpenSpec-native artifacts or already has `aifhub.artifactProtocol: openspec`; otherwise the legacy AI Factory-only config remains the default. In OpenSpec-native mode, canonical plan/change artifacts map to `openspec/changes`, specs map to `openspec/specs`, and runtime AI Factory output stays under `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`.
+
+`/aif-plan full` remains the public planning entrypoint. In OpenSpec-native mode it creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs under `specs/**/spec.md`; legacy `.ai-factory/plans` output is AI Factory-only mode.
 
 See [OpenSpec Compatibility](docs/openspec-compatibility.md) for install/upgrade notes and the capability flags planned for runtime detection.
 
@@ -75,9 +77,9 @@ Optional explicit AIFHub finalizer after passing verification:
 - `aif-analyze` remains extension-owned and bootstraps `.ai-factory/config.yaml` plus `rules/base.md`; it can also prepare explicit OpenSpec-native config without installing OpenSpec skills.
 - `aif-done` is an explicit extension-owned AIFHub/Handoff finalizer that archives verified plans, drafts commit/PR summaries, and drives evidence-backed governance and evolution follow-ups.
 - `aif-plan`, `aif-explore`, `aif-improve`, `aif-implement`, `aif-verify`, `aif-fix`, `aif-roadmap`, and `aif-evolve` remain upstream skills with extension injections.
-- Full-mode plans use a dual artifact model:
-  - `.ai-factory/plans/<plan-id>.md`
-  - `.ai-factory/plans/<plan-id>/`
+- Full-mode planning is mode-gated:
+  - OpenSpec-native mode creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs.
+  - AI Factory-only legacy mode creates `.ai-factory/plans/<plan-id>.md` plus `.ai-factory/plans/<plan-id>/`.
 - Legacy folder-only plans are soft-migrated by generating the missing companion plan file on first improve, implement, or verify entry.
 - На `ai-factory 2.10.0+` extension публикует namespaced runtime-aware `agentFiles` для Codex и Claude; подробности и ограничения собраны в [Codex Agents](docs/codex-agents.md) и [Claude Agents](docs/claude-agents.md).
 
@@ -111,7 +113,7 @@ aif-explore -> aif-plan -> aif-improve -> aif-implement -> aif-verify
 | [Claude Agents](docs/claude-agents.md) | Namespaced Claude subagents, `.claude/agents/` install target, and handoff limitations |
 | [Handoff Naming](docs/handoff.md) | Терминология `Explore / New / Apply / Done` без возврата legacy commands в public path |
 | [Context Loading Policy](docs/context-loading-policy.md) | Runtime context contract and ownership rules |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, OpenSpec-native planning, degraded mode, and capability flags |
 
 ## Validation
 

--- a/docs/active-change-resolver.md
+++ b/docs/active-change-resolver.md
@@ -65,6 +65,8 @@ Runtime state is outside canonical OpenSpec changes:
 
 The helper never creates `.ai-factory/plans/<change-id>` and never writes under `openspec/changes/<change-id>/`.
 
+`/aif-plan full` uses the same change-id vocabulary in OpenSpec-native mode. It should create canonical OpenSpec change artifacts under `openspec/changes/<change-id>/` and keep planning runtime evidence, when needed, under `.ai-factory/state/<change-id>/`.
+
 ## Current Pointer
 
 The pointer file is `.ai-factory/state/current.yaml` by default. The resolver reads these YAML keys:

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -20,7 +20,7 @@ Responsibilities:
 - support migration and bootstrap compatibility
 - support explicit OpenSpec-native bootstrap when requested or when config already has `aifhub.artifactProtocol: openspec`
 
-In OpenSpec-native bootstrap mode, `aif-analyze` may set `paths.plans` to `openspec/changes`, `paths.specs` to `openspec/specs`, and runtime/generated paths to `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`. This changes where consumers resolve canonical plan/change and spec artifacts, but it does not install OpenSpec skills or make later OpenSpec-native workflow stages complete.
+In OpenSpec-native bootstrap mode, `aif-analyze` may set `paths.plans` to `openspec/changes`, `paths.specs` to `openspec/specs`, and runtime/generated paths to `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`. This changes where consumers resolve canonical plan/change and spec artifacts, but it does not install OpenSpec skills.
 
 Bootstrap lookup order follows `aif-analyze`: `.ai-factory/config.yaml`, then `AGENTS.md`, then `CLAUDE.md`, then `.ai-factory/RULES.md`. Legacy bridge files (`AGENTS.md`, `CLAUDE.md`) могут читаться только как migration inputs, если уже существуют, но extension не создаёт новые bridge files. Каноническими bootstrap-результатами остаются `.ai-factory/config.yaml` и `.ai-factory/rules/base.md`.
 
@@ -65,6 +65,17 @@ Optional area rules are loaded via `config.rules.*` when present.
 
 Plan-aware consumer skills additionally use:
 
+In OpenSpec-native mode:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+- `.ai-factory/state/<change-id>/` for runtime state
+- `.ai-factory/qa/<change-id>/` for QA output
+
+In legacy AI Factory-only mode:
+
 - `config.paths.plans/<plan-id>.md`
 - `config.paths.plans/<plan-id>/task.md`
 - `config.paths.plans/<plan-id>/context.md`
@@ -76,7 +87,8 @@ Plan-aware consumer skills additionally use:
 Special ownership case:
 
 - `aif-explore` may read `config.paths.research` and is the only consumer skill allowed to write it
-- `aif-plan` may read the same research artifact and normalize it into plan-local `explore.md`
+- `aif-plan` may read the same research artifact and normalize it into plan-local `explore.md` in legacy AI Factory-only mode
+- OpenSpec-native planning must keep runtime-only notes under `.ai-factory/state/<change-id>/`, not under `openspec/changes/<change-id>/`
 - no consumer skill may use bridge files as a substitute for these runtime paths
 
 ## Artifact Metadata Contract
@@ -138,8 +150,9 @@ If `config.yaml` is missing or incomplete for the requested operation:
 - `RULES.md` owner: `/aif-rules`
 - `rules/base.md` owner: extension `aif-analyze`
 - `aif-rules-check` owner: extension; reads rules but never writes
-- `.ai-factory/plans/<plan-id>.md` owner: built-in `/aif-plan` with extension injection rules
-- `.ai-factory/plans/<plan-id>/status.yaml` owner: `/aif-implement`, `/aif-verify`, `/aif-fix`
+- `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md` owner in OpenSpec-native mode: built-in `/aif-plan` with extension injection rules
+- `.ai-factory/plans/<plan-id>.md` owner in legacy AI Factory-only mode: built-in `/aif-plan` with extension injection rules
+- `.ai-factory/plans/<plan-id>/status.yaml` owner in legacy AI Factory-only mode: `/aif-implement`, `/aif-verify`, `/aif-fix`
 - `rules/*.md` owner: `/aif-plan` when the active plan explicitly adds area-specific rules
 
 ## See Also

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -2,7 +2,7 @@
 
 # OpenSpec Compatibility
 
-OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This page records the supported baseline, bootstrap/config behavior, runtime detection surface, and expected degraded behavior; it does not implement later OpenSpec-native `/aif-plan`, verification, archive, migration, or OpenSpec skill/command installation.
+OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This page records the supported baseline, bootstrap/config behavior, `/aif-plan full` OpenSpec-native planning behavior, runtime detection surface, and expected degraded behavior.
 
 ## Supported Versions
 
@@ -56,6 +56,24 @@ OpenSpec-native bootstrap verifies or creates `openspec/config.yaml`, `openspec/
 
 OpenSpec skills and slash commands are not installed by this extension.
 
+## OpenSpec-Native Planning
+
+`/aif-plan full` remains the public planning entrypoint. When `.ai-factory/config.yaml` has `aifhub.artifactProtocol: openspec`, planning creates canonical OpenSpec change artifacts instead of legacy AI Factory plan folders:
+
+```text
+openspec/changes/<change-id>/
+  proposal.md
+  design.md
+  tasks.md
+  specs/<capability>/spec.md
+```
+
+Behavior-changing plans should include at least one delta spec under `specs/**/spec.md`. Docs/tooling-only plans may omit a delta spec only when they explicitly explain why no product or workflow behavior changes.
+
+Planning validates through `scripts/openspec-runner.mjs` with `validateOpenSpecChange(changeId)` when a compatible OpenSpec CLI is available. Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
+
+Legacy `.ai-factory/plans/<plan-id>.md` plus `.ai-factory/plans/<plan-id>/` output remains available only in AI Factory-only mode.
+
 ## Install And Upgrade Notes
 
 This change only updates extension policy, metadata, and documentation. OpenSpec remains an optional external CLI adapter and is not added to `dependencies` or `devDependencies`.
@@ -66,13 +84,13 @@ When a compatible OpenSpec CLI is missing:
 - AI Factory bootstrap/config workflows may still run in AI Factory-only mode
 - OpenSpec-native validation is unavailable
 - OpenSpec-native archive is unavailable
-- future OpenSpec-aware commands should report capability flags instead of failing extension install
+- OpenSpec-aware commands should report capability flags instead of failing extension install
 
 OpenSpec skills and slash commands are not installed by this extension in v1.
 
 ## Runtime Capability Flags
 
-Issue #38 adds the shared runner in `scripts/openspec-runner.mjs` for OpenSpec CLI detection and normalized command execution. Future OpenSpec-aware commands should consume capability metadata equivalent to:
+Issue #38 adds the shared runner in `scripts/openspec-runner.mjs` for OpenSpec CLI detection and normalized command execution. OpenSpec-aware commands consume capability metadata equivalent to:
 
 ```yaml
 openspec:
@@ -86,4 +104,4 @@ openspec:
   versionSupported: boolean
 ```
 
-The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap consumes this capability shape; planning, verification, archive integration, migration, generated rules, and broader prompt rewrites remain separate follow-up work.
+The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap and planning consume this capability shape; verification, archive integration, migration, generated rules, and broader prompt rewrites remain separate follow-up work.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@
 | `/aif-analyze` | Extension skill | Bootstrap `.ai-factory/config.yaml` and `rules/base.md`; explicit OpenSpec-native config is supported |
 | `/aif-rules-check` | Extension skill (temporary gate) | Read-only rule compliance check against rules hierarchy |
 | `/aif-explore` | Built-in + injection | Explore ideas and persist only `.ai-factory/RESEARCH.md` |
-| `/aif-plan` | Built-in + injection | Create the companion plan file + plan folder pair |
+| `/aif-plan` | Built-in + injection | Create mode-gated full plans: OpenSpec changes in OpenSpec-native mode, companion plan folders in legacy AI Factory mode |
 | `/aif-improve` | Built-in + injection | Refine both plan layers together before execution |
 | `/aif-implement` | Built-in + injection | Execute tasks and own git plus execution metadata |
 | `/aif-verify` | Built-in + injection | Verify findings and update `verify.md` plus `status.yaml`; optional archival/finalizer work lives in `/aif-done` |
@@ -168,11 +168,23 @@ Explore behavior:
 /aif-plan full "add OAuth authentication"
 ```
 
-Full-mode planning creates both:
+Full-mode planning is mode-gated.
+
+In OpenSpec-native mode (`aifhub.artifactProtocol: openspec`), `/aif-plan full` creates canonical OpenSpec change artifacts:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md` when behavior changes
+
+OpenSpec validation runs through `scripts/openspec-runner.mjs` when a compatible CLI is available. Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
+
+In legacy AI Factory-only mode, full-mode planning creates both:
+
 - `.ai-factory/plans/<plan-id>.md`
 - `.ai-factory/plans/<plan-id>/`
 
-If active research exists, `/aif-plan` normalizes it into plan-local `explore.md`.
+If active research exists, `/aif-plan` normalizes it into plan-local `explore.md` only in legacy AI Factory mode. OpenSpec-native runtime notes belong under `.ai-factory/state/<change-id>/`, not inside `openspec/changes/<change-id>/`.
 
 Для открытия новой full plan pair используйте `/aif-plan full`. Historical `/aif-new` больше не является current public command.
 

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -1,4 +1,4 @@
-## AIFHub Plan Companion-Artifact Override
+## AIFHub OpenSpec-Native Planning Override
 
 Apply this block before the upstream `aif-plan` body. When any rule below conflicts with the base skill text, this block wins.
 
@@ -12,9 +12,151 @@ Use the built-in `/aif-plan` skill as the canonical planning entrypoint for this
 - The canonical public flow is `/aif-analyze -> /aif-explore -> /aif-plan -> /aif-improve -> /aif-implement -> /aif-verify`.
 - Legacy planning references should be interpreted as `/aif-plan full`.
 
-### Full-Mode Artifact Contract
+### OpenSpec-native mode
 
-When `/aif-plan full` creates `.ai-factory/plans/<plan-id>.md`, it must also create and keep synchronized the companion folder:
+When `.ai-factory/config.yaml` has `aifhub.artifactProtocol: openspec`, this block overrides legacy plan-folder behavior.
+
+Use canonical OpenSpec artifacts under `openspec/changes/<change-id>/`:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/<capability>/spec.md` when the change affects product or workflow behavior
+
+Do not create legacy `.ai-factory/plans` plan files or companion folders in this mode. Do not write runtime-only files into `openspec/changes/<change-id>/`.
+
+If the task is docs/tooling-only and does not change product or workflow behavior, a delta spec may be omitted only when the plan explicitly explains why no delta spec is needed.
+
+#### Change ID policy
+
+- Derive a safe `<change-id>` slug from the request for new plans.
+- Prefer lowercase kebab-case.
+- Allow only safe relative IDs.
+- Reject IDs containing `/`, `\`, `..`, absolute paths, path traversal, or unsafe characters.
+- Use or reference `normalizeChangeId()` from `scripts/active-change-resolver.mjs` when useful.
+- If `openspec/changes/<change-id>` already exists, do not overwrite silently. Ask for a new ID, or create a deterministic suffix only in autonomous mode when asking is unavailable.
+
+#### Required artifact shape
+
+`proposal.md` should use:
+
+```markdown
+# Proposal: <Title>
+
+## Intent
+
+Why this change is needed.
+
+## Scope
+
+- In scope
+- Out of scope
+
+## Approach
+
+High-level implementation approach.
+
+## Risks / Open Questions
+
+Known risks, assumptions, and unresolved questions.
+```
+
+`design.md` should use:
+
+```markdown
+# Design: <Title>
+
+## Technical Approach
+
+## Data / Artifact Model
+
+## Integration Points
+
+## Alternatives Considered
+
+## Risks
+```
+
+`tasks.md` must be a checkbox checklist:
+
+```markdown
+# Tasks
+
+## 1. Planning and artifacts
+
+- [ ] 1.1 Create/update OpenSpec delta specs
+- [ ] 1.2 Confirm generated artifacts validate
+
+## 2. Implementation
+
+- [ ] 2.1 ...
+```
+
+Delta specs must use OpenSpec requirement sections:
+
+```markdown
+# Delta for <Capability>
+
+## ADDED Requirements
+
+### Requirement: <Requirement name>
+
+The system MUST/SHALL ...
+
+#### Scenario: <Scenario name>
+
+- GIVEN ...
+- WHEN ...
+- THEN ...
+
+## MODIFIED Requirements
+
+### Requirement: <Existing requirement name>
+
+...
+
+## REMOVED Requirements
+
+### Requirement: <Removed requirement name>
+```
+
+Every requirement should include at least one scenario when applicable.
+
+#### Runtime state
+
+Planning may create or update runtime state only under `.ai-factory/state/<change-id>/`.
+
+Use or reference `ensureRuntimeLayout(changeId)` from `scripts/active-change-resolver.mjs` when runtime directories are needed.
+
+Allowed runtime examples:
+
+- `.ai-factory/state/<change-id>/plan-summary.md`
+- `.ai-factory/state/<change-id>/validation.json`
+
+Runtime QA output belongs under `.ai-factory/qa/<change-id>/`.
+
+#### OpenSpec validation
+
+When a compatible OpenSpec CLI is available, validate through `scripts/openspec-runner.mjs` using `validateOpenSpecChange(changeId)` or equivalent runner behavior.
+
+The runner command corresponds to:
+
+```bash
+openspec validate <change-id> --type change --strict --json --no-interactive --no-color
+```
+
+- If validation passes, report success.
+- If validation fails, repair generated artifacts when possible or clearly report the failing file, requirement, or section.
+- Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
+- Do not install OpenSpec skills or slash commands.
+
+Report generated OpenSpec artifact paths and validation status in the normal planning response. Persist validation evidence only under `.ai-factory/state/<change-id>/` when a runtime file is needed.
+
+### Legacy AI Factory mode
+
+When OpenSpec-native mode is not enabled, preserve the existing legacy companion plan-folder contract.
+
+This mode is legacy AI Factory-only mode. When `/aif-plan full` creates `.ai-factory/plans/<plan-id>.md`, it must also create and keep synchronized the companion folder:
 
 - `.ai-factory/plans/<plan-id>/task.md`
 - `.ai-factory/plans/<plan-id>/context.md`
@@ -28,15 +170,17 @@ The companion plan file may remain plain upstream markdown; the shared YAML fron
 
 ### Research Normalization
 
-- If `.ai-factory/RESEARCH.md` exists, normalize the active summary into plan-local `explore.md`.
+- In OpenSpec-native mode, do not import research into `openspec/changes/<change-id>/` as runtime-only notes.
+- In legacy AI Factory mode, if `.ai-factory/RESEARCH.md` exists, normalize the active summary into plan-local `explore.md`.
 - Keep `.ai-factory/RESEARCH.md` read-only.
-- Record the imported source and timestamp in `status.yaml.history`.
+- In legacy AI Factory mode, record the imported source and timestamp in `status.yaml.history`.
 
 ### Plan Resolution and Migration
 
-- When the active branch slug matches an existing plan folder without a companion `.md` plan file, generate the missing plan file before continuing.
-- Record legacy upgrades in `status.yaml.history` with the source folder path and the generated companion plan file path.
-- User-facing guidance must present the normalized canonical pair, not the legacy folder-only shape.
+- In OpenSpec-native mode, use OpenSpec change IDs and the shared active-change vocabulary.
+- In legacy AI Factory mode, when the active branch slug matches an existing plan folder without a companion `.md` plan file, generate the missing plan file before continuing.
+- In legacy AI Factory mode, record legacy upgrades in `status.yaml.history` with the source folder path and the generated companion plan file path.
+- User-facing guidance must present the mode-appropriate canonical artifacts, not a mixed OpenSpec/legacy shape.
 
 ### Handoff Rules
 

--- a/scripts/aif-plan-openspec-artifacts.test.mjs
+++ b/scripts/aif-plan-openspec-artifacts.test.mjs
@@ -1,0 +1,164 @@
+// aif-plan-openspec-artifacts.test.mjs - instruction-level tests for OpenSpec-native planning
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+async function readRepoFile(relativePath) {
+  return readFile(join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function assertIncludes(source, expected, label) {
+  assert.ok(
+    source.includes(expected),
+    `${label} should include ${JSON.stringify(expected)}`
+  );
+}
+
+function assertNotIncludes(source, unexpected, label) {
+  assert.ok(
+    !source.includes(unexpected),
+    `${label} should not include ${JSON.stringify(unexpected)}`
+  );
+}
+
+function extractSection(markdown, heading) {
+  const lines = markdown.split(/\r?\n/);
+  let inFence = false;
+  let start = -1;
+  let end = lines.length;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+
+    if (!inFence && lines[index] === `### ${heading}`) {
+      start = index + 1;
+      break;
+    }
+  }
+
+  assert.notEqual(start, -1, `Expected section heading: ### ${heading}`);
+
+  inFence = false;
+  for (let index = start; index < lines.length; index += 1) {
+    if (lines[index].startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+
+    if (!inFence && lines[index].startsWith('### ')) {
+      end = index;
+      break;
+    }
+  }
+
+  return lines.slice(start, end).join('\n');
+}
+
+describe('aif-plan OpenSpec-native planning contract', () => {
+  it('defines mode-gated OpenSpec-native and legacy sections', async () => {
+    const injection = await readRepoFile('injections/core/aif-plan-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+    const legacy = extractSection(injection, 'Legacy AI Factory mode');
+
+    assertIncludes(openspec, 'aifhub.artifactProtocol: openspec', 'OpenSpec-native section');
+    assertIncludes(openspec, 'overrides legacy plan-folder behavior', 'OpenSpec-native section');
+    assertIncludes(legacy, 'When OpenSpec-native mode is not enabled', 'Legacy section');
+    assertIncludes(legacy, '.ai-factory/plans/<plan-id>.md', 'Legacy section');
+    assertIncludes(legacy, '.ai-factory/plans/<plan-id>/task.md', 'Legacy section');
+  });
+
+  it('requires canonical OpenSpec change artifacts without legacy plan companion files', async () => {
+    const injection = await readRepoFile('injections/core/aif-plan-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'openspec/changes/<change-id>/proposal.md',
+      'openspec/changes/<change-id>/design.md',
+      'openspec/changes/<change-id>/tasks.md',
+      'openspec/changes/<change-id>/specs/<capability>/spec.md'
+    ]) {
+      assertIncludes(openspec, expected, 'OpenSpec-native section');
+    }
+
+    for (const unexpected of [
+      '.ai-factory/plans/<id>.md',
+      '.ai-factory/plans/<id>/task.md',
+      '.ai-factory/plans/<id>/context.md',
+      '.ai-factory/plans/<id>/rules.md',
+      '.ai-factory/plans/<id>/verify.md',
+      '.ai-factory/plans/<id>/status.yaml'
+    ]) {
+      assertNotIncludes(openspec, unexpected, 'OpenSpec-native section');
+    }
+  });
+
+  it('documents OpenSpec artifact templates and delta requirements', async () => {
+    const injection = await readRepoFile('injections/core/aif-plan-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      '# Proposal: <Title>',
+      '## Intent',
+      '## Scope',
+      '## Approach',
+      '## Risks / Open Questions',
+      '# Design: <Title>',
+      '## Technical Approach',
+      '## Data / Artifact Model',
+      '# Tasks',
+      '## ADDED Requirements',
+      '## MODIFIED Requirements',
+      '## REMOVED Requirements',
+      '#### Scenario: <Scenario name>'
+    ]) {
+      assertIncludes(openspec, expected, 'OpenSpec-native section');
+    }
+  });
+
+  it('defines safe change IDs, runtime-state boundaries, and validation through the runner', async () => {
+    const injection = await readRepoFile('injections/core/aif-plan-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'normalizeChangeId()',
+      'ensureRuntimeLayout(changeId)',
+      '.ai-factory/state/<change-id>/',
+      'Do not write runtime-only files into `openspec/changes/<change-id>/`',
+      'validateOpenSpecChange(changeId)',
+      'scripts/openspec-runner.mjs',
+      'openspec validate <change-id> --type change --strict --json --no-interactive --no-color',
+      'Missing or unsupported OpenSpec CLI is degraded validation, not planning failure',
+      'Do not install OpenSpec skills'
+    ]) {
+      assertIncludes(openspec, expected, 'OpenSpec-native section');
+    }
+  });
+
+  it('keeps compatibility docs aligned with OpenSpec-native planning support', async () => {
+    const compatibility = await readRepoFile('docs/openspec-compatibility.md');
+
+    assertNotIncludes(
+      compatibility,
+      'does not implement later OpenSpec-native `/aif-plan`',
+      'docs/openspec-compatibility.md'
+    );
+    assertNotIncludes(
+      compatibility,
+      'planning, verification, archive integration, migration, generated rules, and broader prompt rewrites remain separate follow-up work',
+      'docs/openspec-compatibility.md'
+    );
+    assertIncludes(
+      compatibility,
+      '`/aif-plan full`',
+      'docs/openspec-compatibility.md'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Make `/aif-plan full` emit canonical OpenSpec change folders in `aifhub.artifactProtocol: openspec` mode.
- Keep legacy `.ai-factory/plans` output isolated to explicit AI Factory-only mode.
- Update the plan injection, active-change resolver docs, and compatibility/usage docs to match the new contract.
- Add focused tests for OpenSpec-native artifact layout, delta-spec requirements, runner validation guidance, and legacy-mode gating.

## Testing
- Added and updated unit tests covering the new planning contract.
- Local validation passed for the repository checks and test suite.
- PR covers issue closed #28.