### PR TITLE
Update implement and fix to consume OpenSpec artifacts

### DIFF
--- a/agent-files/claude/aifhub-fixer.md
+++ b/agent-files/claude/aifhub-fixer.md
@@ -16,6 +16,7 @@ Read `.ai-factory/config.yaml` before resolving scope. Treat review comments, re
 Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 
 - Apply only explicitly selected QA or review findings for one active OpenSpec change.
+- Use `scripts/openspec-execution-context.mjs` `buildFixContext(options)` when available before editing, and `writeFixTrace(changeId, trace, options)` for fix traces.
 - Read QA evidence from `.ai-factory/qa/<change-id>/`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present.

--- a/agent-files/claude/aifhub-implement-worker.md
+++ b/agent-files/claude/aifhub-implement-worker.md
@@ -16,6 +16,7 @@ Read `.ai-factory/config.yaml` before resolving scope. Do not create commits.
 Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 
 - Execute exactly one task or tightly coupled task group for one active OpenSpec change.
+- Use `scripts/openspec-execution-context.mjs` `buildImplementationContext(options)` when available before editing, and `writeExecutionTrace(changeId, trace, options)` for implementation traces.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present.
 - Use `.ai-factory/state/<change-id>/` for runtime state and implementation traces.

--- a/agent-files/codex/aifhub-fixer.toml
+++ b/agent-files/codex/aifhub-fixer.toml
@@ -13,6 +13,7 @@ Read .ai-factory/config.yaml before resolving scope. Treat review comments, revi
 Use this mode when config declares aifhub.artifactProtocol: openspec.
 
 - Apply only explicitly selected QA or review findings for one active OpenSpec change.
+- Use scripts/openspec-execution-context.mjs buildFixContext(options) when available before editing, and writeFixTrace(changeId, trace, options) for fix traces.
 - Read QA evidence from .ai-factory/qa/<change-id>/.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present.

--- a/agent-files/codex/aifhub-implement-worker.toml
+++ b/agent-files/codex/aifhub-implement-worker.toml
@@ -13,6 +13,7 @@ Read .ai-factory/config.yaml before resolving scope. Do not create commits.
 Use this mode when config declares aifhub.artifactProtocol: openspec.
 
 - Execute exactly one task or tightly coupled task group for one active OpenSpec change.
+- Use scripts/openspec-execution-context.mjs buildImplementationContext(options) when available before editing, and writeExecutionTrace(changeId, trace, options) for implementation traces.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present.
 - Use .ai-factory/state/<change-id>/ for runtime state and implementation traces.

--- a/docs/active-change-resolver.md
+++ b/docs/active-change-resolver.md
@@ -65,6 +65,10 @@ Runtime state is outside canonical OpenSpec changes:
 
 The helper never creates `.ai-factory/plans/<change-id>` and never writes under `openspec/changes/<change-id>/`.
 
+`scripts/openspec-execution-context.mjs` builds on this resolver for `/aif-implement` and `/aif-fix`. In OpenSpec-native mode it reads canonical OpenSpec artifacts, generated rules, optional OpenSpec `instructions apply` output, and QA evidence for fixes; trace writers then write only under `.ai-factory/state/<change-id>/implementation/` or `.ai-factory/state/<change-id>/fixes/`.
+
+OpenSpec-native implement/fix context does not require legacy `.ai-factory/plans/<id>/task.md`. Generated rules remain derived guidance, and missing OpenSpec CLI instructions degrade to warnings instead of blocking filesystem-based context loading.
+
 `/aif-plan full` uses the same change-id vocabulary in OpenSpec-native mode. It should create canonical OpenSpec change artifacts under `openspec/changes/<change-id>/` and keep planning runtime evidence, when needed, under `.ai-factory/state/<change-id>/`.
 
 `/aif-improve` also uses this vocabulary in OpenSpec-native mode. It refines only canonical OpenSpec artifacts, keeps runtime evidence under `.ai-factory/state/<change-id>/`, and treats archived targets under `openspec/changes/archive/**` as immutable by default. If further work is needed for an archived change, create a new active change instead of editing the archive silently.

--- a/docs/adr/0001-openspec-native-artifact-protocol.md
+++ b/docs/adr/0001-openspec-native-artifact-protocol.md
@@ -77,8 +77,8 @@ These paths are reserved names only in v1. Their detailed behavior is out of sco
 | `/aif-plan` | `openspec/specs`, project context | `openspec/changes/<id>/*` | optional `.ai-factory/state/<id>/*` | Creates OpenSpec-native change in v1 |
 | `/aif-explore` | project context, optional `openspec/specs` | none by default | `.ai-factory/state/<id>/explore.md` or equivalent | Research is not canonical unless promoted into OpenSpec artifacts |
 | `/aif-improve` | `openspec/changes/<id>/*`, `openspec/specs` | `openspec/changes/<id>/*` | patch summary if needed | Must preserve user edits |
-| `/aif-implement` | `openspec/specs`, `openspec/changes/<id>/*`, generated rules | none | `.ai-factory/state/<id>/*` | Execution state is runtime-only |
-| `/aif-fix` | same as implement plus QA reports | none | `.ai-factory/state/<id>/*` | Fixes implementation, not specs unless explicitly requested |
+| `/aif-implement` | `openspec/specs`, `openspec/changes/<id>/*`, generated rules, optional OpenSpec `instructions apply` | none | `.ai-factory/state/<id>/implementation/*` | Execution traces are runtime-only and do not require legacy `.ai-factory/plans/<id>/task.md` |
+| `/aif-fix` | same as implement plus QA reports from `.ai-factory/qa/<id>/*` | none | `.ai-factory/state/<id>/fixes/*` | Fixes implementation, not specs unless explicitly requested; does not require legacy `.ai-factory/plans/<id>/task.md` |
 | `/aif-verify` | `openspec/*`, generated rules | none | `.ai-factory/qa/<id>/*` | Must not archive |
 | `/aif-rules-check` | `openspec/specs`, `openspec/changes/<id>/specs` | none | none | Reads generated rules as derived guidance; never regenerates them |
 | `/aif-done` | `openspec/changes/<id>/*`, QA state | none until #33 archive integration; future `openspec/specs/*` via OpenSpec archive | final summary/state | Only finalizer may drive archive policy |
