### PR TITLE
Add OpenSpec rules compiler for generated AI Factory guidance

### DIFF
--- a/docs/adr/0001-openspec-native-artifact-protocol.md
+++ b/docs/adr/0001-openspec-native-artifact-protocol.md
@@ -50,6 +50,9 @@ Generated AI Factory artifacts:
 
 ```text
 .ai-factory/rules/generated/
+  openspec-base.md
+  openspec-change-<change-id>.md
+  openspec-merged-<change-id>.md
 ```
 
 Generated rules are derived from OpenSpec specs and change specs. They are not canonical requirements and must be recoverable from canonical OpenSpec artifacts.
@@ -77,7 +80,7 @@ These paths are reserved names only in v1. Their detailed behavior is out of sco
 | `/aif-implement` | `openspec/specs`, `openspec/changes/<id>/*`, generated rules | none | `.ai-factory/state/<id>/*` | Execution state is runtime-only |
 | `/aif-fix` | same as implement plus QA reports | none | `.ai-factory/state/<id>/*` | Fixes implementation, not specs unless explicitly requested |
 | `/aif-verify` | `openspec/*`, generated rules | none | `.ai-factory/qa/<id>/*` | Must not archive |
-| `/aif-rules-check` | `openspec/specs`, `openspec/changes/<id>/specs` | none | reports and/or `.ai-factory/rules/generated/*` | Generated rules are derived |
+| `/aif-rules-check` | `openspec/specs`, `openspec/changes/<id>/specs` | none | none | Reads generated rules as derived guidance; never regenerates them |
 | `/aif-done` | `openspec/changes/<id>/*`, QA state | `openspec/specs/*` via OpenSpec archive | final summary/state | Only finalizer may archive |
 
 ## Generated rules policy
@@ -92,6 +95,16 @@ openspec/changes/<change-id>/specs/
 ```
 
 Generated rule output may guide implementation and review, but conflict resolution must defer to canonical OpenSpec artifacts.
+
+The compiler writes exactly these derived files:
+
+```text
+.ai-factory/rules/generated/openspec-base.md
+.ai-factory/rules/generated/openspec-change-<change-id>.md
+.ai-factory/rules/generated/openspec-merged-<change-id>.md
+```
+
+OpenSpec-native consumer and gate skills should read these files as execution guidance when present. Read-only gates such as `aif-rules-check` report missing or stale generated rules and ask the caller to regenerate them through the compiler-owning workflow; they do not write generated files themselves.
 
 ## OpenSpec CLI policy
 
@@ -114,7 +127,7 @@ This ADR defines policy only; it does not implement migration.
 - OpenSpec CLI runner implementation
 - OpenSpec-native `/aif-plan`
 - migration implementation
-- generated rules compiler implementation
+- full implement/fix/verify integration with generated rules
 - TOON/context/KB
 - AIFHub registry/evals
 - OpenSpec capability detection
@@ -136,5 +149,5 @@ Tradeoffs:
 
 - Commands must distinguish canonical writes from runtime writes.
 - Legacy `.ai-factory/plans` consumers need migration or compatibility logic later.
-- Generated rules need a compiler in a later issue before they can be relied on operationally.
+- Generated rules are operational only when the derived files are present and fresh; consumer migrations still need to preserve canonical OpenSpec precedence.
 - OpenSpec validate/archive remains unavailable until a compatible external CLI is present.

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -44,12 +44,16 @@ These skills must not depend on bridge files.
 `aif-rules-check` must use:
 
 - `.ai-factory/config.yaml`
+- in OpenSpec-native mode, generated rules in priority order:
+  - `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
+  - `.ai-factory/rules/generated/openspec-change-<change-id>.md`
+  - `.ai-factory/rules/generated/openspec-base.md`
 - `.ai-factory/RULES.md` if present
 - `.ai-factory/rules/base.md`
-- active plan-local `rules.md` if present
+- active plan-local `rules.md` only in legacy AI Factory-only mode
 - current changed scope from `git diff` / changed files
 
-When plan-local `rules.md` exists, it overrides project-level and base rules for the scoped gate result.
+OpenSpec-native `aif-rules-check` does not require plan-local `rules.md`. If generated rules are missing or stale, the gate reports `WARN` and asks the caller to regenerate rules; it does not edit or regenerate files. In legacy AI Factory-only mode, plan-local `rules.md` overrides project-level and base rules for the scoped gate result.
 
 ## Required Consumer Context Set
 
@@ -71,6 +75,9 @@ In OpenSpec-native mode:
 - `openspec/changes/<change-id>/design.md`
 - `openspec/changes/<change-id>/tasks.md`
 - `openspec/changes/<change-id>/specs/**/spec.md`
