### PR TITLE
Update explore and improve for OpenSpec artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ OpenSpec can be initialized without tool integrations using `openspec init --too
 
 `/aif-plan full` remains the public planning entrypoint. In OpenSpec-native mode it creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs under `specs/**/spec.md`; legacy `.ai-factory/plans` output is AI Factory-only mode.
 
+`/aif-explore` remains research-oriented in OpenSpec-native mode. It may read OpenSpec specs and changes, but writes research/runtime notes only to `.ai-factory/RESEARCH.md` or `.ai-factory/state/<change-id>/` and does not create non-OpenSpec files inside `openspec/changes/<change-id>/`.
+
+`/aif-improve` refines existing OpenSpec-native artifacts in place: `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`. It preserves user edits with patch-style changes, returns changed/preserved summary sections, warns or refuses archived changes, and keeps legacy plan-folder refinement as AI Factory-only behavior.
+
 See [OpenSpec Compatibility](docs/openspec-compatibility.md) for install/upgrade notes and the capability flags planned for runtime detection.
 
 ## Quick Start
@@ -80,6 +84,7 @@ Optional explicit AIFHub finalizer after passing verification:
 - Full-mode planning is mode-gated:
   - OpenSpec-native mode creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs.
   - AI Factory-only legacy mode creates `.ai-factory/plans/<plan-id>.md` plus `.ai-factory/plans/<plan-id>/`.
+- OpenSpec-native explore/improve behavior is mode-gated: explore writes only research/runtime notes outside change folders, while improve edits only canonical OpenSpec change artifacts and preserves user edits.
 - Legacy folder-only plans are soft-migrated by generating the missing companion plan file on first improve, implement, or verify entry.
 - На `ai-factory 2.10.0+` extension публикует namespaced runtime-aware `agentFiles` для Codex и Claude; подробности и ограничения собраны в [Codex Agents](docs/codex-agents.md) и [Claude Agents](docs/claude-agents.md).
 

--- a/docs/active-change-resolver.md
+++ b/docs/active-change-resolver.md
@@ -67,6 +67,8 @@ The helper never creates `.ai-factory/plans/<change-id>` and never writes under 
 
 `/aif-plan full` uses the same change-id vocabulary in OpenSpec-native mode. It should create canonical OpenSpec change artifacts under `openspec/changes/<change-id>/` and keep planning runtime evidence, when needed, under `.ai-factory/state/<change-id>/`.
 
+`/aif-improve` also uses this vocabulary in OpenSpec-native mode. It refines only canonical OpenSpec artifacts, keeps runtime evidence under `.ai-factory/state/<change-id>/`, and treats archived targets under `openspec/changes/archive/**` as immutable by default. If further work is needed for an archived change, create a new active change instead of editing the archive silently.
+
 ## Current Pointer
 
 The pointer file is `.ai-factory/state/current.yaml` by default. The resolver reads these YAML keys:

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -88,7 +88,10 @@ Special ownership case:
 
 - `aif-explore` may read `config.paths.research` and is the only consumer skill allowed to write it
 - `aif-plan` may read the same research artifact and normalize it into plan-local `explore.md` in legacy AI Factory-only mode
+- In OpenSpec-native mode, `aif-explore` may write research and runtime notes outside canonical change folders only: `.ai-factory/RESEARCH.md`, `.ai-factory/state/<change-id>/explore.md`, and `.ai-factory/state/<change-id>/research-notes.md`
+- In OpenSpec-native mode, `aif-improve` edits only valid OpenSpec change artifacts: `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
 - OpenSpec-native planning must keep runtime-only notes under `.ai-factory/state/<change-id>/`, not under `openspec/changes/<change-id>/`
+- Legacy `task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, and `explore.md` apply only to legacy AI Factory-only plan folders, not OpenSpec-native changes
 - no consumer skill may use bridge files as a substitute for these runtime paths
 
 ## Artifact Metadata Contract
@@ -151,6 +154,7 @@ If `config.yaml` is missing or incomplete for the requested operation:
 - `rules/base.md` owner: extension `aif-analyze`
 - `aif-rules-check` owner: extension; reads rules but never writes
 - `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md` owner in OpenSpec-native mode: built-in `/aif-plan` with extension injection rules
+- OpenSpec-native refinement owner: built-in `/aif-improve` with extension injection rules; it preserves user edits and updates only canonical OpenSpec artifacts
 - `.ai-factory/plans/<plan-id>.md` owner in legacy AI Factory-only mode: built-in `/aif-plan` with extension injection rules
 - `.ai-factory/plans/<plan-id>/status.yaml` owner in legacy AI Factory-only mode: `/aif-implement`, `/aif-verify`, `/aif-fix`
 - `rules/*.md` owner: `/aif-plan` when the active plan explicitly adds area-specific rules

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,9 +8,9 @@
 |-------|------|---------|
 | `/aif-analyze` | Extension skill | Bootstrap `.ai-factory/config.yaml` and `rules/base.md`; explicit OpenSpec-native config is supported |
 | `/aif-rules-check` | Extension skill (temporary gate) | Read-only rule compliance check against rules hierarchy |
-| `/aif-explore` | Built-in + injection | Explore ideas and persist only `.ai-factory/RESEARCH.md` |
+| `/aif-explore` | Built-in + injection | Explore ideas; in OpenSpec-native mode, keep research/runtime notes outside canonical change folders |
 | `/aif-plan` | Built-in + injection | Create mode-gated full plans: OpenSpec changes in OpenSpec-native mode, companion plan folders in legacy AI Factory mode |
-| `/aif-improve` | Built-in + injection | Refine both plan layers together before execution |
+| `/aif-improve` | Built-in + injection | Refine OpenSpec-native artifacts with preservation, or both legacy plan layers together before execution |
 | `/aif-implement` | Built-in + injection | Execute tasks and own git plus execution metadata |
 | `/aif-verify` | Built-in + injection | Verify findings and update `verify.md` plus `status.yaml`; optional archival/finalizer work lives in `/aif-done` |
 | `/aif-fix` | Built-in + injection | Apply fixes for verification findings |
@@ -152,15 +152,18 @@ The extension does not install OpenSpec skills or slash commands.
 
 ```bash
 /aif-explore "add OAuth authentication"
+/aif-explore <change-id>
 /aif-explore <plan-id>
 /aif-explore @.ai-factory/plans/<plan-id>.md
 ```
 
 Explore behavior:
 - reads `.ai-factory/config.yaml` first
-- resolves either the companion plan file or the plan folder to one active pair
-- writes only `.ai-factory/RESEARCH.md`
-- routes new work to `/aif-plan full`
+- in OpenSpec-native mode, stays research-oriented and may read `openspec/specs/**` plus `openspec/changes/<change-id>/**`
+- in OpenSpec-native mode, writes research/runtime output only to `.ai-factory/RESEARCH.md` or `.ai-factory/state/<change-id>/`
+- does not create non-OpenSpec files inside `openspec/changes/<change-id>/`
+- in legacy AI Factory-only mode, resolves either the companion plan file or the plan folder to one active pair and writes only `.ai-factory/RESEARCH.md`
+- routes new work to `/aif-plan full`; route existing OpenSpec-native changes to `/aif-improve <change-id>`
 
 ### 3. Create a full plan
 
@@ -192,14 +195,20 @@ If active research exists, `/aif-plan` normalizes it into plan-local `explore.md
 
 ```bash
 /aif-improve
+/aif-improve <change-id>
+/aif-improve @openspec/changes/<change-id>/
 /aif-improve @.ai-factory/plans/<plan-id>/
 /aif-improve @.ai-factory/plans/<plan-id>.md
 ```
 
 Improve behavior:
-- resolves the plan file, the plan folder, or any plan-local artifact path
-- updates the plan summary plus plan-folder artifacts together
-- auto-generates a missing companion plan file for legacy folder-only plans
+- in OpenSpec-native mode, resolves the active change with `scripts/active-change-resolver.mjs`
+- refines only `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
+- preserves user edits, prefers patch-style changes, and returns `Changed:` / `Preserved:` summary sections
+- warns or refuses archived targets under `openspec/changes/archive/**` because archived changes are immutable by default
+- validates through `scripts/openspec-runner.mjs` when a compatible CLI is available; missing or unsupported CLI is degraded validation
+- in legacy AI Factory-only mode, resolves the plan file, the plan folder, or any plan-local artifact path
+- updates the legacy plan summary plus plan-folder artifacts together and auto-generates a missing companion plan file for legacy folder-only plans
 
 ### 5. Implement
 

--- a/injections/core/aif-explore-plan-folder.md
+++ b/injections/core/aif-explore-plan-folder.md
@@ -1,6 +1,61 @@
-## AIFHub Extension Override
+## AIFHub OpenSpec-native Override
 
-When working in a repository that uses this extension:
+Apply this block before the upstream `aif-explore` body. When any rule below conflicts with the base skill text, this block wins.
+
+### Goal
+
+Keep `/aif-explore` as a research-oriented command while making the extension aware of OpenSpec-native artifact ownership.
+
+### Mode Detection
+
+Before resolving exploration inputs, read `.ai-factory/config.yaml` when it exists.
+
+- If the config contains `aifhub.artifactProtocol: openspec`, use **OpenSpec-native mode**.
+- Otherwise, use **Legacy AI Factory-only mode**.
+- If the config is missing, continue with Legacy AI Factory-only mode and state that no OpenSpec-native protocol was detected.
+
+### OpenSpec-native mode
+
+When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-explore` is research-oriented and must not create canonical OpenSpec change artifacts unless the upstream user request explicitly asks for planning through `/aif-plan`.
+
+Allowed read context:
+
+- `.ai-factory/config.yaml`
+- `.ai-factory/DESCRIPTION.md`
+- `.ai-factory/ARCHITECTURE.md`
+- `.ai-factory/RESEARCH.md`
+- `openspec/specs/**`
+- `openspec/changes/<change-id>/**`
+- `.ai-factory/state/<change-id>/`
+
+Canonical OpenSpec change files under an active change are only:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+
+Write boundaries:
+
+- Write research output only to `.ai-factory/RESEARCH.md` or runtime notes under `.ai-factory/state/<change-id>/`.
+- Valid runtime note targets include `.ai-factory/state/<change-id>/explore.md` and `.ai-factory/state/<change-id>/research-notes.md`.
+- Do not create non-OpenSpec files under `openspec/changes/<change-id>/`.
+- Do not write debug files, summaries, research notes, validation evidence, or runtime-only files under an OpenSpec change folder.
+- If no change ID is known, write only to `.ai-factory/RESEARCH.md` and report that no change-scoped runtime path was selected.
+
+Response and next-step guidance:
+
+- Report where research was written in the normal response.
+- Distinguish research output from canonical OpenSpec artifacts.
+- Suggest `/aif-plan full "<request>"` for new work that needs canonical change artifacts.
+- Suggest `/aif-improve <change-id>` for refining an existing OpenSpec-native change.
+- Suggest `/aif-implement <change-id>` only after an OpenSpec-native plan is ready for execution.
+- Do not suggest deprecated `*-plus` aliases.
+- Do not install OpenSpec skills or slash commands.
+
+### Legacy AI Factory-only mode
+
+When OpenSpec-native mode is not enabled, preserve the extension's companion plan behavior:
 
 - Treat `.ai-factory/plans/<plan-id>.md` and `.ai-factory/plans/<plan-id>/` as one active plan pair.
 - If `@path` points to the plan file, the plan folder, or one of its local artifacts (`task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, `explore.md`), resolve the whole pair before continuing.
@@ -11,8 +66,6 @@ When working in a repository that uses this extension:
   - `/aif-improve <plan-id>` for plan refinement
   - `/aif-implement <plan-id>` for execution
 - If a legacy folder-only plan is detected, present the canonical next step using the normalized plan id and companion plan-file model.
-
-If this override conflicts with the base `aif-explore` wording, follow the extension workflow rules above.
 
 ### Codex Runtime
 

--- a/injections/core/aif-explore-plan-folder.md
+++ b/injections/core/aif-explore-plan-folder.md
@@ -16,7 +16,7 @@ Before resolving exploration inputs, read `.ai-factory/config.yaml` when it exis
 
 ### OpenSpec-native mode
 
-When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-explore` is research-oriented and must not create canonical OpenSpec change artifacts unless the upstream user request explicitly asks for planning through `/aif-plan`.
+When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-explore` is research-oriented and must not create canonical OpenSpec change artifacts.
 
 Allowed read context:
 

--- a/injections/core/aif-improve-plan-folder.md
+++ b/injections/core/aif-improve-plan-folder.md
@@ -1,10 +1,10 @@
-## AIFHub Improve Companion-Artifact Override
+## AIFHub Improve OpenSpec-native Override
 
 Apply this block before the upstream `aif-improve` body. When any rule below conflicts with the base skill text, this block wins.
 
 ### Goal
 
-Use the built-in `/aif-improve` skill as the canonical refinement command for the extension's companion plan-file + plan-folder workflow.
+Use the built-in `/aif-improve` skill as the canonical refinement command for both OpenSpec-native changes and the extension's legacy companion plan workflow.
 
 ### Skill-Context Resolution
 
@@ -15,23 +15,81 @@ Read skill-context in this order:
 
 If both exist, `aif-improve` wins.
 
-### Plan Resolution
+### Mode Detection
 
-Resolve all of these inputs to one active pair:
+Before resolving a target, read `.ai-factory/config.yaml` when it exists.
 
-- `.ai-factory/plans/<plan-id>.md`
-- `.ai-factory/plans/<plan-id>/`
-- any plan-local artifact path inside `.ai-factory/plans/<plan-id>/`
+- If the config contains `aifhub.artifactProtocol: openspec`, use **OpenSpec-native mode**.
+- Otherwise, use **Legacy AI Factory-only mode**.
+- If the config is missing, continue with Legacy AI Factory-only mode and state that no OpenSpec-native protocol was detected.
 
-When a legacy folder-only plan is selected:
+### OpenSpec-native mode
 
-- create `.ai-factory/plans/<plan-id>.md` before refinement continues
-- preserve the existing folder artifacts
-- record the upgrade in `status.yaml.history`
+When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-improve` refines an existing OpenSpec-native change.
 
-### Workflow Rules
+Resolve the active change using the shared vocabulary from `scripts/active-change-resolver.mjs`:
 
-- `/aif-improve` is the canonical refinement command for this extension workflow.
+- Prefer an explicit `<change-id>` or `@openspec/changes/<change-id>` input when provided.
+- Otherwise use `resolveActiveChange` behavior: current working directory, current branch mapping, current pointer, then single active change.
+- Treat the selected change ID, selected source, candidate list, warnings, and errors as user-visible refinement context.
+- If the resolved path is under `openspec/changes/archive/**`, do not edit silently. Archived changes are immutable by default; report the archived target clearly and suggest creating a new change for further work.
+
+Refine only these canonical OpenSpec artifacts:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+
+Legacy companion plan artifacts, including `task.md`, `context.md`, `rules.md`, `verify.md`, and `status.yaml` are not OpenSpec-native refinement targets.
+
+Preservation rules:
+
+- Read current artifact content before editing.
+- Preserve user-written sections unless they are explicitly obsolete or contradict the refined requirement.
+- Prefer patch-style edits over whole-file regeneration.
+- If an artifact is missing, create only missing artifacts needed by the requested refinement.
+- When a delta spec exists, update the relevant requirement in an existing delta spec instead of regenerating the whole file.
+- Keep unrelated requirements, scenarios, task checkboxes, and design notes intact.
+
+Validation and runtime state:
+
+- Run or recommend OpenSpec validation through `validateOpenSpecChange(changeId)` from `scripts/openspec-runner.mjs`, or equivalent shared-runner behavior.
+- Validation should correspond to `openspec validate <change-id> --type change --strict --json --no-interactive --no-color`.
+- Missing or unsupported OpenSpec CLI is degraded validation, not a refinement failure.
+- Summarize validation success, failure, or degraded status in the normal response.
+- Runtime notes may be written only under `.ai-factory/state/<change-id>/`.
+- Prefer `ensureRuntimeLayout(changeId)` when runtime directories are needed.
+- Valid persisted runtime evidence includes `.ai-factory/state/<change-id>/improve-summary.md` and `.ai-factory/state/<change-id>/last-validation.json`.
+- Do not write runtime-only files or validation evidence under `openspec/changes/<change-id>/`.
+
+Output summary:
+
+```text
+Changed:
+- proposal.md: ...
+- design.md: ...
+- tasks.md: ...
+- specs/<capability>/spec.md: ...
+
+Preserved:
+- ...
+```
+
+The response must report the selected change ID, selected source, changed canonical artifact paths, preserved user-written areas, and validation status. Do not install OpenSpec skills or slash commands.
+
+### Legacy AI Factory-only mode
+
+When OpenSpec-native mode is not enabled, preserve the extension's companion plan behavior:
+
+- Resolve all of these inputs to one active pair:
+  - `.ai-factory/plans/<plan-id>.md`
+  - `.ai-factory/plans/<plan-id>/`
+  - any plan-local artifact path inside `.ai-factory/plans/<plan-id>/`
+- When a legacy folder-only plan is selected:
+  - create `.ai-factory/plans/<plan-id>.md` before refinement continues
+  - preserve the existing folder artifacts
+  - record the upgrade in `status.yaml.history`
 - Update the plan file summary and the plan-folder artifacts together.
 - Keep `status.yaml` as the canonical execution state file.
 - When refinement completes successfully and the next step is execution, route to `/aif-implement`.

--- a/scripts/aif-explore-improve-openspec-artifacts.test.mjs
+++ b/scripts/aif-explore-improve-openspec-artifacts.test.mjs
@@ -119,7 +119,8 @@ describe('aif-explore and aif-improve OpenSpec-native contracts', () => {
       '.ai-factory/plans/<id>/',
       '.ai-factory/plans/<plan-id>/',
       'openspec/changes/<change-id>/explore.md',
-      'openspec/changes/<change-id>/research-notes.md'
+      'openspec/changes/<change-id>/research-notes.md',
+      'unless the upstream user request explicitly asks for planning through `/aif-plan`'
     ]) {
       assertNotIncludes(openspec, unexpected, 'aif-explore OpenSpec-native section');
     }

--- a/scripts/aif-explore-improve-openspec-artifacts.test.mjs
+++ b/scripts/aif-explore-improve-openspec-artifacts.test.mjs
@@ -1,0 +1,221 @@
+// aif-explore-improve-openspec-artifacts.test.mjs - instruction-level tests for OpenSpec explore/improve contracts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+async function readRepoFile(relativePath) {
+  return readFile(join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function assertIncludes(source, expected, label) {
+  assert.ok(
+    source.includes(expected),
+    `${label} should include ${JSON.stringify(expected)}`
+  );
+}
+
+function assertNotIncludes(source, unexpected, label) {
+  assert.ok(
+    !source.includes(unexpected),
+    `${label} should not include ${JSON.stringify(unexpected)}`
+  );
+}
+
+function assertNoInstallGuidance(source, label) {
+  assert.doesNotMatch(
+    source,
+    /\b(?:must|should|need(?:s)? to|required to|recommended to|recommend)\s+install OpenSpec skills\b/i,
+    `${label} should not tell agents to install OpenSpec skills`
+  );
+}
+
+function extractSection(markdown, heading) {
+  const lines = markdown.split(/\r?\n/);
+  let inFence = false;
+  let start = -1;
+  let startLevel = 0;
+  let end = lines.length;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (/^\s*(```|~~~)/.test(lines[index])) {
+      inFence = !inFence;
+      continue;
+    }
+
+    const match = inFence ? null : lines[index].match(/^(#{1,6})\s+(.+?)\s*$/);
+
+    if (match && match[2] === heading) {
+      start = index + 1;
+      startLevel = match[1].length;
+      break;
+    }
+  }
+
+  assert.notEqual(start, -1, `Expected section heading: ${'#'.repeat(startLevel || 3)} ${heading}`);
+
+  inFence = false;
+  for (let index = start; index < lines.length; index += 1) {
+    if (/^\s*(```|~~~)/.test(lines[index])) {
+      inFence = !inFence;
+      continue;
+    }
+
+    const match = inFence ? null : lines[index].match(/^(#{1,6})\s+(.+?)\s*$/);
+
+    if (match && match[1].length <= startLevel) {
+      end = index;
+      break;
+    }
+  }
+
+  return lines.slice(start, end).join('\n');
+}
+
+describe('aif-explore and aif-improve OpenSpec-native contracts', () => {
+  it('defines mode-gated OpenSpec-native and legacy sections in both injections', async () => {
+    for (const [relativePath, legacyHeading] of [
+      ['injections/core/aif-explore-plan-folder.md', 'Legacy AI Factory-only mode'],
+      ['injections/core/aif-improve-plan-folder.md', 'Legacy AI Factory-only mode']
+    ]) {
+      const injection = await readRepoFile(relativePath);
+      const openspec = extractSection(injection, 'OpenSpec-native mode');
+      const legacy = extractSection(injection, legacyHeading);
+
+      assertIncludes(openspec, 'aifhub.artifactProtocol: openspec', `${relativePath} OpenSpec-native section`);
+      assertIncludes(legacy, 'When OpenSpec-native mode is not enabled', `${relativePath} legacy section`);
+      assertIncludes(legacy, '.ai-factory/plans/<plan-id>.md', `${relativePath} legacy section`);
+      assertIncludes(legacy, '.ai-factory/plans/<plan-id>/', `${relativePath} legacy section`);
+    }
+  });
+
+  it('keeps /aif-explore research-oriented without legacy plan-file requirements', async () => {
+    const injection = await readRepoFile('injections/core/aif-explore-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'research-oriented',
+      '.ai-factory/config.yaml',
+      '.ai-factory/DESCRIPTION.md',
+      '.ai-factory/ARCHITECTURE.md',
+      '.ai-factory/RESEARCH.md',
+      'openspec/specs/**',
+      'openspec/changes/<change-id>/**',
+      '.ai-factory/state/<change-id>/explore.md',
+      '.ai-factory/state/<change-id>/research-notes.md',
+      'Do not create non-OpenSpec files under `openspec/changes/<change-id>/`',
+      'Report where research was written'
+    ]) {
+      assertIncludes(openspec, expected, 'aif-explore OpenSpec-native section');
+    }
+
+    for (const unexpected of [
+      '.ai-factory/plans/<id>.md',
+      '.ai-factory/plans/<plan-id>.md',
+      '.ai-factory/plans/<id>/',
+      '.ai-factory/plans/<plan-id>/',
+      'openspec/changes/<change-id>/explore.md',
+      'openspec/changes/<change-id>/research-notes.md'
+    ]) {
+      assertNotIncludes(openspec, unexpected, 'aif-explore OpenSpec-native section');
+    }
+  });
+
+  it('limits /aif-explore OpenSpec change files to canonical artifacts and current commands', async () => {
+    const injection = await readRepoFile('injections/core/aif-explore-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'openspec/changes/<change-id>/proposal.md',
+      'openspec/changes/<change-id>/design.md',
+      'openspec/changes/<change-id>/tasks.md',
+      'openspec/changes/<change-id>/specs/**/spec.md',
+      '/aif-plan full "<request>"',
+      '/aif-improve <change-id>',
+      '/aif-implement <change-id>'
+    ]) {
+      assertIncludes(openspec, expected, 'aif-explore OpenSpec-native section');
+    }
+
+    for (const unexpected of [
+      'aif-plan-plus',
+      'aif-improve-plus',
+      'aif-implement-plus'
+    ]) {
+      assertNotIncludes(openspec, unexpected, 'aif-explore OpenSpec-native section');
+    }
+  });
+
+  it('targets only canonical OpenSpec artifacts from /aif-improve OpenSpec-native mode', async () => {
+    const injection = await readRepoFile('injections/core/aif-improve-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'scripts/active-change-resolver.mjs',
+      'resolveActiveChange',
+      'openspec/changes/<change-id>/proposal.md',
+      'openspec/changes/<change-id>/design.md',
+      'openspec/changes/<change-id>/tasks.md',
+      'openspec/changes/<change-id>/specs/**/spec.md',
+      '`task.md`, `context.md`, `rules.md`, `verify.md`, and `status.yaml` are not OpenSpec-native refinement targets'
+    ]) {
+      assertIncludes(openspec, expected, 'aif-improve OpenSpec-native section');
+    }
+
+    for (const unexpected of [
+      '.ai-factory/plans/<id>.md',
+      '.ai-factory/plans/<plan-id>.md',
+      '.ai-factory/plans/<id>/task.md',
+      '.ai-factory/plans/<plan-id>/task.md',
+      'refine `task.md`',
+      'refine `context.md`',
+      'refine `rules.md`',
+      'refine `verify.md`',
+      'refine `status.yaml`'
+    ]) {
+      assertNotIncludes(openspec, unexpected, 'aif-improve OpenSpec-native section');
+    }
+  });
+
+  it('requires preservation, archived-change handling, runtime-state boundaries, and validation for /aif-improve', async () => {
+    const injection = await readRepoFile('injections/core/aif-improve-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'Read current artifact content before editing',
+      'Preserve user-written sections',
+      'patch-style',
+      'create only missing artifacts',
+      'update the relevant requirement in an existing delta spec',
+      'Changed:',
+      'Preserved:',
+      'openspec/changes/archive/**',
+      'immutable by default',
+      'validateOpenSpecChange(changeId)',
+      'scripts/openspec-runner.mjs',
+      'Missing or unsupported OpenSpec CLI is degraded validation',
+      'ensureRuntimeLayout(changeId)',
+      '.ai-factory/state/<change-id>/improve-summary.md',
+      '.ai-factory/state/<change-id>/last-validation.json'
+    ]) {
+      assertIncludes(openspec, expected, 'aif-improve OpenSpec-native section');
+    }
+  });
+
+  it('does not tell OpenSpec-native users to install OpenSpec skills', async () => {
+    for (const relativePath of [
+      'injections/core/aif-explore-plan-folder.md',
+      'injections/core/aif-improve-plan-folder.md'
+    ]) {
+      const injection = await readRepoFile(relativePath);
+      const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+      assertIncludes(openspec, 'Do not install OpenSpec skills', `${relativePath} OpenSpec-native section`);
+      assertNoInstallGuidance(openspec, `${relativePath} OpenSpec-native section`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add instruction-level coverage for `/aif-explore` and `/aif-improve` OpenSpec-native contracts
- Rewrite both injections to distinguish OpenSpec-native mode from legacy AI Factory-only behavior
- Update context-loading and public docs to describe research/runtime boundaries, preservation rules, and archived-change handling

## Testing
- Added focused contract tests for the new OpenSpec-native prompt rules
- Local validation passed: extension checks, agent-file checks, doc-link checks, and the full test suite

Closed #29