@@ -105,6 +105,8 @@ The compiler writes exactly these derived files:
 ```
 
 OpenSpec-native consumer and gate skills should read these files as execution guidance when present. Read-only gates such as `aif-rules-check` report missing or stale generated rules and ask the caller to regenerate them through the compiler-owning workflow; they do not write generated files themselves.
+
+Runtime consumers such as `/aif-implement` and `/aif-fix` treat generated rules as derived guidance only. When generated rules are missing or stale, they warn and continue from canonical OpenSpec artifacts rather than silently regenerating or treating generated files as source of truth.
 
 ## OpenSpec CLI policy
 

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -98,7 +98,9 @@ Special ownership case:
 - In OpenSpec-native mode, `aif-explore` may write research and runtime notes outside canonical change folders only: `.ai-factory/RESEARCH.md`, `.ai-factory/state/<change-id>/explore.md`, and `.ai-factory/state/<change-id>/research-notes.md`
 - In OpenSpec-native mode, `aif-improve` edits only valid OpenSpec change artifacts: `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
 - OpenSpec-native planning must keep runtime-only notes under `.ai-factory/state/<change-id>/`, not under `openspec/changes/<change-id>/`
-- In OpenSpec-native mode, `aif-implement` and `aif-fix` may write runtime execution state under `.ai-factory/state/<change-id>/` and implementation source changes within the selected task/finding scope; they do not rewrite canonical OpenSpec artifacts unless explicitly requested
+- In OpenSpec-native mode, `aif-implement` consumes canonical OpenSpec artifacts and generated rules through `scripts/openspec-execution-context.mjs` when available. It writes implementation traces only under `.ai-factory/state/<change-id>/implementation/` and does not require legacy `.ai-factory/plans/<id>/task.md`
+- In OpenSpec-native mode, `aif-fix` consumes the same canonical OpenSpec artifacts plus QA evidence under `.ai-factory/qa/<change-id>/`. It writes fix traces only under `.ai-factory/state/<change-id>/fixes/` and does not require legacy `.ai-factory/plans/<id>/task.md`
+- In OpenSpec-native mode, `aif-implement` and `aif-fix` may change implementation source files within the selected task/finding scope; they do not rewrite canonical OpenSpec artifacts unless explicitly requested
 - In OpenSpec-native mode, `aif-verify` writes QA evidence and findings under `.ai-factory/qa/<change-id>/` and must not archive
 - In OpenSpec-native mode, `aif-done` follows OpenSpec archive policy and writes finalizer/runtime state outside `openspec/changes/<change-id>/`; concrete archive integration is tracked separately by #33
 - Legacy `task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, and `explore.md` apply only to legacy AI Factory-only plan folders, not OpenSpec-native changes
@@ -166,7 +168,9 @@ If `config.yaml` is missing or incomplete for the requested operation:
 - `.ai-factory/rules/generated/*.md` owner: OpenSpec generated rules compiler; derived from `openspec/specs/**/spec.md` and `openspec/changes/<change-id>/specs/**/spec.md`, safe to delete and regenerate
 - `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md` owner in OpenSpec-native mode: built-in `/aif-plan` with extension injection rules
 - OpenSpec-native refinement owner: built-in `/aif-improve` with extension injection rules; it preserves user edits and updates only canonical OpenSpec artifacts
-- `.ai-factory/state/<change-id>/*` owner in OpenSpec-native mode: `/aif-implement` and `/aif-fix` for execution progress, fix notes, and git strategy; `/aif-explore` may own research-only state files
+- `.ai-factory/state/<change-id>/implementation/*` owner in OpenSpec-native mode: `/aif-implement` execution traces
+- `.ai-factory/state/<change-id>/fixes/*` owner in OpenSpec-native mode: `/aif-fix` fix traces
+- `.ai-factory/state/<change-id>/*` owner in OpenSpec-native mode: runtime state for execution progress, fix notes, and git strategy; `/aif-explore` may own research-only state files
 - `.ai-factory/qa/<change-id>/*` owner in OpenSpec-native mode: `/aif-verify`
 - OpenSpec-native finalizer state owner: `/aif-done`; canonical archive writes remain governed by OpenSpec archive policy and #33
 - `.ai-factory/plans/<plan-id>.md` owner in legacy AI Factory-only mode: built-in `/aif-plan` with extension injection rules

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -221,7 +221,10 @@ Improve behavior:
 
 Implement behavior:
 - in OpenSpec-native mode, reads `proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md`, accepted specs, and generated rules
-- in OpenSpec-native mode, writes execution progress and git strategy under `.ai-factory/state/<change-id>/`; it does not write canonical OpenSpec artifacts unless the user explicitly expands scope
+- in OpenSpec-native mode, uses `scripts/openspec-execution-context.mjs` when available to prepare implementation context and optional OpenSpec `instructions apply` guidance
+- in OpenSpec-native mode, writes implementation traces only under `.ai-factory/state/<change-id>/implementation/`; it does not write canonical OpenSpec artifacts unless the user explicitly expands scope
+- in OpenSpec-native mode, does not require legacy `.ai-factory/plans/<id>/task.md`
+- generated rules are derived guidance; missing or stale generated rules warn without replacing canonical OpenSpec artifacts
 - in legacy AI Factory-only mode, owns `status.yaml` execution metadata and git-strategy persistence
 - supports `--from <n>` resume and optional Claude worker mode
 - routes completion to `/aif-verify`
@@ -283,6 +286,15 @@ Governance note: roadmap/architecture/rules follow-ups must be backed by verifie
 /aif-fix B001 I001
 /aif-fix --all
 ```
+
+Fix behavior:
+- in OpenSpec-native mode, reads the same canonical OpenSpec artifacts as `/aif-implement`
+- in OpenSpec-native mode, reads QA evidence from `.ai-factory/qa/<change-id>/`
+- in OpenSpec-native mode, uses `scripts/openspec-execution-context.mjs` when available to prepare fix context and optional OpenSpec `instructions apply` guidance
+- in OpenSpec-native mode, writes fix traces only under `.ai-factory/state/<change-id>/fixes/`
+- in OpenSpec-native mode, does not write runtime traces into `openspec/changes/<change-id>/`
+- in OpenSpec-native mode, does not require legacy `.ai-factory/plans/<id>/task.md`
+- generated rules are derived guidance; missing or stale generated rules warn without replacing canonical OpenSpec artifacts
 
 After fixes, run:
 

--- a/injections/core/aif-fix-plan-folder.md
+++ b/injections/core/aif-fix-plan-folder.md
@@ -27,6 +27,8 @@ Before resolving fix findings, read `.ai-factory/config.yaml` when it exists.
 
 When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-fix` applies selected QA findings for the active OpenSpec change.
 
+Use `buildFixContext(options)` from `scripts/openspec-execution-context.mjs` when available before editing implementation files. Treat the returned resolver diagnostics, canonical artifacts, QA evidence, generated rules, OpenSpec apply instructions, runtime paths, warnings, and errors as the machine-readable fix context. If the helper is unavailable, fall back to the explicit filesystem reads and runtime boundaries in this section.
+
 Use shared vocabulary consistently: `OpenSpec-native mode`, `canonical OpenSpec change`, `active change`, `change-id`, `base specs`, `delta specs`, `generated rules`, `runtime state`, `QA evidence`, and `legacy AI Factory-only mode`.
 
 Resolve the active change using `scripts/active-change-resolver.mjs` when available:
@@ -52,6 +54,7 @@ Read generated rules as derived fix guidance when present:
 
 Write fix traces only to runtime state:
 
+- Prefer `writeFixTrace(changeId, trace, options)` from `scripts/openspec-execution-context.mjs` for fix traces.
 - `.ai-factory/state/<change-id>/`
 - `.ai-factory/state/<change-id>/fixes/`
 

--- a/injections/core/aif-implement-plan-folder.md
+++ b/injections/core/aif-implement-plan-folder.md
@@ -25,7 +25,9 @@ Before resolving an implementation target, read `.ai-factory/config.yaml` when i
 
 ### OpenSpec-native mode
 
-When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-implement` executes implementation tasks for the active OpenSpec change. This prompt guidance does not implement the runtime behavior rewrite tracked by issue #31.
+When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-implement` executes implementation tasks for the active OpenSpec change.
+
+Use `buildImplementationContext(options)` from `scripts/openspec-execution-context.mjs` when available before editing implementation files. Treat the returned resolver diagnostics, canonical artifacts, generated rules, OpenSpec apply instructions, runtime paths, warnings, and errors as the machine-readable implementation context. If the helper is unavailable, fall back to the explicit filesystem reads and runtime boundaries in this section.
 
 Use shared vocabulary consistently: `OpenSpec-native mode`, `canonical OpenSpec change`, `active change`, `change-id`, `base specs`, `delta specs`, `generated rules`, `runtime state`, `QA evidence`, and `legacy AI Factory-only mode`.
 
@@ -51,6 +53,7 @@ Read generated rules as derived implementation guidance when present:
 
 Execution trace and runtime state boundaries:
 
+- Prefer `writeExecutionTrace(changeId, trace, options)` from `scripts/openspec-execution-context.mjs` for implementation traces.
 - Write implementation progress, task execution traces, degraded capability notes, and runner metadata only under `.ai-factory/state/<change-id>/`.
 - Do not write runtime-only files, summaries, validation output, or execution traces under `openspec/changes/<change-id>/`.
 - Do not create legacy plan-folder execution artifacts in OpenSpec-native mode.

--- a/scripts/openspec-execution-context.mjs
+++ b/scripts/openspec-execution-context.mjs
@@ -1,0 +1,706 @@
+// openspec-execution-context.mjs - OpenSpec implement/fix runtime context helpers
+import { createHash } from 'node:crypto';
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  ensureRuntimeLayout,
+  normalizeChangeId,
+  resolveActiveChange
+} from './active-change-resolver.mjs';
+import {
+  detectOpenSpec as defaultDetectOpenSpec,
+  getOpenSpecInstructions as defaultGetOpenSpecInstructions
+} from './openspec-runner.mjs';
+
+const MODE = 'openspec-native';
+const GENERATED_DIR = path.join('.ai-factory', 'rules', 'generated');
+const TRACE_STATE_DIR = path.join('.ai-factory', 'state');
+const INSTRUCTIONS_ARTIFACT = 'apply';
+const REQUIRED_CHANGE_ARTIFACTS = ['proposal.md', 'design.md', 'tasks.md'];
+
+export async function buildImplementationContext(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const resolverResult = await resolveActiveChange({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId: options.changeId,
+    getCurrentBranch: options.getCurrentBranch
+  });
+
+  if (!resolverResult.ok) {
+    return createContextFailure({
+      resolverResult,
+      warnings: resolverResult.warnings,
+      errors: resolverResult.errors
+    });
+  }
+
+  const layout = await ensureRuntimeLayout(resolverResult.changeId, {
+    rootDir,
+    cwd: options.cwd,
+    stateDir: options.stateDir,
+    qaDir: options.qaDir
+  });
+  const canonical = await collectCanonicalChangeArtifacts(resolverResult.changeId, { ...options, rootDir });
+  const generatedRules = await collectGeneratedRules(resolverResult.changeId, { ...options, rootDir });
+  const instructions = await collectOpenSpecInstructions(resolverResult.changeId, { ...options, rootDir });
+  const warnings = dedupeDiagnostics([
+    ...resolverResult.warnings,
+    ...canonical.warnings,
+    ...generatedRules.warnings,
+    ...instructions.warnings
+  ]);
+  const errors = [
+    ...canonical.errors,
+    ...generatedRules.errors,
+    ...instructions.errors
+  ];
+
+  return {
+    ok: errors.length === 0,
+    mode: MODE,
+    changeId: resolverResult.changeId,
+    resolver: createResolverSummary(resolverResult),
+    paths: {
+      change: resolverResult.changePath,
+      state: layout.statePath,
+      qa: layout.qaPath,
+      generatedRules: path.join(rootDir, GENERATED_DIR)
+    },
+    canonicalArtifacts: canonical.canonicalArtifacts,
+    generatedRules: generatedRules.generatedRules,
+    openspecInstructions: instructions.openspecInstructions,
+    warnings,
+    errors
+  };
+}
+
+export async function buildFixContext(options = {}) {
+  const context = await buildImplementationContext(options);
+
+  if (!context.ok) {
+    return {
+      ...context,
+      qaEvidence: []
+    };
+  }
+
+  const qa = await collectQaEvidence(context.changeId, {
+    ...options,
+    rootDir: resolveRootDir(options),
+    qaDir: context.paths.qa
+  });
+  const missingQa = qa.qaEvidence.length === 0;
+  const warnings = dedupeDiagnostics([
+    ...context.warnings,
+    ...qa.warnings,
+    ...(missingQa ? [missingQaEvidenceDiagnostic()] : [])
+  ]);
+  const errors = [
+    ...context.errors,
+    ...qa.errors,
+    ...(missingQa && options.requireQaEvidence ? [missingQaEvidenceDiagnostic()] : [])
+  ];
+
+  return {
+    ...context,
+    ok: errors.length === 0,
+    qaEvidence: qa.qaEvidence,
+    warnings,
+    errors
+  };
+}
+
+export async function collectCanonicalChangeArtifacts(changeId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      changeId: null,
+      canonicalArtifacts: {},
+      warnings: [],
+      errors: [normalized.error]
+    };
+  }
+
+  const resolvedChangeId = normalized.changeId;
+  const changeDir = path.join(rootDir, 'openspec', 'changes', resolvedChangeId);
+  const artifacts = {};
+  const warnings = [];
+
+  for (const fileName of REQUIRED_CHANGE_ARTIFACTS) {
+    const artifact = await readOptionalTextFile(rootDir, path.join(changeDir, fileName));
+    artifacts[artifactKey(fileName)] = artifact;
+
+    if (!artifact.exists) {
+      warnings.push({
+        code: 'missing-canonical-artifact',
+        message: `Canonical OpenSpec artifact is missing: ${artifact.path}`,
+        path: artifact.path
+      });
+    }
+  }
+
+  const baseSpecs = await collectTextFiles(rootDir, path.join(rootDir, 'openspec', 'specs'), isSpecMarkdown);
+  const deltaSpecs = await collectTextFiles(rootDir, path.join(changeDir, 'specs'), isSpecMarkdown);
+
+  return {
+    ok: true,
+    changeId: resolvedChangeId,
+    canonicalArtifacts: {
+      proposal: artifacts.proposal,
+      design: artifacts.design,
+      tasks: artifacts.tasks,
+      baseSpecs,
+      deltaSpecs
+    },
+    warnings,
+    errors: []
+  };
+}
+
+export async function collectGeneratedRules(changeId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      changeId: null,
+      generatedRules: [],
+      warnings: [],
+      errors: [normalized.error]
+    };
+  }
+
+  const resolvedChangeId = normalized.changeId;
+  const generatedDir = path.join(rootDir, GENERATED_DIR);
+  const fingerprints = await collectCurrentSpecFingerprints(rootDir, resolvedChangeId);
+  const expected = [
+    {
+      kind: 'merged',
+      fileName: `openspec-merged-${resolvedChangeId}.md`,
+      expectedFingerprints: new Map([...fingerprints.base, ...fingerprints.delta])
+    },
+    {
+      kind: 'change',
+      fileName: `openspec-change-${resolvedChangeId}.md`,
+      expectedFingerprints: fingerprints.delta
+    },
+    {
+      kind: 'base',
+      fileName: 'openspec-base.md',
+      expectedFingerprints: fingerprints.base
+    }
+  ];
+  const generatedRules = [];
+  const warnings = [];
+
+  for (const expectedFile of expected) {
+    const filePath = path.join(generatedDir, expectedFile.fileName);
+    const item = await readOptionalTextFile(rootDir, filePath);
+    const stale = item.exists
+      ? determineStaleness(item.content, expectedFile.expectedFingerprints)
+      : null;
+
+    generatedRules.push({
+      kind: expectedFile.kind,
+      path: item.path,
+      exists: item.exists,
+      stale,
+      content: item.content
+    });
+
+    if (!item.exists) {
+      warnings.push({
+        code: 'missing-generated-rules',
+        message: `Generated OpenSpec rules are missing: ${item.path}`,
+        path: item.path
+      });
+      continue;
+    }
+
+    if (stale === true) {
+      warnings.push({
+        code: 'stale-generated-rules',
+        message: `Generated OpenSpec rules are stale: ${item.path}`,
+        path: item.path
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    changeId: resolvedChangeId,
+    generatedRules,
+    warnings: dedupeDiagnostics(warnings),
+    errors: []
+  };
+}
+
+export async function collectQaEvidence(changeId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      changeId: null,
+      qaEvidence: [],
+      warnings: [],
+      errors: [normalized.error]
+    };
+  }
+
+  const qaDir = options.qaDir !== undefined
+    ? path.resolve(options.qaDir)
+    : path.join(rootDir, '.ai-factory', 'qa', normalized.changeId);
+  const qaEvidence = await collectTextFiles(rootDir, qaDir, () => true);
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    qaEvidence,
+    warnings: [],
+    errors: []
+  };
+}
+
+export async function writeExecutionTrace(changeId, trace, options = {}) {
+  return writeTrace({
+    changeId,
+    trace,
+    options,
+    type: 'Implementation',
+    directoryName: 'implementation'
+  });
+}
+
+export async function writeFixTrace(changeId, trace, options = {}) {
+  return writeTrace({
+    changeId,
+    trace,
+    options,
+    type: 'Fix',
+    directoryName: 'fixes'
+  });
+}
+
+async function collectOpenSpecInstructions(changeId, options) {
+  const detectOpenSpec = options.detectOpenSpec ?? defaultDetectOpenSpec;
+  const getOpenSpecInstructions = options.getOpenSpecInstructions ?? defaultGetOpenSpecInstructions;
+  const runOptions = createOpenSpecRunOptions(options);
+  const unavailable = (detail) => ({
+    openspecInstructions: createUnavailableInstructions(detail),
+    warnings: [
+      {
+        code: 'openspec-instructions-unavailable',
+        message: 'OpenSpec apply instructions were unavailable; continuing with filesystem artifacts.',
+        detail
+      }
+    ],
+    errors: []
+  });
+
+  let detection;
+
+  try {
+    detection = await detectOpenSpec(runOptions);
+  } catch (err) {
+    return unavailable(err?.message ?? 'OpenSpec detection failed.');
+  }
+
+  if (!detection?.available || !detection?.canValidate) {
+    return unavailable(detection?.errors?.[0]?.message ?? detection?.reason ?? 'OpenSpec CLI is unavailable or unsupported.');
+  }
+
+  let instructions;
+
+  try {
+    instructions = await getOpenSpecInstructions(INSTRUCTIONS_ARTIFACT, {
+      ...runOptions,
+      change: changeId
+    });
+  } catch (err) {
+    return unavailable(err?.message ?? 'OpenSpec instructions command failed.');
+  }
+
+  if (!instructions?.ok) {
+    return unavailable(instructions?.error?.message ?? 'OpenSpec instructions command failed.');
+  }
+
+  return {
+    openspecInstructions: {
+      available: true,
+      artifact: INSTRUCTIONS_ARTIFACT,
+      json: instructions.json ?? null,
+      stdout: instructions.stdout ?? '',
+      stderr: instructions.stderr ?? '',
+      raw: instructions
+    },
+    warnings: [],
+    errors: []
+  };
+}
+
+async function writeTrace({ changeId, trace, options, type, directoryName }) {
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error.message);
+  }
+
+  const runId = normalizeRunId(options.runId ?? createDefaultRunId(options));
+  const rootDir = resolveRootDir(options);
+  assertCanonicalTraceStateDir(rootDir, options.stateDir);
+
+  const statePath = path.join(rootDir, TRACE_STATE_DIR, normalized.changeId);
+  const outputDir = path.join(statePath, directoryName);
+  const targetPath = path.resolve(outputDir, `${runId}.md`);
+
+  if (!isWithinDirectory(targetPath, outputDir) || !isWithinDirectory(targetPath, statePath)) {
+    throw new Error(`Trace output path escapes runtime state: ${targetPath}`);
+  }
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(targetPath, renderTraceMarkdown({
+    changeId: normalized.changeId,
+    trace,
+    type
+  }), 'utf8');
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    runId,
+    path: targetPath,
+    relativePath: toPosix(path.relative(rootDir, targetPath)),
+    warnings: [],
+    errors: []
+  };
+}
+
+function assertCanonicalTraceStateDir(rootDir, stateDir) {
+  if (stateDir === undefined || stateDir === null) {
+    return;
+  }
+
+  const canonicalStateDir = path.join(rootDir, TRACE_STATE_DIR);
+  const requestedStateDir = path.resolve(rootDir, stateDir);
+
+  if (!samePath(requestedStateDir, canonicalStateDir)) {
+    throw new Error(`Trace stateDir must resolve to canonical runtime state directory: ${toPosix(TRACE_STATE_DIR)}.`);
+  }
+}
+
+function renderTraceMarkdown({ changeId, trace, type }) {
+  const nextStep = trace?.nextStep ?? `/aif-verify ${changeId}`;
+  const lines = [
+    `# ${type} Trace: ${changeId}`,
+    '',
+    '## Summary',
+    '',
+    normalizeTraceText(trace?.summary, 'No summary provided.'),
+    '',
+    '## Canonical artifacts read',
+    '',
+    ...renderList(trace?.canonicalArtifactsRead),
+    '',
+    '## Generated rules read',
+    '',
+    ...renderList(trace?.generatedRulesRead),
+    '',
+    '## Changed files',
+    '',
+    ...renderList(trace?.changedFiles),
+    '',
+    '## Next step',
+    '',
+    nextStep,
+    ''
+  ];
+
+  return lines.join('\n');
+}
+
+function renderList(values) {
+  const items = Array.isArray(values) ? values.filter((value) => String(value).trim().length > 0) : [];
+
+  if (items.length === 0) {
+    return ['- none'];
+  }
+
+  return items.map((item) => `- ${item}`);
+}
+
+function normalizeTraceText(value, fallback) {
+  const text = String(value ?? '').trim();
+  return text.length > 0 ? text : fallback;
+}
+
+function normalizeRunId(input) {
+  if (typeof input !== 'string') {
+    throw new Error(`Invalid OpenSpec run id: ${JSON.stringify(input)}.`);
+  }
+
+  const runId = input.trim();
+
+  if (
+    runId.length === 0
+    || path.isAbsolute(runId)
+    || runId.includes('/')
+    || runId.includes('\\')
+    || runId === '..'
+    || runId.includes('..')
+    || !/^[A-Za-z0-9._-]+$/.test(runId)
+  ) {
+    throw new Error(`Invalid OpenSpec run id: ${JSON.stringify(input)}.`);
+  }
+
+  return runId;
+}
+
+function createDefaultRunId(options = {}) {
+  const date = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+  return `run-${date.toISOString().replace(/[:.]/g, '-')}`;
+}
+
+async function collectCurrentSpecFingerprints(rootDir, changeId) {
+  const baseFiles = await collectTextFiles(rootDir, path.join(rootDir, 'openspec', 'specs'), isSpecMarkdown);
+  const deltaFiles = await collectTextFiles(
+    rootDir,
+    path.join(rootDir, 'openspec', 'changes', changeId, 'specs'),
+    isSpecMarkdown
+  );
+
+  return {
+    base: fingerprintMap(baseFiles),
+    delta: fingerprintMap(deltaFiles)
+  };
+}
+
+function fingerprintMap(files) {
+  return new Map(files.map((file) => [
+    file.path,
+    createFingerprint(file.content)
+  ]));
+}
+
+function createFingerprint(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
+}
+
+function determineStaleness(content, expectedFingerprints) {
+  const actualFingerprints = parseSourceFingerprints(content);
+
+  if (actualFingerprints.size === 0 && expectedFingerprints.size === 0) {
+    return false;
+  }
+
+  if (actualFingerprints.size === 0) {
+    return null;
+  }
+
+  if (actualFingerprints.size !== expectedFingerprints.size) {
+    return true;
+  }
+
+  for (const [relativePath, fingerprint] of expectedFingerprints) {
+    if (actualFingerprints.get(relativePath) !== fingerprint) {
+      return true;
+    }
+  }
+
+  for (const relativePath of actualFingerprints.keys()) {
+    if (!expectedFingerprints.has(relativePath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function parseSourceFingerprints(content) {
+  const fingerprints = new Map();
+  const pattern = /^-\s+(sha256:\S+)\s+(.+?)\s*$/gm;
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    fingerprints.set(toPosix(match[2].trim()), match[1].trim());
+  }
+
+  return fingerprints;
+}
+
+async function collectTextFiles(rootDir, directoryPath, predicate) {
+  if (!await isDirectory(directoryPath)) {
+    return [];
+  }
+
+  const filePaths = [];
+  await collectFilePaths(directoryPath, filePaths, predicate);
+
+  const sorted = filePaths.sort((left, right) => toPosix(path.relative(rootDir, left)).localeCompare(toPosix(path.relative(rootDir, right))));
+  const result = [];
+
+  for (const filePath of sorted) {
+    const content = await readFile(filePath, 'utf8');
+    result.push({
+      path: toPosix(path.relative(rootDir, filePath)),
+      content
+    });
+  }
+
+  return result;
+}
+
+async function collectFilePaths(directoryPath, filePaths, predicate) {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const sortedEntries = entries.sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of sortedEntries) {
+    const childPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      await collectFilePaths(childPath, filePaths, predicate);
+      continue;
+    }
+
+    if (entry.isFile() && predicate(childPath)) {
+      filePaths.push(childPath);
+    }
+  }
+}
+
+async function readOptionalTextFile(rootDir, filePath) {
+  const relativePath = toPosix(path.relative(rootDir, filePath));
+
+  try {
+    return {
+      path: relativePath,
+      exists: true,
+      content: await readFile(filePath, 'utf8')
+    };
+  } catch (err) {
+    if (err?.code !== 'ENOENT') {
+      throw err;
+    }
+
+    return {
+      path: relativePath,
+      exists: false,
+      content: ''
+    };
+  }
+}
+
+function createContextFailure({ resolverResult, warnings = [], errors = [] }) {
+  return {
+    ok: false,
+    mode: MODE,
+    changeId: null,
+    resolver: createResolverSummary(resolverResult),
+    paths: {},
+    canonicalArtifacts: {},
+    generatedRules: [],
+    openspecInstructions: createUnavailableInstructions(null),
+    warnings: dedupeDiagnostics(warnings),
+    errors
+  };
+}
+
+function createResolverSummary(result) {
+  return {
+    source: result?.source ?? null,
+    candidates: result?.candidates ?? [],
+    warnings: result?.warnings ?? []
+  };
+}
+
+function createUnavailableInstructions(detail) {
+  return {
+    available: false,
+    artifact: INSTRUCTIONS_ARTIFACT,
+    json: null,
+    stdout: '',
+    stderr: '',
+    raw: null,
+    detail
+  };
+}
+
+function missingQaEvidenceDiagnostic() {
+  return {
+    code: 'missing-qa-evidence',
+    message: 'No QA evidence was found for this change. Run /aif-verify before /aif-fix when possible.'
+  };
+}
+
+function createOpenSpecRunOptions(options) {
+  return {
+    cwd: options.rootDir,
+    command: options.command,
+    env: options.env,
+    executor: options.executor,
+    nodeVersion: options.nodeVersion
+  };
+}
+
+function artifactKey(fileName) {
+  return path.basename(fileName, path.extname(fileName));
+}
+
+function isSpecMarkdown(filePath) {
+  return path.basename(filePath) === 'spec.md';
+}
+
+async function isDirectory(targetPath) {
+  try {
+    const item = await stat(targetPath);
+    return item.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isWithinDirectory(targetPath, directoryPath) {
+  const relative = path.relative(directoryPath, targetPath);
+  return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function samePath(left, right) {
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+
+  return process.platform === 'win32'
+    ? resolvedLeft.toLowerCase() === resolvedRight.toLowerCase()
+    : resolvedLeft === resolvedRight;
+}
+
+function resolveRootDir(options = {}) {
+  return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  const result = [];
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.code ?? ''}:${diagnostic.message ?? ''}:${diagnostic.path ?? ''}`;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(diagnostic);
+    }
+  }
+
+  return result;
+}

--- a/scripts/openspec-execution-context.mjs
+++ b/scripts/openspec-execution-context.mjs
@@ -1,6 +1,6 @@
 // openspec-execution-context.mjs - OpenSpec implement/fix runtime context helpers
 import { createHash } from 'node:crypto';
-import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -16,7 +16,6 @@ import {
 
 const MODE = 'openspec-native';
 const GENERATED_DIR = path.join('.ai-factory', 'rules', 'generated');
-const TRACE_STATE_DIR = path.join('.ai-factory', 'state');
 const INSTRUCTIONS_ARTIFACT = 'apply';
 const REQUIRED_CHANGE_ARTIFACTS = ['proposal.md', 'design.md', 'tasks.md'];
 
@@ -257,7 +256,7 @@ export async function collectQaEvidence(changeId, options = {}) {
   }
 
   const qaDir = options.qaDir !== undefined
-    ? path.resolve(options.qaDir)
+    ? resolveFromRoot(rootDir, options.qaDir)
     : path.join(rootDir, '.ai-factory', 'qa', normalized.changeId);
   const qaEvidence = await collectTextFiles(rootDir, qaDir, () => true);
 
@@ -356,13 +355,18 @@ async function writeTrace({ changeId, trace, options, type, directoryName }) {
 
   const runId = normalizeRunId(options.runId ?? createDefaultRunId(options));
   const rootDir = resolveRootDir(options);
-  assertCanonicalTraceStateDir(rootDir, options.stateDir);
+  const layout = await ensureRuntimeLayout(normalized.changeId, {
+    rootDir,
+    cwd: options.cwd,
+    stateDir: options.stateDir,
+    qaDir: options.qaDir
+  });
+  assertSafeTraceStatePath(rootDir, layout.statePath);
 
-  const statePath = path.join(rootDir, TRACE_STATE_DIR, normalized.changeId);
-  const outputDir = path.join(statePath, directoryName);
+  const outputDir = path.join(layout.statePath, directoryName);
   const targetPath = path.resolve(outputDir, `${runId}.md`);
 
-  if (!isWithinDirectory(targetPath, outputDir) || !isWithinDirectory(targetPath, statePath)) {
+  if (!isWithinDirectory(targetPath, outputDir) || !isWithinDirectory(targetPath, layout.statePath)) {
     throw new Error(`Trace output path escapes runtime state: ${targetPath}`);
   }
 
@@ -384,16 +388,21 @@ async function writeTrace({ changeId, trace, options, type, directoryName }) {
   };
 }
 
-function assertCanonicalTraceStateDir(rootDir, stateDir) {
-  if (stateDir === undefined || stateDir === null) {
-    return;
+function assertSafeTraceStatePath(rootDir, statePath) {
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedStatePath = path.resolve(statePath);
+
+  if (!isWithinDirectory(resolvedStatePath, resolvedRoot)) {
+    throw new Error(`Trace state path escapes repository root: ${resolvedStatePath}`);
   }
 
-  const canonicalStateDir = path.join(rootDir, TRACE_STATE_DIR);
-  const requestedStateDir = path.resolve(rootDir, stateDir);
-
-  if (!samePath(requestedStateDir, canonicalStateDir)) {
-    throw new Error(`Trace stateDir must resolve to canonical runtime state directory: ${toPosix(TRACE_STATE_DIR)}.`);
+  for (const forbiddenDir of [
+    path.join(resolvedRoot, 'openspec', 'changes'),
+    path.join(resolvedRoot, '.ai-factory', 'plans')
+  ]) {
+    if (isWithinDirectory(resolvedStatePath, forbiddenDir)) {
+      throw new Error('Trace state path must stay outside canonical OpenSpec changes and legacy plan folders.');
+    }
   }
 }
 
@@ -672,17 +681,12 @@ function isWithinDirectory(targetPath, directoryPath) {
   return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
-function samePath(left, right) {
-  const resolvedLeft = path.resolve(left);
-  const resolvedRight = path.resolve(right);
-
-  return process.platform === 'win32'
-    ? resolvedLeft.toLowerCase() === resolvedRight.toLowerCase()
-    : resolvedLeft === resolvedRight;
-}
-
 function resolveRootDir(options = {}) {
   return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function resolveFromRoot(rootDir, value) {
+  return path.resolve(rootDir, value);
 }
 
 function toPosix(value) {

--- a/scripts/openspec-execution-context.test.mjs
+++ b/scripts/openspec-execution-context.test.mjs
@@ -274,7 +274,10 @@ describe('OpenSpec execution context API', () => {
   });
 
   it('builds fix context with QA evidence and warns or fails when QA evidence is missing', async () => {
-    const { buildFixContext } = await loadExecutionContext();
+    const {
+      buildFixContext,
+      collectQaEvidence
+    } = await loadExecutionContext();
     const rootDir = await createTempRoot();
     await createOpenSpecChange(rootDir, 'add-oauth');
     await writeFixture(rootDir, '.ai-factory/qa/add-oauth/verify.md', '# Verify\n');
@@ -288,6 +291,16 @@ describe('OpenSpec execution context API', () => {
     assert.equal(withQa.ok, true);
     assert.deepEqual(withQa.qaEvidence.map((item) => item.path), [
       '.ai-factory/qa/add-oauth/verify.md'
+    ]);
+
+    await writeFixture(rootDir, 'custom-qa/add-oauth/verify.md', '# Custom Verify\n');
+    const relativeQa = await collectQaEvidence('add-oauth', {
+      rootDir,
+      qaDir: 'custom-qa/add-oauth'
+    });
+
+    assert.deepEqual(relativeQa.qaEvidence.map((item) => item.path), [
+      'custom-qa/add-oauth/verify.md'
     ]);
 
     const missingRoot = await createTempRoot();
@@ -353,13 +366,26 @@ describe('OpenSpec execution context API', () => {
     assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', '.ai-factory')), false);
     assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'plans', 'add-oauth')), false);
 
+    const customState = await writeExecutionTrace('add-oauth', {
+      summary: 'Custom runtime state',
+      canonicalArtifactsRead: ['openspec/changes/add-oauth/tasks.md'],
+      generatedRulesRead: [],
+      changedFiles: []
+    }, {
+      rootDir,
+      stateDir: '.ai-factory/custom-state',
+      runId: 'custom-001'
+    });
+
+    assert.equal(customState.relativePath, '.ai-factory/custom-state/add-oauth/implementation/custom-001.md');
+
     await assert.rejects(
       () => writeExecutionTrace('add-oauth', { summary: 'bad state' }, {
         rootDir,
         stateDir: 'openspec/changes',
         runId: 'escape'
       }),
-      /canonical runtime state directory/
+      /outside canonical OpenSpec changes/
     );
     assert.equal(
       await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'implementation', 'escape.md')),

--- a/scripts/openspec-execution-context.test.mjs
+++ b/scripts/openspec-execution-context.test.mjs
@@ -1,0 +1,428 @@
+// openspec-execution-context.test.mjs - tests for OpenSpec implement/fix runtime context
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const tempRoots = [];
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PROMPT_ASSETS = [
+  'injections/core/aif-implement-plan-folder.md',
+  'injections/core/aif-fix-plan-folder.md',
+  'agent-files/codex/aifhub-implement-worker.toml',
+  'agent-files/codex/aifhub-fixer.toml',
+  'agent-files/claude/aifhub-implement-worker.md',
+  'agent-files/claude/aifhub-fixer.md'
+];
+
+async function loadExecutionContext() {
+  return import('./openspec-execution-context.mjs');
+}
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-openspec-context-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createOpenSpecChange(rootDir, changeId = 'add-oauth') {
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, '# Tasks\n\n- [ ] Implement\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/specs/auth/spec.md`, deltaAuthSpec);
+  await writeFixture(rootDir, 'openspec/specs/auth/spec.md', baseAuthSpec);
+}
+
+async function createGeneratedRules(rootDir, changeId = 'add-oauth', options = {}) {
+  const baseFingerprint = options.baseFingerprint ?? 'sha256:test-base';
+  const changeFingerprint = options.changeFingerprint ?? 'sha256:test-change';
+  await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md', generatedRulesContent({
+    title: 'Base OpenSpec Rules',
+    fingerprints: [`${baseFingerprint} openspec/specs/auth/spec.md`]
+  }));
+  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-change-${changeId}.md`, generatedRulesContent({
+    title: 'Change OpenSpec Rules',
+    fingerprints: [`${changeFingerprint} openspec/changes/${changeId}/specs/auth/spec.md`]
+  }));
+  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-merged-${changeId}.md`, generatedRulesContent({
+    title: 'Merged OpenSpec Rules',
+    fingerprints: [
+      `${baseFingerprint} openspec/specs/auth/spec.md`,
+      `${changeFingerprint} openspec/changes/${changeId}/specs/auth/spec.md`
+    ]
+  }));
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function missingCliDetection() {
+  return {
+    available: false,
+    canValidate: false,
+    canArchive: false,
+    reason: 'missing-cli',
+    errors: [
+      {
+        code: 'missing-cli',
+        message: 'OpenSpec CLI is not available on PATH.'
+      }
+    ]
+  };
+}
+
+function availableCliDetection() {
+  return {
+    available: true,
+    canValidate: true,
+    canArchive: true,
+    reason: null,
+    errors: []
+  };
+}
+
+function generatedRulesContent({ title, fingerprints }) {
+  return [
+    '# Generated OpenSpec Rules',
+    '',
+    `View: ${title}`,
+    'Source of truth: OpenSpec canonical specs',
+    '',
+    '## Source Fingerprints',
+    '',
+    ...fingerprints.map((fingerprint) => `- ${fingerprint}`),
+    ''
+  ].join('\n');
+}
+
+const baseAuthSpec = `# Auth
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.
+`;
+
+const deltaAuthSpec = `# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: OAuth sign in
+
+The system MUST support OAuth sign in.
+`;
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec execution context API', () => {
+  it('exports the required public functions', async () => {
+    const context = await loadExecutionContext();
+
+    for (const name of [
+      'buildImplementationContext',
+      'buildFixContext',
+      'collectCanonicalChangeArtifacts',
+      'collectGeneratedRules',
+      'collectQaEvidence',
+      'writeExecutionTrace',
+      'writeFixTrace'
+    ]) {
+      assert.equal(typeof context[name], 'function', `${name} should be exported`);
+    }
+  });
+
+  it('builds implementation context for an explicit change id and reads canonical artifacts', async () => {
+    const { buildImplementationContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.mode, 'openspec-native');
+    assert.equal(result.changeId, 'add-oauth');
+    assert.equal(result.resolver.source, 'explicit');
+    assert.deepEqual(result.resolver.candidates, ['add-oauth']);
+    assert.equal(result.canonicalArtifacts.proposal.content, '# Proposal\n');
+    assert.equal(result.canonicalArtifacts.design.content, '# Design\n');
+    assert.match(result.canonicalArtifacts.tasks.content, /- \[ \] Implement/);
+    assert.deepEqual(result.canonicalArtifacts.baseSpecs.map((item) => item.path), [
+      'openspec/specs/auth/spec.md'
+    ]);
+    assert.deepEqual(result.canonicalArtifacts.deltaSpecs.map((item) => item.path), [
+      'openspec/changes/add-oauth/specs/auth/spec.md'
+    ]);
+  });
+
+  it('reads generated rules when present and warns when fingerprints are stale', async () => {
+    const { buildImplementationContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await createGeneratedRules(rootDir, 'add-oauth');
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.generatedRules.map((item) => item.path), [
+      '.ai-factory/rules/generated/openspec-merged-add-oauth.md',
+      '.ai-factory/rules/generated/openspec-change-add-oauth.md',
+      '.ai-factory/rules/generated/openspec-base.md'
+    ]);
+    assert.equal(result.generatedRules.every((item) => item.exists), true);
+    assert.ok(
+      result.warnings.some((warning) => warning.code === 'stale-generated-rules'),
+      'stale generated rules should warn when fingerprints differ'
+    );
+  });
+
+  it('warns when generated rules are missing', async () => {
+    const { buildImplementationContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.generatedRules.length, 3);
+    assert.equal(result.generatedRules.every((item) => item.exists === false), true);
+    assert.ok(
+      result.warnings.some((warning) => warning.code === 'missing-generated-rules'),
+      'missing generated rules should warn'
+    );
+  });
+
+  it('uses OpenSpec apply instructions when compatible CLI support is injected', async () => {
+    const { buildImplementationContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    const calls = [];
+    await createOpenSpecChange(rootDir, 'add-oauth');
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => availableCliDetection(),
+      getOpenSpecInstructions: async (artifact, options) => {
+        calls.push({ artifact, options });
+        return {
+          ok: true,
+          json: { steps: ['apply change'] },
+          stdout: '{"steps":["apply change"]}',
+          stderr: ''
+        };
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.map((call) => ({ artifact: call.artifact, change: call.options.change })), [
+      { artifact: 'apply', change: 'add-oauth' }
+    ]);
+    assert.deepEqual(result.openspecInstructions.json, { steps: ['apply change'] });
+    assert.equal(result.openspecInstructions.available, true);
+  });
+
+  it('does not fail context creation when OpenSpec CLI is missing', async () => {
+    const { buildImplementationContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.openspecInstructions.available, false);
+    assert.ok(
+      result.warnings.some((warning) => warning.code === 'openspec-instructions-unavailable'),
+      'missing CLI should produce degraded instructions warning'
+    );
+  });
+
+  it('builds fix context with QA evidence and warns or fails when QA evidence is missing', async () => {
+    const { buildFixContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth/verify.md', '# Verify\n');
+
+    const withQa = await buildFixContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(withQa.ok, true);
+    assert.deepEqual(withQa.qaEvidence.map((item) => item.path), [
+      '.ai-factory/qa/add-oauth/verify.md'
+    ]);
+
+    const missingRoot = await createTempRoot();
+    await createOpenSpecChange(missingRoot, 'add-oauth');
+
+    const missingQa = await buildFixContext({
+      rootDir: missingRoot,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(missingQa.ok, true);
+    assert.ok(
+      missingQa.warnings.some((warning) => warning.code === 'missing-qa-evidence'),
+      'missing QA evidence should warn by default'
+    );
+
+    const requiredQa = await buildFixContext({
+      rootDir: missingRoot,
+      changeId: 'add-oauth',
+      requireQaEvidence: true,
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(requiredQa.ok, false);
+    assert.equal(requiredQa.errors[0].code, 'missing-qa-evidence');
+  });
+
+  it('writes implementation and fix traces only under runtime state', async () => {
+    const {
+      writeExecutionTrace,
+      writeFixTrace
+    } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+
+    const execution = await writeExecutionTrace('add-oauth', {
+      summary: 'Implemented OAuth',
+      canonicalArtifactsRead: ['openspec/changes/add-oauth/tasks.md'],
+      generatedRulesRead: ['.ai-factory/rules/generated/openspec-base.md'],
+      changedFiles: ['src/auth.js']
+    }, {
+      rootDir,
+      runId: 'run-001'
+    });
+
+    const fix = await writeFixTrace('add-oauth', {
+      summary: 'Fixed OAuth',
+      canonicalArtifactsRead: ['openspec/changes/add-oauth/tasks.md'],
+      generatedRulesRead: [],
+      changedFiles: ['src/auth.js']
+    }, {
+      rootDir,
+      runId: 'fix-001'
+    });
+
+    assert.equal(execution.ok, true);
+    assert.equal(execution.relativePath, '.ai-factory/state/add-oauth/implementation/run-001.md');
+    assert.equal(fix.ok, true);
+    assert.equal(fix.relativePath, '.ai-factory/state/add-oauth/fixes/fix-001.md');
+    assert.match(await readFile(execution.path, 'utf8'), /# Implementation Trace: add-oauth/);
+    assert.match(await readFile(fix.path, 'utf8'), /# Fix Trace: add-oauth/);
+    assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', '.ai-factory')), false);
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'plans', 'add-oauth')), false);
+
+    await assert.rejects(
+      () => writeExecutionTrace('add-oauth', { summary: 'bad state' }, {
+        rootDir,
+        stateDir: 'openspec/changes',
+        runId: 'escape'
+      }),
+      /canonical runtime state directory/
+    );
+    assert.equal(
+      await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'implementation', 'escape.md')),
+      false
+    );
+  });
+
+  it('returns stable failure shape for unsafe change ids and rejects unsafe run ids', async () => {
+    const {
+      buildImplementationContext,
+      writeExecutionTrace
+    } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: '../escape',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.mode, 'openspec-native');
+    assert.equal(result.changeId, null);
+    assert.deepEqual(result.canonicalArtifacts, {});
+    assert.deepEqual(result.generatedRules, []);
+    assert.equal(result.errors[0].code, 'invalid-change-id');
+
+    await assert.rejects(
+      () => writeExecutionTrace('add-oauth', { summary: 'bad' }, { rootDir, runId: '../escape' }),
+      /Invalid OpenSpec run id/
+    );
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'state', 'add-oauth')), false);
+  });
+
+  it('does not require legacy plan-folder files for OpenSpec-native context', async () => {
+    const { buildImplementationContext } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+
+    const result = await buildImplementationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'plans', 'add-oauth', 'task.md')), false);
+  });
+
+  it('updates implement and fix prompt assets to reference execution context helper', async () => {
+    for (const relativePath of PROMPT_ASSETS) {
+      const content = await readFile(path.join(REPO_ROOT, relativePath), 'utf8');
+
+      assert.match(
+        content,
+        /openspec-execution-context\.mjs|buildImplementationContext|buildFixContext/,
+        `${relativePath} should reference the OpenSpec execution context helper`
+      );
+      assert.match(
+        content,
+        /\.ai-factory\/state\/<change-id>\//,
+        `${relativePath} should keep runtime traces under .ai-factory/state/<change-id>/`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared OpenSpec execution context helper for `/aif-implement` and `/aif-fix`
- Read canonical change artifacts, derived rules, QA evidence, and optional `instructions apply` output in OpenSpec-native mode
- Write implementation and fix traces only under `.ai-factory/state/<change-id>/`
- Update implement/fix prompt assets and docs to reflect the runtime contract

## Testing
- Added targeted unit coverage for context resolution, generated rules, QA evidence, trace writing, unsafe IDs, and missing CLI degradation
- `npm run validate` passed
- `npm test` passed