+- `.ai-factory/rules/generated/openspec-base.md`
+- `.ai-factory/rules/generated/openspec-change-<change-id>.md`
+- `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
 - `.ai-factory/state/<change-id>/` for runtime state
 - `.ai-factory/qa/<change-id>/` for QA output
 
@@ -153,6 +160,7 @@ If `config.yaml` is missing or incomplete for the requested operation:
 - `RULES.md` owner: `/aif-rules`
 - `rules/base.md` owner: extension `aif-analyze`
 - `aif-rules-check` owner: extension; reads rules but never writes
+- `.ai-factory/rules/generated/*.md` owner: OpenSpec generated rules compiler; derived from `openspec/specs/**/spec.md` and `openspec/changes/<change-id>/specs/**/spec.md`, safe to delete and regenerate
 - `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md` owner in OpenSpec-native mode: built-in `/aif-plan` with extension injection rules
 - OpenSpec-native refinement owner: built-in `/aif-improve` with extension injection rules; it preserves user edits and updates only canonical OpenSpec artifacts
 - `.ai-factory/plans/<plan-id>.md` owner in legacy AI Factory-only mode: built-in `/aif-plan` with extension injection rules

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -1,0 +1,970 @@
+// openspec-rules-compiler.mjs - derive AI Factory rule guidance from OpenSpec specs
+import { createHash } from 'node:crypto';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import { detectOpenSpec as defaultDetectOpenSpec, showOpenSpecItem as defaultShowOpenSpecItem } from './openspec-runner.mjs';
+import { normalizeChangeId, resolveActiveChange } from './active-change-resolver.mjs';
+
+const GENERATED_DIR = path.join('.ai-factory', 'rules', 'generated');
+const BASE_FILE = 'openspec-base.md';
+const SECTION_ORDER = new Map([
+  ['Requirements', 0],
+  ['ADDED Requirements', 1],
+  ['MODIFIED Requirements', 2],
+  ['REMOVED Requirements', 3]
+]);
+
+export async function compileOpenSpecRules(changeId, options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const resolverResult = await resolveActiveChange({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId,
+    getCurrentBranch: options.getCurrentBranch
+  });
+
+  if (!resolverResult.ok) {
+    return createCompilerResult({
+      ok: false,
+      warnings: resolverResult.warnings,
+      errors: resolverResult.errors
+    });
+  }
+
+  const collected = await collectOpenSpecRuleSources(resolverResult.changeId, {
+    ...options,
+    rootDir
+  });
+
+  if (!collected.ok) {
+    return createCompilerResult({
+      ok: false,
+      changeId: resolverResult.changeId,
+      mode: collected.mode,
+      warnings: [...resolverResult.warnings, ...collected.warnings],
+      errors: collected.errors,
+      sources: collected.sources
+    });
+  }
+
+  const rendered = renderGeneratedRules(collected.sources, {
+    ...options,
+    changeId: resolverResult.changeId
+  });
+  const written = await writeGeneratedRules(resolverResult.changeId, rendered, {
+    ...options,
+    rootDir
+  });
+
+  if (!written.ok) {
+    return createCompilerResult({
+      ok: false,
+      changeId: resolverResult.changeId,
+      mode: collected.mode,
+      warnings: [...resolverResult.warnings, ...collected.warnings, ...rendered.warnings, ...written.warnings],
+      errors: written.errors,
+      sources: collected.sources,
+      files: written.files
+    });
+  }
+
+  return createCompilerResult({
+    ok: true,
+    changeId: resolverResult.changeId,
+    mode: collected.mode,
+    warnings: [...resolverResult.warnings, ...collected.warnings, ...rendered.warnings, ...written.warnings],
+    errors: [],
+    sources: collected.sources,
+    files: written.files
+  });
+}
+
+export async function collectOpenSpecRuleSources(changeId, options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return createSourceResult({
+      ok: false,
+      errors: [normalized.error]
+    });
+  }
+
+  const resolvedChangeId = normalized.changeId;
+  const changeDir = path.join(rootDir, 'openspec', 'changes', resolvedChangeId);
+
+  if (!await isDirectory(changeDir)) {
+    return createSourceResult({
+      ok: false,
+      errors: [
+        {
+          code: 'explicit-change-not-found',
+          message: `OpenSpec change '${resolvedChangeId}' was not found.`
+        }
+      ]
+    });
+  }
+
+  const warnings = [];
+  const cli = await detectOpenSpecCapability(rootDir, options);
+  warnings.push(...cli.warnings);
+
+  const baseSpecsDir = path.join(rootDir, 'openspec', 'specs');
+  const changeSpecsDir = path.join(changeDir, 'specs');
+  const baseFiles = await collectSpecFiles(baseSpecsDir);
+  const changeFiles = await collectSpecFiles(changeSpecsDir);
+  const sources = [];
+
+  for (const filePath of baseFiles) {
+    const source = await readRuleSource(filePath, {
+      rootDir,
+      kind: 'base',
+      specsDir: baseSpecsDir,
+      changeId: null,
+      cli
+    });
+    warnings.push(...source.warnings);
+    sources.push(source.item);
+  }
+
+  for (const filePath of changeFiles) {
+    const source = await readRuleSource(filePath, {
+      rootDir,
+      kind: 'change',
+      specsDir: changeSpecsDir,
+      changeId: resolvedChangeId,
+      cli
+    });
+    warnings.push(...source.warnings);
+    sources.push(source.item);
+  }
+
+  const mode = chooseMode(sources, cli);
+
+  return createSourceResult({
+    ok: true,
+    mode,
+    warnings: dedupeDiagnostics(warnings),
+    sources: sortSources(sources)
+  });
+}
+
+export function renderGeneratedRules(sources, options = {}) {
+  const normalized = normalizeChangeId(options.changeId);
+  const changeId = normalized.ok ? normalized.changeId : options.changeId;
+  const sortedSources = sortSources(Array.from(sources ?? []));
+  const baseSources = sortedSources.filter((source) => source.kind === 'base');
+  const changeSources = sortedSources.filter((source) => source.kind === 'change');
+  const baseContent = renderDocument({
+    kind: 'base',
+    title: 'Base OpenSpec Rules',
+    changeId,
+    sources: baseSources,
+    emptyMessage: 'No base OpenSpec requirements found.'
+  });
+  const changeContent = renderDocument({
+    kind: 'change',
+    title: 'Change OpenSpec Rules',
+    changeId,
+    sources: changeSources,
+    emptyMessage: 'No OpenSpec change requirements found.'
+  });
+  const mergedContent = renderDocument({
+    kind: 'merged',
+    title: 'Merged OpenSpec Rules',
+    changeId,
+    sources: sortedSources,
+    emptyMessage: 'No OpenSpec requirements found.'
+  });
+
+  return {
+    ok: true,
+    changeId,
+    warnings: [],
+    files: [
+      {
+        kind: 'base',
+        fileName: BASE_FILE,
+        content: baseContent
+      },
+      {
+        kind: 'change',
+        fileName: `openspec-change-${changeId}.md`,
+        content: changeContent
+      },
+      {
+        kind: 'merged',
+        fileName: `openspec-merged-${changeId}.md`,
+        content: mergedContent
+      }
+    ]
+  };
+}
+
+export async function writeGeneratedRules(changeId, rendered, options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return createWriteResult({
+      ok: false,
+      errors: [normalized.error]
+    });
+  }
+
+  const generatedDir = path.resolve(rootDir, GENERATED_DIR);
+  const renderedFiles = Array.from(rendered?.files ?? []);
+  const expectedNames = new Set([
+    BASE_FILE,
+    `openspec-change-${normalized.changeId}.md`,
+    `openspec-merged-${normalized.changeId}.md`
+  ]);
+  const files = [];
+
+  if (renderedFiles.length !== 3 || renderedFiles.some((file) => !expectedNames.has(file.fileName))) {
+    return createWriteResult({
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-rendered-files',
+          message: 'Rendered rules must contain exactly the base, change, and merged generated files.'
+        }
+      ]
+    });
+  }
+
+  await mkdir(generatedDir, { recursive: true });
+
+  for (const renderedFile of renderedFiles) {
+    const targetPath = path.resolve(generatedDir, renderedFile.fileName);
+
+    if (!isWithinDirectory(targetPath, generatedDir)) {
+      return createWriteResult({
+        ok: false,
+        files,
+        errors: [
+          {
+            code: 'unsafe-generated-path',
+            message: `Generated output path escapes '${GENERATED_DIR}': ${renderedFile.fileName}`
+          }
+        ]
+      });
+    }
+
+    await writeFile(targetPath, renderedFile.content, 'utf8');
+    files.push({
+      kind: renderedFile.kind,
+      path: targetPath,
+      relativePath: toPosix(path.relative(rootDir, targetPath)),
+      written: true
+    });
+  }
+
+  return createWriteResult({
+    ok: true,
+    files
+  });
+}
+
+export function parseSpecMarkdownFallback(markdown, options = {}) {
+  const warnings = [];
+  const requirements = [];
+  const lines = String(markdown ?? '').replace(/\r\n/g, '\n').split('\n');
+  let currentSection = 'Requirements';
+  let currentRequirement = null;
+  let currentScenario = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const sectionMatch = line.match(/^#{2,6}\s+((?:ADDED|MODIFIED|REMOVED)\s+Requirements|Requirements)\s*$/i);
+    const requirementMatch = line.match(/^#{3,6}\s+Requirement:\s*(.+?)\s*$/i);
+    const scenarioMatch = line.match(/^#{4,6}\s+Scenario:\s*(.+?)\s*$/i);
+
+    if (sectionMatch) {
+      currentSection = canonicalSection(sectionMatch[1]);
+      currentScenario = null;
+      continue;
+    }
+
+    if (requirementMatch) {
+      if (currentRequirement !== null) {
+        requirements.push(finalizeRequirement(currentRequirement));
+      }
+
+      currentRequirement = {
+        title: requirementMatch[1].trim(),
+        section: currentSection,
+        bodyLines: [],
+        scenarios: []
+      };
+      currentScenario = null;
+      continue;
+    }
+
+    if (scenarioMatch) {
+      if (currentRequirement === null) {
+        warnings.push({
+          code: 'scenario-without-requirement',
+          message: `Scenario '${scenarioMatch[1].trim()}' has no preceding requirement.`
+        });
+        continue;
+      }
+
+      currentScenario = {
+        title: scenarioMatch[1].trim(),
+        steps: []
+      };
+      currentRequirement.scenarios.push(currentScenario);
+      continue;
+    }
+
+    if (currentScenario !== null) {
+      const step = normalizeMarkdownLine(line);
+
+      if (step.length > 0) {
+        currentScenario.steps.push(step);
+      }
+      continue;
+    }
+
+    if (currentRequirement !== null) {
+      const bodyLine = line.trim();
+
+      if (bodyLine.length > 0) {
+        currentRequirement.bodyLines.push(bodyLine);
+      }
+    }
+  }
+
+  if (currentRequirement !== null) {
+    requirements.push(finalizeRequirement(currentRequirement));
+  }
+
+  if (requirements.length === 0 && String(markdown ?? '').trim().length > 0) {
+    warnings.push({
+      code: 'no-requirements-found',
+      message: 'No OpenSpec requirements were parsed from markdown fallback input.'
+    });
+  }
+
+  return {
+    requirements: sortRequirements(requirements),
+    warnings,
+    source: options.source ?? null
+  };
+}
+
+export function extractRequirementsFromShowJson(json, options = {}) {
+  const warnings = [];
+  const requirements = [];
+  const seen = new Set();
+
+  visitJsonNode(json, {
+    section: options.section ?? 'Requirements',
+    requirements,
+    warnings,
+    seen
+  });
+
+  return {
+    requirements: sortRequirements(requirements),
+    warnings
+  };
+}
+
+async function detectOpenSpecCapability(rootDir, options) {
+  const detectOpenSpec = options.detectOpenSpec ?? defaultDetectOpenSpec;
+  const showOpenSpecItem = options.showOpenSpecItem ?? defaultShowOpenSpecItem;
+
+  try {
+    const detection = await detectOpenSpec({
+      cwd: rootDir,
+      env: options.env,
+      executor: options.executor,
+      nodeVersion: options.nodeVersion
+    });
+    const warnings = [];
+
+    if (!detection.available || !detection.canValidate) {
+      warnings.push(...normalizeDetectionWarnings(detection));
+    }
+
+    return {
+      detection,
+      showOpenSpecItem,
+      available: Boolean(detection.available && detection.canValidate),
+      runOptions: {
+        command: options.command,
+        env: options.env,
+        executor: options.executor
+      },
+      warnings
+    };
+  } catch (err) {
+    return {
+      detection: null,
+      showOpenSpecItem,
+      available: false,
+      runOptions: {
+        command: options.command,
+        env: options.env,
+        executor: options.executor
+      },
+      warnings: [
+        {
+          code: 'openspec-detection-failed',
+          message: 'OpenSpec CLI detection failed; using filesystem fallback.',
+          detail: err?.message ?? 'Unknown detection error.'
+        }
+      ]
+    };
+  }
+}
+
+async function readRuleSource(filePath, context) {
+  const content = await readFile(filePath, 'utf8');
+  const relativePath = toPosix(path.relative(context.rootDir, filePath));
+  const capability = toPosix(path.relative(context.specsDir, path.dirname(filePath)));
+  const warnings = [];
+  let parseResult = null;
+  let extractionMode = 'filesystem-fallback';
+
+  if (context.cli.available) {
+    const cliResult = await tryReadRequirementsFromCli(capability, context);
+    warnings.push(...cliResult.warnings);
+
+    if (cliResult.requirements.length > 0) {
+      parseResult = cliResult;
+      extractionMode = 'cli-json';
+    }
+  }
+
+  if (parseResult === null) {
+    parseResult = parseSpecMarkdownFallback(content, { source: relativePath });
+    warnings.push(...parseResult.warnings.map((warning) => ({
+      ...warning,
+      path: relativePath
+    })));
+  }
+
+  const fingerprint = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+  const requirements = parseResult.requirements.map((requirement) => ({
+    ...requirement,
+    kind: context.kind,
+    changeId: context.kind === 'change' ? context.changeId : null,
+    capability,
+    relativePath,
+    fingerprint
+  }));
+
+  return {
+    item: {
+      kind: context.kind,
+      changeId: context.kind === 'change' ? context.changeId : null,
+      capability,
+      relativePath,
+      path: filePath,
+      fingerprint,
+      mode: extractionMode,
+      requirements
+    },
+    warnings
+  };
+}
+
+async function tryReadRequirementsFromCli(capability, context) {
+  try {
+    const result = await context.cli.showOpenSpecItem(capability, {
+      ...context.cli.runOptions,
+      cwd: context.rootDir,
+      type: 'spec',
+      deltasOnly: context.kind === 'change'
+    });
+
+    if (!result.ok) {
+      return {
+        requirements: [],
+        warnings: [
+          {
+            code: 'cli-json-unavailable',
+            message: `OpenSpec CLI JSON was unavailable for '${capability}'; using filesystem fallback.`,
+            detail: result.error?.message ?? null
+          }
+        ]
+      };
+    }
+
+    const extracted = extractRequirementsFromShowJson(result.json);
+
+    if (extracted.requirements.length === 0) {
+      return {
+        requirements: [],
+        warnings: [
+          {
+            code: 'cli-json-empty',
+            message: `OpenSpec CLI JSON for '${capability}' did not contain requirements; using filesystem fallback.`
+          },
+          ...extracted.warnings
+        ]
+      };
+    }
+
+    return extracted;
+  } catch (err) {
+    return {
+      requirements: [],
+      warnings: [
+        {
+          code: 'cli-json-error',
+          message: `OpenSpec CLI JSON extraction failed for '${capability}'; using filesystem fallback.`,
+          detail: err?.message ?? 'Unknown CLI JSON extraction error.'
+        }
+      ]
+    };
+  }
+}
+
+async function collectSpecFiles(rootDir) {
+  if (!await isDirectory(rootDir)) {
+    return [];
+  }
+
+  const files = [];
+  await collectSpecFilesRecursive(rootDir, files);
+  return files.sort((left, right) => toPosix(left).localeCompare(toPosix(right)));
+}
+
+async function collectSpecFilesRecursive(dirPath, files) {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const sortedEntries = entries.sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of sortedEntries) {
+    const childPath = path.join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      await collectSpecFilesRecursive(childPath, files);
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === 'spec.md') {
+      files.push(childPath);
+    }
+  }
+}
+
+function renderDocument({ kind, title, changeId, sources, emptyMessage }) {
+  const lines = [
+    '# Generated OpenSpec Rules',
+    '',
+    `View: ${title}`,
+    'Source of truth: OpenSpec canonical specs',
+    'Generated files are derived guidance and are safe to delete, overwrite, and regenerate.'
+  ];
+
+  if (kind !== 'base') {
+    lines.push(`Change: ${changeId}`);
+  }
+
+  lines.push('', '## Source Fingerprints');
+
+  if (sources.length === 0) {
+    lines.push('', emptyMessage, '');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const source of sources) {
+    lines.push(`- ${source.fingerprint} ${source.relativePath}`);
+  }
+
+  const requirements = flattenRequirements(sources);
+
+  if (requirements.length === 0) {
+    lines.push('', emptyMessage, '');
+    return `${lines.join('\n')}\n`;
+  }
+
+  let previousSection = null;
+
+  for (const requirement of requirements) {
+    if (requirement.section !== previousSection) {
+      lines.push('', `## ${requirement.section}`);
+      previousSection = requirement.section;
+    }
+
+    lines.push('', `### Requirement: ${requirement.title}`, '');
+    lines.push('Source:');
+    lines.push(`- Kind: ${requirement.kind}`);
+    lines.push(`- Path: ${requirement.relativePath}`);
+    lines.push(`- Capability: ${requirement.capability}`);
+    lines.push(`- Change: ${requirement.changeId ?? 'none'}`);
+    lines.push(`- Section: ${requirement.section}`);
+    lines.push(`- Fingerprint: ${requirement.fingerprint}`);
+
+    if (requirement.body.length > 0) {
+      lines.push('', ...requirement.body);
+    }
+
+    for (const scenario of requirement.scenarios) {
+      lines.push('', `#### Scenario: ${scenario.title}`);
+
+      for (const step of scenario.steps) {
+        lines.push(`- ${step}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+function flattenRequirements(sources) {
+  return sources
+    .flatMap((source) => source.requirements)
+    .sort(compareRequirements);
+}
+
+function sortSources(sources) {
+  return Array.from(sources).sort((left, right) => {
+    const kindComparison = compareKind(left.kind, right.kind);
+
+    if (kindComparison !== 0) {
+      return kindComparison;
+    }
+
+    return left.capability.localeCompare(right.capability)
+      || left.relativePath.localeCompare(right.relativePath);
+  });
+}
+
+function sortRequirements(requirements) {
+  return Array.from(requirements).sort(compareRequirements);
+}
+
+function compareRequirements(left, right) {
+  return compareKind(left.kind, right.kind)
+    || left.capability.localeCompare(right.capability)
+    || sectionRank(left.section) - sectionRank(right.section)
+    || left.title.localeCompare(right.title)
+    || firstScenarioTitle(left).localeCompare(firstScenarioTitle(right));
+}
+
+function compareKind(left, right) {
+  return kindRank(left) - kindRank(right);
+}
+
+function kindRank(kind) {
+  return kind === 'base' ? 0 : 1;
+}
+
+function sectionRank(section) {
+  return SECTION_ORDER.get(section) ?? 99;
+}
+
+function firstScenarioTitle(requirement) {
+  return requirement.scenarios[0]?.title ?? '';
+}
+
+function canonicalSection(section) {
+  const normalized = String(section ?? '').trim().replace(/\s+/g, ' ');
+  const lower = normalized.toLowerCase();
+
+  if (lower === 'added requirements') {
+    return 'ADDED Requirements';
+  }
+
+  if (lower === 'modified requirements') {
+    return 'MODIFIED Requirements';
+  }
+
+  if (lower === 'removed requirements') {
+    return 'REMOVED Requirements';
+  }
+
+  return 'Requirements';
+}
+
+function finalizeRequirement(requirement) {
+  return {
+    title: requirement.title,
+    section: requirement.section,
+    body: requirement.bodyLines,
+    scenarios: requirement.scenarios.map((scenario) => ({
+      title: scenario.title,
+      steps: scenario.steps
+    })),
+    kind: requirement.kind ?? 'base',
+    changeId: requirement.changeId ?? null,
+    capability: requirement.capability ?? '',
+    relativePath: requirement.relativePath ?? '',
+    fingerprint: requirement.fingerprint ?? ''
+  };
+}
+
+function normalizeMarkdownLine(line) {
+  return line.trim().replace(/^[-*]\s+/, '').trim();
+}
+
+function visitJsonNode(node, state) {
+  if (node === null || node === undefined) {
+    return;
+  }
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      visitJsonNode(item, state);
+    }
+    return;
+  }
+
+  if (typeof node !== 'object') {
+    return;
+  }
+
+  const section = inferJsonSection(node, state.section);
+
+  if (looksLikeRequirement(node)) {
+    const requirement = normalizeJsonRequirement(node, section);
+    const key = `${requirement.section}:${requirement.title}`;
+
+    if (!state.seen.has(key)) {
+      state.seen.add(key);
+      state.requirements.push(requirement);
+    }
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'requirements' || key === 'reqs') {
+      visitJsonRequirementsCollection(value, {
+        ...state,
+        section
+      });
+      continue;
+    }
+
+    if (/^(added|modified|removed)$/i.test(key)) {
+      visitJsonRequirementsCollection(value, {
+        ...state,
+        section: canonicalSection(`${key.toUpperCase()} Requirements`)
+      });
+      continue;
+    }
+
+    if (/^(added|modified|removed)\s*Requirements$/i.test(key)) {
+      visitJsonRequirementsCollection(value, {
+        ...state,
+        section: canonicalSection(key)
+      });
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      visitJsonNode(value, {
+        ...state,
+        section
+      });
+    }
+  }
+}
+
+function visitJsonRequirementsCollection(value, state) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitJsonNode(item, state);
+    }
+    return;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    for (const [title, item] of Object.entries(value)) {
+      if (item !== null && typeof item === 'object') {
+        visitJsonNode({
+          title,
+          ...item
+        }, state);
+      }
+    }
+  }
+}
+
+function looksLikeRequirement(node) {
+  return typeof (node.title ?? node.name ?? node.requirement) === 'string'
+    && (
+      node.description !== undefined
+      || node.text !== undefined
+      || node.body !== undefined
+      || node.scenarios !== undefined
+      || node.scenario !== undefined
+    );
+}
+
+function normalizeJsonRequirement(node, section) {
+  const title = String(node.title ?? node.name ?? node.requirement).trim();
+  const body = normalizeBody(node.description ?? node.text ?? node.body);
+  const scenarios = normalizeJsonScenarios(node.scenarios ?? node.scenario);
+
+  return {
+    title,
+    section,
+    body,
+    scenarios,
+    kind: 'base',
+    changeId: null,
+    capability: '',
+    relativePath: '',
+    fingerprint: ''
+  };
+}
+
+function normalizeJsonScenarios(input) {
+  if (input === undefined || input === null) {
+    return [];
+  }
+
+  const values = Array.isArray(input) ? input : [input];
+  return values.map((scenario, index) => {
+    if (typeof scenario === 'string') {
+      return {
+        title: `Scenario ${index + 1}`,
+        steps: normalizeBody(scenario)
+      };
+    }
+
+    const title = String(scenario.title ?? scenario.name ?? `Scenario ${index + 1}`).trim();
+    const steps = normalizeBody(
+      scenario.steps
+      ?? scenario.given
+      ?? scenario.when
+      ?? scenario.then
+      ?? scenario.description
+      ?? scenario.body
+      ?? ''
+    );
+
+    return {
+      title,
+      steps
+    };
+  });
+}
+
+function normalizeBody(input) {
+  if (input === undefined || input === null) {
+    return [];
+  }
+
+  if (Array.isArray(input)) {
+    return input.flatMap((item) => normalizeBody(item));
+  }
+
+  return String(input)
+    .split(/\r?\n/)
+    .map(normalizeMarkdownLine)
+    .filter((line) => line.length > 0);
+}
+
+function inferJsonSection(node, fallback) {
+  const candidate = node.section ?? node.type ?? node.kind ?? fallback;
+  return canonicalSection(String(candidate).includes('Requirements') ? candidate : fallback);
+}
+
+function chooseMode(sources, cli) {
+  if (!cli.available) {
+    return 'filesystem-fallback';
+  }
+
+  const modes = new Set(sources.map((source) => source.mode));
+
+  if (modes.size === 1 && modes.has('cli-json')) {
+    return 'cli-json';
+  }
+
+  if (modes.has('cli-json')) {
+    return 'mixed';
+  }
+
+  return 'filesystem-fallback';
+}
+
+function normalizeDetectionWarnings(detection) {
+  if (Array.isArray(detection.errors) && detection.errors.length > 0) {
+    return detection.errors.map((error) => ({
+      code: error.code ?? detection.reason ?? 'openspec-unavailable',
+      message: error.message ?? 'OpenSpec CLI is unavailable; using filesystem fallback.'
+    }));
+  }
+
+  return [
+    {
+      code: detection.reason ?? 'openspec-unavailable',
+      message: 'OpenSpec CLI is unavailable or unsupported; using filesystem fallback.'
+    }
+  ];
+}
+
+function createCompilerResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? false,
+    changeId: overrides.changeId ?? null,
+    mode: overrides.mode ?? 'failed',
+    warnings: dedupeDiagnostics(overrides.warnings ?? []),
+    errors: overrides.errors ?? [],
+    sources: overrides.sources ?? [],
+    files: overrides.files ?? []
+  };
+}
+
+function createSourceResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? false,
+    mode: overrides.mode ?? 'failed',
+    warnings: dedupeDiagnostics(overrides.warnings ?? []),
+    errors: overrides.errors ?? [],
+    sources: overrides.sources ?? []
+  };
+}
+
+function createWriteResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? false,
+    warnings: dedupeDiagnostics(overrides.warnings ?? []),
+    errors: overrides.errors ?? [],
+    files: overrides.files ?? []
+  };
+}
+
+function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  const result = [];
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.code ?? ''}:${diagnostic.message ?? ''}:${diagnostic.path ?? ''}`;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(diagnostic);
+    }
+  }
+
+  return result;
+}
+
+async function isDirectory(targetPath) {
+  try {
+    const item = await stat(targetPath);
+    return item.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isWithinDirectory(targetPath, dirPath) {
+  const relative = path.relative(dirPath, targetPath);
+  return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function toPosix(value) {
+  return String(value).replaceAll(path.sep, '/');
+}

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -221,9 +221,15 @@ export async function writeGeneratedRules(changeId, rendered, options = {}) {
     `openspec-change-${normalized.changeId}.md`,
     `openspec-merged-${normalized.changeId}.md`
   ]);
+  const renderedNames = renderedFiles.map((file) => file.fileName);
+  const renderedNameSet = new Set(renderedNames);
   const files = [];
 
-  if (renderedFiles.length !== 3 || renderedFiles.some((file) => !expectedNames.has(file.fileName))) {
+  if (
+    renderedFiles.length !== expectedNames.size
+    || renderedNameSet.size !== expectedNames.size
+    || renderedNames.some((fileName) => !expectedNames.has(fileName))
+  ) {
     return createWriteResult({
       ok: false,
       errors: [

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -833,21 +833,26 @@ function normalizeJsonScenarios(input) {
     }
 
     const title = String(scenario.title ?? scenario.name ?? `Scenario ${index + 1}`).trim();
-    const steps = normalizeBody(
-      scenario.steps
-      ?? scenario.given
-      ?? scenario.when
-      ?? scenario.then
-      ?? scenario.description
-      ?? scenario.body
-      ?? ''
-    );
+    const steps = normalizeJsonScenarioSteps(scenario);
 
     return {
       title,
       steps
     };
   });
+}
+
+function normalizeJsonScenarioSteps(scenario) {
+  const fields = [
+    scenario.steps,
+    scenario.given,
+    scenario.when,
+    scenario.then,
+    scenario.description,
+    scenario.body
+  ];
+
+  return fields.flatMap((field) => normalizeBody(field));
 }
 
 function normalizeBody(input) {

--- a/scripts/openspec-rules-compiler.test.mjs
+++ b/scripts/openspec-rules-compiler.test.mjs
@@ -1,0 +1,488 @@
+// openspec-rules-compiler.test.mjs - tests for OpenSpec generated rules compiler
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const tempRoots = [];
+
+async function loadCompiler() {
+  return import('./openspec-rules-compiler.mjs');
+}
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-openspec-rules-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createChange(rootDir, changeId, specs = {}) {
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, `# ${changeId}\n`);
+
+  for (const [specPath, content] of Object.entries(specs)) {
+    await writeFixture(rootDir, `openspec/changes/${changeId}/specs/${specPath}`, content);
+  }
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readGenerated(rootDir, fileName) {
+  return readFile(path.join(rootDir, '.ai-factory', 'rules', 'generated', fileName), 'utf8');
+}
+
+function missingCliDetection() {
+  return {
+    available: false,
+    canValidate: false,
+    canArchive: false,
+    version: null,
+    supportedRange: '>=1.3.1 <2.0.0',
+    versionSupported: false,
+    requiresNode: '>=20.19.0',
+    nodeVersion: '20.19.0',
+    nodeSupported: true,
+    command: 'openspec',
+    reason: 'missing-cli',
+    errors: [
+      {
+        code: 'missing-cli',
+        message: 'OpenSpec CLI is not available on PATH.'
+      }
+    ]
+  };
+}
+
+function compilerOptions(rootDir, overrides = {}) {
+  return {
+    rootDir,
+    detectOpenSpec: async () => missingCliDetection(),
+    getCurrentBranch: async () => 'feat/add-generated-rules',
+    ...overrides
+  };
+}
+
+const baseBillingSpec = `# Billing
+
+## Requirements
+
+### Requirement: Track Usage
+
+The system MUST track customer usage.
+
+#### Scenario: usage is captured
+
+- GIVEN a billable account
+- WHEN usage is reported
+- THEN the usage entry is stored
+`;
+
+const deltaAuthSpec = `# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: Require MFA
+
+The system MUST require MFA for administrators.
+
+#### Scenario: administrator signs in
+
+- GIVEN an administrator account
+- WHEN the administrator signs in
+- THEN an MFA challenge is required
+`;
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec rules compiler API', () => {
+  it('exports the required public functions', async () => {
+    const {
+      collectOpenSpecRuleSources,
+      compileOpenSpecRules,
+      extractRequirementsFromShowJson,
+      parseSpecMarkdownFallback,
+      renderGeneratedRules,
+      writeGeneratedRules
+    } = await loadCompiler();
+
+    assert.equal(typeof compileOpenSpecRules, 'function');
+    assert.equal(typeof collectOpenSpecRuleSources, 'function');
+    assert.equal(typeof renderGeneratedRules, 'function');
+    assert.equal(typeof writeGeneratedRules, 'function');
+    assert.equal(typeof parseSpecMarkdownFallback, 'function');
+    assert.equal(typeof extractRequirementsFromShowJson, 'function');
+  });
+});
+
+describe('compileOpenSpecRules filesystem fallback', () => {
+  it('compiles base specs only and leaves canonical OpenSpec files untouched', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'add-generated-rules');
+    const specPath = await writeFixture(rootDir, 'openspec/specs/billing/spec.md', baseBillingSpec);
+
+    const result = await compileOpenSpecRules('add-generated-rules', compilerOptions(rootDir));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, 'add-generated-rules');
+    assert.equal(result.mode, 'filesystem-fallback');
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.files.length, 3);
+    assert.equal(result.files.every((file) => path.isAbsolute(file.path) && file.written), true);
+    assert.equal(result.sources.some((source) => source.kind === 'base' && source.relativePath === 'openspec/specs/billing/spec.md'), true);
+    assert.equal(result.warnings.some((warning) => warning.code === 'missing-cli'), true);
+
+    const baseRules = await readGenerated(rootDir, 'openspec-base.md');
+    const changeRules = await readGenerated(rootDir, 'openspec-change-add-generated-rules.md');
+    const mergedRules = await readGenerated(rootDir, 'openspec-merged-add-generated-rules.md');
+
+    assert.match(baseRules, /^# Generated OpenSpec Rules/m);
+    assert.match(baseRules, /openspec\/specs\/billing\/spec\.md/);
+    assert.match(baseRules, /Requirement: Track Usage/);
+    assert.match(baseRules, /Scenario: usage is captured/);
+    assert.match(baseRules, /GIVEN a billable account/);
+    assert.match(baseRules, /sha256:/);
+    assert.doesNotMatch(baseRules, /\d{4}-\d{2}-\d{2}T/);
+    assert.match(changeRules, /No OpenSpec change requirements found/);
+    assert.match(mergedRules, /Requirement: Track Usage/);
+    assert.equal(await readFile(specPath, 'utf8'), baseBillingSpec);
+    assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-generated-rules', '.ai-factory')), false);
+  });
+
+  it('compiles delta specs only and includes change metadata in change and merged output', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'add-mfa', {
+      'auth/spec.md': deltaAuthSpec
+    });
+
+    const result = await compileOpenSpecRules('add-mfa', compilerOptions(rootDir));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.sources.some((source) => source.kind === 'change' && source.changeId === 'add-mfa'), true);
+
+    const baseRules = await readGenerated(rootDir, 'openspec-base.md');
+    const changeRules = await readGenerated(rootDir, 'openspec-change-add-mfa.md');
+    const mergedRules = await readGenerated(rootDir, 'openspec-merged-add-mfa.md');
+
+    assert.match(baseRules, /No base OpenSpec requirements found/);
+    assert.match(changeRules, /Change: add-mfa/);
+    assert.match(changeRules, /ADDED Requirements/);
+    assert.match(changeRules, /Requirement: Require MFA/);
+    assert.match(changeRules, /openspec\/changes\/add-mfa\/specs\/auth\/spec\.md/);
+    assert.match(mergedRules, /Change: add-mfa/);
+    assert.match(mergedRules, /Requirement: Require MFA/);
+  });
+
+  it('writes stable merged output with base requirements before delta requirements', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, 'openspec/specs/zeta/spec.md', `# Zeta
+
+## Requirements
+
+### Requirement: Base Zeta
+
+The system MUST keep zeta behavior.
+`);
+    await writeFixture(rootDir, 'openspec/specs/alpha/spec.md', `# Alpha
+
+## Requirements
+
+### Requirement: Base Alpha
+
+The system MUST keep alpha behavior.
+`);
+    await createChange(rootDir, 'sort-generated-rules', {
+      'beta/spec.md': `# Beta
+
+## ADDED Requirements
+
+### Requirement: Delta Beta
+
+The system MUST add beta behavior.
+`
+    });
+
+    await compileOpenSpecRules('sort-generated-rules', compilerOptions(rootDir));
+    const firstBase = await readGenerated(rootDir, 'openspec-base.md');
+    const firstChange = await readGenerated(rootDir, 'openspec-change-sort-generated-rules.md');
+    const firstMerged = await readGenerated(rootDir, 'openspec-merged-sort-generated-rules.md');
+
+    await compileOpenSpecRules('sort-generated-rules', compilerOptions(rootDir));
+    const secondBase = await readGenerated(rootDir, 'openspec-base.md');
+    const secondChange = await readGenerated(rootDir, 'openspec-change-sort-generated-rules.md');
+    const secondMerged = await readGenerated(rootDir, 'openspec-merged-sort-generated-rules.md');
+
+    assert.equal(secondBase, firstBase);
+    assert.equal(secondChange, firstChange);
+    assert.equal(secondMerged, firstMerged);
+    assert.ok(secondBase.indexOf('Requirement: Base Alpha') < secondBase.indexOf('Requirement: Base Zeta'));
+    assert.ok(secondMerged.indexOf('Requirement: Base Alpha') < secondMerged.indexOf('Requirement: Delta Beta'));
+  });
+
+  it('fails clearly for an explicit missing change and writes no generated files', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'available-change');
+
+    const result = await compileOpenSpecRules('missing-change', compilerOptions(rootDir));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.changeId, null);
+    assert.equal(result.files.length, 0);
+    assert.equal(result.errors[0].code, 'explicit-change-not-found');
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'rules', 'generated')), false);
+  });
+
+  it('rejects unsafe change ids before writing generated files', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+
+    const result = await compileOpenSpecRules('../escape', compilerOptions(rootDir));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.changeId, null);
+    assert.equal(result.files.length, 0);
+    assert.equal(result.errors[0].code, 'invalid-change-id');
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'rules', 'generated')), false);
+  });
+
+  it('resolves the active change when no change id is provided', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await createChange(rootDir, 'branch-rules', {
+      'auth/spec.md': deltaAuthSpec
+    });
+
+    const result = await compileOpenSpecRules(undefined, compilerOptions(rootDir, {
+      getCurrentBranch: async () => 'feat/branch-rules'
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, 'branch-rules');
+    assert.equal(result.files.some((file) => file.relativePath === '.ai-factory/rules/generated/openspec-merged-branch-rules.md'), true);
+  });
+});
+
+describe('compileOpenSpecRules CLI JSON preference', () => {
+  it('prefers compatible OpenSpec CLI JSON requirements when available', async () => {
+    const { compileOpenSpecRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, 'openspec/specs/billing/spec.md', `# Billing
+
+## Requirements
+
+### Requirement: Fallback Base
+
+The fallback parser SHOULD NOT be used when CLI JSON is complete.
+`);
+    await createChange(rootDir, 'cli-rules', {
+      'auth/spec.md': `# Auth
+
+## ADDED Requirements
+
+### Requirement: Fallback Delta
+
+The fallback parser SHOULD NOT be used when CLI JSON is complete.
+`
+    });
+    const calls = [];
+
+    const result = await compileOpenSpecRules('cli-rules', compilerOptions(rootDir, {
+      detectOpenSpec: async () => ({
+        available: true,
+        canValidate: true,
+        canArchive: true,
+        version: '1.3.1',
+        supportedRange: '>=1.3.1 <2.0.0',
+        versionSupported: true,
+        requiresNode: '>=20.19.0',
+        nodeVersion: '20.19.0',
+        nodeSupported: true,
+        command: 'openspec',
+        reason: null,
+        errors: []
+      }),
+      showOpenSpecItem: async (itemName, options) => {
+        calls.push({ itemName, options });
+        return {
+          ok: true,
+          json: {
+            requirements: [
+              {
+                title: `CLI ${itemName}`,
+                description: `Requirement from CLI for ${itemName}.`,
+                scenarios: [
+                  {
+                    title: 'cli scenario',
+                    steps: ['GIVEN CLI JSON', 'WHEN compiled', 'THEN generated rules use it']
+                  }
+                ]
+              }
+            ]
+          },
+          error: null
+        };
+      }
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.mode, 'cli-json');
+    assert.deepEqual(calls.map((call) => [call.itemName, call.options.deltasOnly]), [
+      ['billing', false],
+      ['auth', true]
+    ]);
+
+    const mergedRules = await readGenerated(rootDir, 'openspec-merged-cli-rules.md');
+    assert.match(mergedRules, /Requirement: CLI billing/);
+    assert.match(mergedRules, /Requirement: CLI auth/);
+    assert.doesNotMatch(mergedRules, /Fallback Base/);
+    assert.doesNotMatch(mergedRules, /Fallback Delta/);
+  });
+});
+
+describe('OpenSpec requirements extraction helpers', () => {
+  it('parses documented markdown fallback sections, requirements, and scenarios', async () => {
+    const { parseSpecMarkdownFallback } = await loadCompiler();
+
+    const parsed = parseSpecMarkdownFallback(`# Capability
+
+## Requirements
+
+### Requirement: Base Behavior
+
+The system MUST keep base behavior.
+
+#### Scenario: base scenario
+
+- GIVEN base state
+- WHEN base action runs
+- THEN base outcome occurs
+
+## MODIFIED Requirements
+
+### Requirement: Modified Behavior
+
+The system MUST update behavior.
+
+## REMOVED Requirements
+
+### Requirement: Removed Behavior
+
+The system MUST remove old behavior.
+`);
+
+    assert.deepEqual(parsed.requirements.map((requirement) => [requirement.section, requirement.title]), [
+      ['Requirements', 'Base Behavior'],
+      ['MODIFIED Requirements', 'Modified Behavior'],
+      ['REMOVED Requirements', 'Removed Behavior']
+    ]);
+    assert.deepEqual(parsed.requirements[0].scenarios[0], {
+      title: 'base scenario',
+      steps: ['GIVEN base state', 'WHEN base action runs', 'THEN base outcome occurs']
+    });
+  });
+
+  it('extracts requirements from nested OpenSpec show JSON shapes', async () => {
+    const { extractRequirementsFromShowJson } = await loadCompiler();
+
+    const extracted = extractRequirementsFromShowJson({
+      spec: {
+        requirements: {
+          'Base JSON': {
+            description: 'The system MUST read base JSON.',
+            scenarios: [
+              {
+                name: 'base json scenario',
+                steps: ['GIVEN JSON', 'WHEN extracted', 'THEN it becomes a requirement']
+              }
+            ]
+          }
+        }
+      },
+      deltas: {
+        added: {
+          requirements: [
+            {
+              title: 'Added JSON',
+              description: 'The system MUST read delta JSON.'
+            }
+          ]
+        }
+      }
+    });
+
+    assert.deepEqual(extracted.requirements.map((requirement) => [requirement.section, requirement.title]), [
+      ['Requirements', 'Base JSON'],
+      ['ADDED Requirements', 'Added JSON']
+    ]);
+    assert.deepEqual(extracted.requirements[0].scenarios[0].steps, [
+      'GIVEN JSON',
+      'WHEN extracted',
+      'THEN it becomes a requirement'
+    ]);
+  });
+});
+
+describe('aif-rules-check OpenSpec-native prompt contract', () => {
+  it('documents the generated rules hierarchy before project and base rules', async () => {
+    const skill = await readFile('skills/aif-rules-check/SKILL.md', 'utf8');
+    const mergedIndex = skill.indexOf('.ai-factory/rules/generated/openspec-merged-<change-id>.md');
+    const changeIndex = skill.indexOf('.ai-factory/rules/generated/openspec-change-<change-id>.md');
+    const baseGeneratedIndex = skill.indexOf('.ai-factory/rules/generated/openspec-base.md');
+    const projectRulesIndex = skill.indexOf('.ai-factory/RULES.md');
+    const baseRulesIndex = skill.indexOf('.ai-factory/rules/base.md');
+
+    assert.notEqual(mergedIndex, -1, 'missing merged generated rules priority');
+    assert.notEqual(changeIndex, -1, 'missing change generated rules priority');
+    assert.notEqual(baseGeneratedIndex, -1, 'missing base generated rules priority');
+    assert.ok(mergedIndex < changeIndex, 'merged generated rules should be highest priority');
+    assert.ok(changeIndex < baseGeneratedIndex, 'change generated rules should precede base generated rules');
+    assert.ok(baseGeneratedIndex < projectRulesIndex, 'generated rules should precede project rules');
+    assert.ok(projectRulesIndex < baseRulesIndex, 'project rules should precede base rules');
+  });
+
+  it('does not require plan-local rules.md in OpenSpec-native mode', async () => {
+    const skill = await readFile('skills/aif-rules-check/SKILL.md', 'utf8');
+
+    assert.match(
+      skill,
+      /OpenSpec-native[\s\S]+does not require plan-local `rules\.md`/i,
+      'OpenSpec-native mode must explicitly avoid requiring plan-local rules.md'
+    );
+    assert.match(
+      skill,
+      /legacy AI Factory-only[\s\S]+plan-local `rules\.md`/i,
+      'plan-local rules.md must remain gated to legacy AI Factory-only mode'
+    );
+  });
+
+  it('stays read-only and asks for regeneration when generated rules are missing or stale', async () => {
+    const skill = await readFile('skills/aif-rules-check/SKILL.md', 'utf8');
+
+    assert.match(skill, /read-only/i);
+    assert.match(skill, /missing or stale generated rules/i);
+    assert.match(skill, /regenerate rules/i);
+    assert.match(skill, /must not regenerate or edit generated rules/i);
+  });
+});

--- a/scripts/openspec-rules-compiler.test.mjs
+++ b/scripts/openspec-rules-compiler.test.mjs
@@ -267,6 +267,36 @@ The system MUST add beta behavior.
     assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'rules', 'generated')), false);
   });
 
+  it('rejects duplicate generated output filenames before writing files', async () => {
+    const { writeGeneratedRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+
+    const result = await writeGeneratedRules('duplicate-files', {
+      files: [
+        {
+          kind: 'base',
+          fileName: 'openspec-base.md',
+          content: 'base one\n'
+        },
+        {
+          kind: 'base',
+          fileName: 'openspec-base.md',
+          content: 'base two\n'
+        },
+        {
+          kind: 'change',
+          fileName: 'openspec-change-duplicate-files.md',
+          content: 'change\n'
+        }
+      ]
+    }, { rootDir });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.files.length, 0);
+    assert.equal(result.errors[0].code, 'invalid-rendered-files');
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'rules', 'generated')), false);
+  });
+
   it('resolves the active change when no change id is provided', async () => {
     const { compileOpenSpecRules } = await loadCompiler();
     const rootDir = await createTempRoot();

--- a/scripts/openspec-rules-compiler.test.mjs
+++ b/scripts/openspec-rules-compiler.test.mjs
@@ -442,6 +442,33 @@ The system MUST remove old behavior.
       'THEN it becomes a requirement'
     ]);
   });
+
+  it('preserves structured given when then scenario fields from CLI JSON', async () => {
+    const { extractRequirementsFromShowJson } = await loadCompiler();
+
+    const extracted = extractRequirementsFromShowJson({
+      requirements: [
+        {
+          title: 'Structured Scenario',
+          description: 'The system MUST preserve structured scenario steps.',
+          scenarios: [
+            {
+              title: 'structured flow',
+              given: 'GIVEN an OpenSpec CLI scenario',
+              when: 'WHEN generated rules are compiled',
+              then: 'THEN every structured step is preserved'
+            }
+          ]
+        }
+      ]
+    });
+
+    assert.deepEqual(extracted.requirements[0].scenarios[0].steps, [
+      'GIVEN an OpenSpec CLI scenario',
+      'WHEN generated rules are compiled',
+      'THEN every structured step is preserved'
+    ]);
+  });
 });
 
 describe('aif-rules-check OpenSpec-native prompt contract', () => {

--- a/skills/aif-rules-check/SKILL.md
+++ b/skills/aif-rules-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aif-rules-check
 description: Read-only gate that checks changed files against project rules hierarchy. Returns PASS, WARN, or FAIL without editing rules or source code.
-version: 1.0.0
+version: 1.1.0
 author: ichi
 ---
 
@@ -15,10 +15,13 @@ This is an **extension-owned temporary gate**. When upstream `ai-factory` adds a
 
 - **Read-only**: never edits rules, source code, or plan artifacts.
 - **Reads**:
-  - `.ai-factory/config.yaml` - project configuration, plan resolution, and rules paths
+  - `.ai-factory/config.yaml` - project configuration, mode detection, plan resolution, and rules paths
+  - `.ai-factory/rules/generated/openspec-merged-<change-id>.md` - OpenSpec-native merged generated rules, highest priority when present
+  - `.ai-factory/rules/generated/openspec-change-<change-id>.md` - OpenSpec-native change generated rules
+  - `.ai-factory/rules/generated/openspec-base.md` - OpenSpec-native base generated rules
   - `.ai-factory/RULES.md` - project-level rules (if present)
   - `.ai-factory/rules/base.md` - base rules created by `aif-analyze`
-  - plan-local `rules.md` - highest-priority plan rules (if an active plan exists)
+  - plan-local `rules.md` - legacy AI Factory-only plan rules when explicitly in legacy mode
   - changed files and current diff via `git diff`
 - **Returns**: `PASS | WARN | FAIL` with structured findings.
 
@@ -27,11 +30,24 @@ This is an **extension-owned temporary gate**. When upstream `ai-factory` adds a
 ### Step 1: Load Rules Hierarchy
 
 1. Read `.ai-factory/config.yaml` for path configuration and active plan resolution.
-2. Load rules in priority order:
+2. Detect rules mode:
+   - OpenSpec-native mode when config contains `aifhub.artifactProtocol: openspec` or the active scope is clearly under `openspec/changes/<change-id>/`.
+   - Legacy AI Factory-only mode otherwise.
+3. In OpenSpec-native mode, load rules in priority order:
+   - `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
+   - `.ai-factory/rules/generated/openspec-change-<change-id>.md`
+   - `.ai-factory/rules/generated/openspec-base.md`
+   - `.ai-factory/RULES.md` (project-level overrides, if present)
+   - `.ai-factory/rules/base.md` (base rules from `aif-analyze`, if present)
+4. OpenSpec-native mode does not require plan-local `rules.md`. Plan-local `rules.md` is ignored unless the run is explicitly legacy AI Factory-only.
+5. If OpenSpec-native generated rules are missing or stale generated rules are detected:
+   - Return `WARN` with message: "OpenSpec generated rules are missing or stale; regenerate rules before relying on this gate."
+   - Suggest that the owner workflow regenerate rules; this read-only gate must not regenerate or edit generated rules.
+6. In legacy AI Factory-only mode, load rules in priority order:
    - plan-local `rules.md` (plan-specific, highest priority, if active plan exists)
    - `.ai-factory/RULES.md` (project-level overrides, if present)
    - `.ai-factory/rules/base.md` (base rules from `aif-analyze`)
-3. If no rules files exist:
+7. If no rules files exist:
    - Return `WARN` with message: "No rules files found. Run `/aif-analyze` to create base rules."
    - Stop.
 
@@ -81,17 +97,19 @@ Verdict rules:
 
 - If rules are missing: suggest `/aif-analyze`.
 - If rules are outdated: suggest `/aif-rules`.
+- If OpenSpec generated rules are missing or stale generated rules are detected: suggest `regenerate rules` through the compiler-owning workflow before relying on this gate.
 - If blocking findings exist: suggest `/aif-fix`.
-- If plan-local rules are missing: suggest adding `rules.md` to the plan folder.
+- If plan-local rules are missing in legacy AI Factory-only mode: suggest adding `rules.md` to the plan folder.
 - **Never** suggest editing rules from this skill - that is the responsibility of `/aif-rules`.
 
 ## Ownership Boundary
 
 | Artifact | Owner | This Skill |
 |----------|-------|------------|
+| `.ai-factory/rules/generated/*.md` | OpenSpec generated rules compiler | Reads only |
 | `.ai-factory/RULES.md` | `/aif-rules` | Reads only |
 | `.ai-factory/rules/base.md` | `aif-analyze` | Reads only |
-| plan-local `rules.md` | `/aif-plan` | Reads only |
+| plan-local `rules.md` | `/aif-plan` | Reads only in legacy AI Factory-only mode |
 | source code files | project | Reads only |
 
 ## Rules
@@ -99,6 +117,7 @@ Verdict rules:
 - Never modify any files - this is a read-only gate.
 - Never apply fixes - that is the responsibility of `/aif-fix`.
 - Never write or update rules - that is the responsibility of `/aif-rules` or `aif-analyze`.
+- Never regenerate or edit generated rules - if `.ai-factory/rules/generated/*.md` is missing or stale, return `WARN` and ask the caller to regenerate rules through the compiler-owning workflow.
 - Only flag material rule violations, not general style preferences.
 - Use bounded scope: active plan pair or explicitly passed changed scope.
 - If rules are missing or outdated, suggest `/aif-analyze` or `/aif-rules` but do not edit them.


### PR DESCRIPTION
## Summary
- Add a dependency-free OpenSpec rules compiler that collects base and change specs, prefers compatible CLI JSON, and falls back to deterministic markdown parsing
- Write generated rules to `.ai-factory/rules/generated/` with safe paths and stable ordering
- Update `aif-rules-check` and the related docs to read generated OpenSpec rules in native mode

## Testing
- Added and ran targeted unit tests for compiler exports, fallback parsing, CLI JSON extraction, safe writes, and deterministic output
- Ran the full repository test suite and validation checks locally