### PR TITLE
Add OpenSpec CLI finalization to /aif-done

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-When the OpenSpec CLI is unavailable, the extension remains usable. OpenSpec validation/archive capabilities are disabled until a compatible `openspec` CLI is available, but OpenSpec-native planning can still generate structurally correct artifacts with degraded validation.
+When the OpenSpec CLI is unavailable, the extension remains usable. OpenSpec validation/archive capabilities are disabled until a compatible `openspec` CLI is available, but OpenSpec-native planning can still generate structurally correct artifacts with degraded validation. `/aif-done` fails archive-required OpenSpec-native finalization when the CLI is missing.
 
 AI Factory-only mode follows the Node/runtime support of AI Factory and upstream. OpenSpec-native validation/archive requires Node `>=20.19.0` because that is the OpenSpec CLI runtime requirement.
 
@@ -37,7 +37,7 @@ OpenSpec can be initialized without tool integrations using `openspec init --too
 
 `/aif-improve` refines existing OpenSpec-native artifacts in place: `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`. It preserves user edits with patch-style changes, returns changed/preserved summary sections, warns or refuses archived changes, and keeps legacy plan-folder refinement as AI Factory-only behavior.
 
-Prompt assets for `/aif-implement`, `/aif-fix`, `/aif-verify`, `/aif-done`, `/aif-rules-check`, and bundled runtime agents are mode-gated. In OpenSpec-native mode they read canonical OpenSpec artifacts and write runtime/QA/finalizer state outside `openspec/changes`; in legacy AI Factory-only mode they keep using `.ai-factory/plans` plan-folder artifacts.
+Prompt assets for `/aif-implement`, `/aif-fix`, `/aif-verify`, `/aif-done`, `/aif-rules-check`, and bundled runtime agents are mode-gated. In OpenSpec-native mode they read canonical OpenSpec artifacts and write runtime/QA/finalizer state outside `openspec/changes`; in legacy AI Factory-only mode they keep using `.ai-factory/plans` plan-folder artifacts. `/aif-done` is the OpenSpec-native finalizer: it requires passing `/aif-verify` evidence, archives through `openspec archive <change-id> --yes` via the shared OpenSpec runner, supports `--skip-specs`, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`.
 
 See [OpenSpec Compatibility](docs/openspec-compatibility.md) for install/upgrade notes and the capability flags planned for runtime detection.
 
@@ -73,7 +73,7 @@ If verification finds issues:
 Optional explicit AIFHub finalizer after passing verification:
 
 ```bash
-/aif-done                     # archive, commit/PR drafts, evidence-driven follow-ups
+/aif-done                     # OpenSpec CLI archive, commit/PR drafts, evidence-driven follow-ups
 ```
 
 `/aif-analyze` здесь выступает отдельным bootstrap/setup step. Canonical public workflow начинается после него.
@@ -81,7 +81,7 @@ Optional explicit AIFHub finalizer after passing verification:
 ## What This Extension Adds
 
 - `aif-analyze` remains extension-owned and bootstraps `.ai-factory/config.yaml` plus `rules/base.md`; it can also prepare explicit OpenSpec-native config without installing OpenSpec skills.
-- `aif-done` is an explicit extension-owned AIFHub/Handoff finalizer that archives verified legacy plans or follows OpenSpec-native archive policy, drafts commit/PR summaries, and drives evidence-backed governance and evolution follow-ups.
+- `aif-done` is an explicit extension-owned AIFHub/Handoff finalizer that archives verified OpenSpec-native changes through OpenSpec CLI or archives verified legacy plans in AI Factory-only mode, drafts commit/PR summaries, and drives evidence-backed governance and evolution follow-ups.
 - `aif-plan`, `aif-explore`, `aif-improve`, `aif-implement`, `aif-verify`, `aif-fix`, `aif-roadmap`, and `aif-evolve` remain upstream skills with extension injections.
 - Full-mode planning is mode-gated:
   - OpenSpec-native mode creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs.

--- a/agent-files/claude/aifhub-done-finalizer.md
+++ b/agent-files/claude/aifhub-done-finalizer.md
@@ -15,13 +15,15 @@ Read `.ai-factory/config.yaml` before resolving scope. Reject `--force`, force f
 
 Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 
-- Finalize exactly one verification-passing active OpenSpec change.
-- Read QA evidence from `.ai-factory/qa/<change-id>/` and proceed only when the verdict is `pass` or `pass-with-notes`.
+- Finalize exactly one verification-passing active OpenSpec change through `scripts/openspec-done-finalizer.mjs`.
+- Read QA evidence from `.ai-factory/qa/<change-id>/` and proceed only when `/aif-verify` clearly passed for this change. Refuse unverified changes and `Code verification: PENDING`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present and runtime state from `.ai-factory/state/<change-id>/` when relevant.
-- Do not archive through legacy `.ai-factory/specs`. Full `openspec archive` integration is deferred to issue #33 or later runtime integration.
-- Allowed writes are limited to finalization runtime state under `.ai-factory/state/<change-id>/` when needed for drafts; do not write canonical OpenSpec artifacts unless a later finalizer contract explicitly owns that behavior.
-- Return selected active OpenSpec change, precondition state, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, archive integration status, commit/PR summary draft, governance follow-up result, and any `/aif-evolve` recommendation.
+- Check dirty working tree state before archive; fail or record dirty entries only when explicitly requested.
+- Archive only through `archiveOpenSpecChange` from `scripts/openspec-runner.mjs`: normal archive is `openspec archive <change-id> --yes`, and docs/tooling-only finalization uses `--skip-specs`.
+- `/aif-verify` does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
+- Allowed writes are `.ai-factory/qa/<change-id>/` final evidence and `.ai-factory/state/<change-id>/` final summaries; do not write runtime-only files into `openspec/changes/<change-id>/`.
+- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, and any `/aif-evolve` recommendation.
 
 ## Legacy AI Factory-only mode
 

--- a/agent-files/codex/aifhub-done-finalizer.toml
+++ b/agent-files/codex/aifhub-done-finalizer.toml
@@ -12,13 +12,15 @@ Read .ai-factory/config.yaml before resolving scope. Reject --force, force final
 
 Use this mode when config declares aifhub.artifactProtocol: openspec.
 
-- Finalize exactly one verification-passing active OpenSpec change.
-- Read QA evidence from .ai-factory/qa/<change-id>/ and proceed only when the verdict is pass or pass-with-notes.
+- Finalize exactly one verification-passing active OpenSpec change through scripts/openspec-done-finalizer.mjs.
+- Read QA evidence from .ai-factory/qa/<change-id>/ and proceed only when /aif-verify clearly passed for this change. Refuse unverified changes and Code verification: PENDING.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present and runtime state from .ai-factory/state/<change-id>/ when relevant.
-- Do not archive through legacy .ai-factory/specs. Full openspec archive integration is deferred to issue #33 or later runtime integration.
-- Allowed writes are limited to finalization runtime state under .ai-factory/state/<change-id>/ when needed for drafts; do not write canonical OpenSpec artifacts unless a later finalizer contract explicitly owns that behavior.
-- Return selected active OpenSpec change, precondition state, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, archive integration status, commit/PR summary draft, governance follow-up result, and any /aif-evolve recommendation.
+- Check dirty working tree state before archive; fail or record dirty entries only when explicitly requested.
+- Archive only through archiveOpenSpecChange from scripts/openspec-runner.mjs: normal archive is openspec archive <change-id> --yes, and docs/tooling-only finalization uses --skip-specs.
+- /aif-verify does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy .ai-factory/specs archive.
+- Allowed writes are .ai-factory/qa/<change-id>/ final evidence and .ai-factory/state/<change-id>/ final summaries; do not write runtime-only files into openspec/changes/<change-id>/.
+- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, and any /aif-evolve recommendation.
 
 ## Legacy AI Factory-only mode
 

--- a/docs/adr/0001-openspec-native-artifact-protocol.md
+++ b/docs/adr/0001-openspec-native-artifact-protocol.md
@@ -81,7 +81,7 @@ These paths are reserved names only in v1. Their detailed behavior is out of sco
 | `/aif-fix` | same as implement plus QA reports from `.ai-factory/qa/<id>/*` | none | `.ai-factory/state/<id>/fixes/*` | Fixes implementation, not specs unless explicitly requested; does not require legacy `.ai-factory/plans/<id>/task.md` |
 | `/aif-verify` | `openspec/*`, generated rules | none | `.ai-factory/qa/<id>/*` | Validates OpenSpec before code checks; must not archive |
 | `/aif-rules-check` | `openspec/specs`, `openspec/changes/<id>/specs` | none | none | Reads generated rules as derived guidance; never regenerates them |
-| `/aif-done` | `openspec/changes/<id>/*`, QA state | none until #33 archive integration; future `openspec/specs/*` via OpenSpec archive | final summary/state | Only finalizer may drive archive policy |
+| `/aif-done` | `openspec/changes/<id>/*`, QA state | `openspec/specs/*` only through OpenSpec CLI archive | `.ai-factory/qa/<id>/done.md`, archive evidence, `.ai-factory/state/<id>/final-summary.md` | Requires passing `/aif-verify`; supports `--skip-specs`; never custom-mutates OpenSpec specs |
 
 ## Generated rules policy
 
@@ -118,6 +118,8 @@ AIFHub Extension must not install OpenSpec skills or commands. If a compatible O
 
 For `/aif-verify`, invalid OpenSpec validation is a hard fail before lint, tests, or review. Missing or unsupported CLI remains degraded mode unless `aifhub.openspec.requireCliForVerify: true` requires strict CLI availability. Verification evidence belongs under `.ai-factory/qa/<change-id>/`, and `/aif-verify` does not archive.
 
+For `/aif-done`, OpenSpec-native archive is the finalizer step after passing `/aif-verify` evidence. It archives through `openspec archive <change-id> --yes` via the shared runner, supports `--skip-specs` for docs/tooling-only changes, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`. Missing or unsupported OpenSpec CLI fails archive-required finalization. Legacy `.ai-factory/specs` finalization remains AI Factory-only behavior.
+
 ## Legacy artifact policy
 
 Legacy `.ai-factory/plans` artifacts are pre-migration planning and execution records. Before migration is implemented, commands may read them as compatibility inputs and migration sources.
@@ -137,7 +139,7 @@ This ADR defines policy only; it does not implement migration.
 - OpenSpec capability detection
 - bootstrap changes
 - active-change resolver
-- concrete archive integration for #33 and migration behavior outside #32 verify validate/status runtime behavior
+- migration behavior outside verify validate/status runtime behavior
 
 ## Consequences
 
@@ -154,4 +156,4 @@ Tradeoffs:
 - Commands must distinguish canonical writes from runtime writes.
 - Legacy `.ai-factory/plans` consumers need migration or compatibility logic later.
 - Generated rules are operational only when the derived files are present and fresh; consumer migrations still need to preserve canonical OpenSpec precedence.
-- OpenSpec validate/archive remains unavailable until a compatible external CLI is present.
+- OpenSpec validate and archive-required done finalization remain unavailable until a compatible external CLI is present.

--- a/docs/claude-agents.md
+++ b/docs/claude-agents.md
@@ -15,7 +15,7 @@
 | `aifhub-verifier` | Low-write verifier для OpenSpec change or legacy plan pair и changed scope с gate result | Read, Write, Edit, Glob, Grep, Bash | `acceptEdits` | Только `.ai-factory/qa/<change-id>/` in OpenSpec-native mode or `status.yaml`/`verify.md` for validated legacy plan pair |
 | `aifhub-fixer` | Targeted fixer по выбранным verification/review findings | Read, Write, Edit, Glob, Grep, Bash | `acceptEdits` | Только validated changed scope выбранных findings plus `.ai-factory/state/<change-id>/` in OpenSpec-native mode or `status.yaml`/`fixes/*.md` |
 | `aifhub-rules-sidecar` | Read-only sidecar для проверки generated OpenSpec rules or `.ai-factory/RULES.md`, `.ai-factory/rules/base.md` и plan-local `rules.md` | Read, Glob, Grep | `dontAsk` | Не пишет файлы |
-| `aifhub-done-finalizer` | Finalization helper для OpenSpec deferred archive status или legacy archive/spec summary после passing verification | Read, Write, Edit, Glob, Grep, Bash | `acceptEdits` | OpenSpec-native finalizer state outside `openspec/changes` or legacy `status.yaml`, archive dir в `.ai-factory/specs/` и `.ai-factory/specs/index.yaml`; `--force` запрещён |
+| `aifhub-done-finalizer` | Finalization helper для OpenSpec CLI archive/final summary или legacy archive/spec summary после passing verification | Read, Write, Edit, Glob, Grep, Bash | `acceptEdits` | OpenSpec-native `.ai-factory/qa/<change-id>/` final evidence and `.ai-factory/state/<change-id>/` summary, with archive only through OpenSpec CLI; legacy `status.yaml`, archive dir в `.ai-factory/specs/` и `.ai-factory/specs/index.yaml`; `--force` запрещён |
 
 `name` является authoritative spawn-name. Filename нужен только как удобная convention в репозитории и в manifest.
 
@@ -24,7 +24,7 @@
 - `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope и возвращают findings-first output без auto-fix. Запускаются в фоне (`background: true`).
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
-- `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing plan и готовит summary/archive work.
+- `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, and prepares summary/archive evidence.
 
 ## Как это работает
 
@@ -55,7 +55,7 @@
 - Попросить plan polisher: `Используй aifhub-plan-polisher для точечной полировки текущего OpenSpec change или legacy плана без редактирования source code.`
 - Попросить verifier: `Запусти aifhub-verifier для active OpenSpec change or legacy plan pair и changed files. Обнови только verification artifacts и верни verdict с counts по findings.`
 - Попросить fixer: `Используй aifhub-fixer и исправь только findings B001 и I002, затем верни files modified и re-verify recommendation.`
-- Попросить done finalizer: `Запусти aifhub-done-finalizer для passing OpenSpec change или legacy plan. Для OpenSpec-native scope отчитай deferred archive status и finalizer state; для legacy scope используй `.ai-factory/specs/<plan-id>/` archive path. Подготовь commit/PR summary draft.`
+- Попросить done finalizer: `Запусти aifhub-done-finalizer для passing OpenSpec change или legacy plan. Для OpenSpec-native scope проверь /aif-verify evidence, archive through openspec archive <change-id> --yes, use --skip-specs for docs/tooling-only work, and report .ai-factory/qa/<change-id>/ plus .ai-factory/state/<change-id>/ outputs. Для legacy scope используй `.ai-factory/specs/<plan-id>/` archive path. Подготовь commit/PR summary draft.`
 
 Во всех случаях полезно явно задавать scope: какой plan, какие файлы или какой changed range должен анализироваться.
 
@@ -76,7 +76,7 @@
 - `aifhub-review-sidecar`, `aifhub-security-sidecar` и `aifhub-rules-sidecar` намеренно read-only; они не должны выполнять edits.
 - `aifhub-verifier` не должен писать code; его write scope ограничен QA/verification artifacts.
 - `aifhub-fixer` не должен делать unrelated refactor и не должен переписывать canonical OpenSpec artifacts or legacy plan artifacts вне выбранного finding scope.
-- `aifhub-done-finalizer` не должен напрямую обходить owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`; для этих файлов допустим только evidence-backed owner-safe update или exact handoff.
+- `aifhub-done-finalizer` не должен custom-mutating `openspec/specs`, manually moving OpenSpec change folders, archiving unverified changes, or using legacy `.ai-factory/specs` archive in OpenSpec-native mode; он также не должен напрямую обходить owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.
 - Эта страница не вводит новый runtime behavior; она документирует опубликованные `agentFiles` и naming contract.
 
 ## See Also

--- a/docs/codex-agents.md
+++ b/docs/codex-agents.md
@@ -15,7 +15,7 @@
 | `aifhub-verifier` | Low-write verifier для OpenSpec change or legacy plan pair и changed scope с gate result | `workspace-write` | Только `.ai-factory/qa/<change-id>/` in OpenSpec-native mode or `status.yaml`/`verify.md` for validated legacy plan pair |
 | `aifhub-fixer` | Targeted fixer по выбранным verification/review findings | `workspace-write` | Только validated changed scope выбранных findings plus `.ai-factory/state/<change-id>/` in OpenSpec-native mode or `status.yaml`/`fixes/*.md` for legacy plan pair; allowlist может только сузить уже подтверждённый scope |
 | `aifhub-rules-sidecar` | Read-only sidecar для проверки generated OpenSpec rules or `.ai-factory/RULES.md`, `.ai-factory/rules/base.md` и plan-local `rules.md` | `read-only` | Не пишет файлы |
-| `aifhub-done-finalizer` | Finalization helper для OpenSpec deferred archive status или legacy archive/spec summary после passing verification | `workspace-write` | OpenSpec-native finalizer state outside `openspec/changes` or legacy `status.yaml`, archive dir в `.ai-factory/specs/` и `.ai-factory/specs/index.yaml`; `--force` запрещён |
+| `aifhub-done-finalizer` | Finalization helper для OpenSpec CLI archive/final summary или legacy archive/spec summary после passing verification | `workspace-write` | OpenSpec-native `.ai-factory/qa/<change-id>/` final evidence and `.ai-factory/state/<change-id>/` summary, with archive only through OpenSpec CLI; legacy `status.yaml`, archive dir в `.ai-factory/specs/` и `.ai-factory/specs/index.yaml`; `--force` запрещён |
 
 `name` является authoritative spawn-name. Filename нужен только как удобная convention в репозитории и в manifest.
 
@@ -24,7 +24,7 @@
 - `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope и возвращают findings-first output без auto-fix.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
-- `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing plan и готовит summary/archive work, не обходя owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.
+- `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, prepares summary/archive evidence, and does not bypass owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.
 
 ## Как это работает
 
@@ -50,7 +50,7 @@
 - Попросить plan polisher: `Используй aifhub-plan-polisher для точечной полировки текущего OpenSpec change или legacy плана без редактирования source code.`
 - Попросить verifier: `Запусти aifhub-verifier для active OpenSpec change or legacy plan pair и changed files. Обнови только verification artifacts и верни verdict с counts по findings.`
 - Попросить fixer: `Используй aifhub-fixer и исправь только findings B001 и I002, затем верни files modified и re-verify recommendation.`
-- Попросить done finalizer: `Запусти aifhub-done-finalizer для passing OpenSpec change или legacy plan. Для OpenSpec-native scope отчитай deferred archive status и finalizer state; для legacy scope используй `.ai-factory/specs/<plan-id>/` archive path. Подготовь commit/PR summary draft.`
+- Попросить done finalizer: `Запусти aifhub-done-finalizer для passing OpenSpec change или legacy plan. Для OpenSpec-native scope проверь /aif-verify evidence, archive through openspec archive <change-id> --yes, use --skip-specs for docs/tooling-only work, and report .ai-factory/qa/<change-id>/ plus .ai-factory/state/<change-id>/ outputs. Для legacy scope используй `.ai-factory/specs/<plan-id>/` archive path. Подготовь commit/PR summary draft.`
 
 Во всех случаях полезно явно задавать scope: какой plan, какие файлы или какой changed range должен анализироваться.
 
@@ -59,7 +59,7 @@
 - `aifhub-review-sidecar`, `aifhub-security-sidecar` и `aifhub-rules-sidecar` намеренно read-only; они не должны выполнять edits.
 - `aifhub-verifier` не должен писать code; даже при `sandbox_mode = "workspace-write"` его write scope ограничен QA/verification artifacts.
 - `aifhub-fixer` не должен делать unrelated refactor и не должен переписывать canonical OpenSpec artifacts or legacy plan artifacts вне выбранного finding scope.
-- `aifhub-done-finalizer` не должен напрямую обходить owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`; для этих файлов допустим только evidence-backed owner-safe update или exact handoff.
+- `aifhub-done-finalizer` не должен custom-mutating `openspec/specs`, manually moving OpenSpec change folders, archiving unverified changes, or using legacy `.ai-factory/specs` archive in OpenSpec-native mode; он также не должен напрямую обходить owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.
 - `aifhub-plan-polisher` и `aifhub-implement-worker` write-capable, но их write scope всё равно ограничен инструкциями конкретного агента.
 - Эта страница не вводит новый runtime behavior; она документирует уже опубликованные `agentFiles`, naming contract и expected sandbox policy.
 

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -102,7 +102,7 @@ Special ownership case:
 - In OpenSpec-native mode, `aif-fix` consumes the same canonical OpenSpec artifacts plus QA evidence under `.ai-factory/qa/<change-id>/`. It writes fix traces only under `.ai-factory/state/<change-id>/fixes/` and does not require legacy `.ai-factory/plans/<id>/task.md`
 - In OpenSpec-native mode, `aif-implement` and `aif-fix` may change implementation source files within the selected task/finding scope; they do not rewrite canonical OpenSpec artifacts unless explicitly requested
 - In OpenSpec-native mode, `aif-verify` reads canonical OpenSpec artifacts, validates the active change before code checks when validation is enabled, writes OpenSpec validation/status evidence plus QA findings under `.ai-factory/qa/<change-id>/`, treats missing CLI as degraded mode unless strict config requires CLI, hard-fails invalid OpenSpec before lint/tests/review, and must not archive
-- In OpenSpec-native mode, `aif-done` follows OpenSpec archive policy and writes finalizer/runtime state outside `openspec/changes/<change-id>/`; concrete archive integration is tracked separately by #33
+- In OpenSpec-native mode, `aif-done` requires passing `/aif-verify` evidence, archives through `openspec archive <change-id> --yes` via the OpenSpec CLI runner, supports `--skip-specs`, writes final evidence under `.ai-factory/qa/<change-id>/`, writes final summaries under `.ai-factory/state/<change-id>/`, and does not use custom archive logic or legacy `.ai-factory/specs` finalization
 - Legacy `task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, and `explore.md` apply only to legacy AI Factory-only plan folders, not OpenSpec-native changes
 - no consumer skill may use bridge files as a substitute for these runtime paths
 
@@ -172,7 +172,7 @@ If `config.yaml` is missing or incomplete for the requested operation:
 - `.ai-factory/state/<change-id>/fixes/*` owner in OpenSpec-native mode: `/aif-fix` fix traces
 - `.ai-factory/state/<change-id>/*` owner in OpenSpec-native mode: runtime state for execution progress, fix notes, and git strategy; `/aif-explore` may own research-only state files
 - `.ai-factory/qa/<change-id>/*` owner in OpenSpec-native mode: `/aif-verify`
-- OpenSpec-native finalizer state owner: `/aif-done`; canonical archive writes remain governed by OpenSpec archive policy and #33
+- OpenSpec-native finalizer state owner: `/aif-done`; it owns `.ai-factory/qa/<change-id>/done.md`, `.ai-factory/qa/<change-id>/openspec-archive.json`, raw archive output, and `.ai-factory/state/<change-id>/final-summary.md`; canonical archive mutation must flow through OpenSpec CLI, not custom file movement
 - `.ai-factory/plans/<plan-id>.md` owner in legacy AI Factory-only mode: built-in `/aif-plan` with extension injection rules
 - `.ai-factory/plans/<plan-id>/status.yaml` owner in legacy AI Factory-only mode: `/aif-implement`, `/aif-verify`, `/aif-fix`
 - `rules/*.md` owner: `/aif-plan` when the active plan explicitly adds area-specific rules

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -83,7 +83,7 @@ When a compatible OpenSpec CLI is missing:
 - extension install remains valid
 - AI Factory bootstrap/config workflows may still run in AI Factory-only mode
 - OpenSpec-native validation is unavailable and `/aif-verify` continues in degraded mode unless `aifhub.openspec.requireCliForVerify: true`
-- OpenSpec-native archive is unavailable
+- OpenSpec-native archive-required `/aif-done` fails with an explicit CLI requirement
 - OpenSpec-aware commands should report capability flags instead of failing extension install
 
 OpenSpec skills and slash commands are not installed by this extension in v1.
@@ -106,4 +106,6 @@ openspec:
 
 `/aif-verify` uses `scripts/openspec-verification-context.mjs` with `scripts/openspec-runner.mjs` to validate the active OpenSpec change before normal code checks. Invalid OpenSpec artifacts hard-fail before lint, tests, or review. Validation/status evidence is written under `.ai-factory/qa/<change-id>/`; `/aif-verify` does not archive.
 
-The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap, planning, generated-rules guidance, and prompt assets for implement, fix, verify, done, rules-check, and runtime agents consume this capability shape. Runtime integrations remain scoped: #31 covers implementation/fix runtime state alignment, #32 covers verify validate/status runtime behavior, and #33 covers archive/finalizer integration.
+`/aif-done` is the OpenSpec-native finalizer. It refuses archive unless `/aif-verify` passed for the same change, guards dirty working tree state, archives through `openspec archive <change-id> --yes` via `scripts/openspec-runner.mjs`, supports `--skip-specs` for docs/tooling-only changes, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`. It does not use custom archive logic or legacy `.ai-factory/specs` archives in OpenSpec-native mode.
+
+The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap, planning, generated-rules guidance, and prompt assets for implement, fix, verify, done, rules-check, and runtime agents consume this capability shape. Runtime integrations remain scoped: #31 covers implementation/fix runtime state alignment, #32 covers verify validate/status runtime behavior, and done finalization covers archive/finalizer integration.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -254,7 +254,7 @@ Verify behavior:
 /aif-done
 ```
 
-`/aif-done` owns post-verify finalization, commit/PR drafting, and evidence-backed governance/evolution follow-ups. In OpenSpec-native mode it follows OpenSpec archive policy and writes finalizer state outside canonical change artifacts; concrete archive integration remains tracked by #33. In legacy AI Factory-only mode it archives the verified plan pair to `.ai-factory/specs/<plan-id>/`. `/aif-verify` remains verification-only, including `--check-only` runs.
+`/aif-done` owns post-verify finalization, commit/PR drafting, and evidence-backed governance/evolution follow-ups. In OpenSpec-native mode it requires passing `/aif-verify` evidence, guards dirty working tree state, archives through `openspec archive <change-id> --yes` via the shared OpenSpec runner, supports `--skip-specs` for docs/tooling-only changes, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`. Missing OpenSpec CLI fails archive-required finalization. In legacy AI Factory-only mode it archives the verified plan pair to `.ai-factory/specs/<plan-id>/`. `/aif-verify` remains verification-only, including `--check-only` runs.
 
 ### Review Gates (optional)
 
@@ -271,7 +271,7 @@ All three gates are independent and can run in any order. If any gate returns `F
 `/aif-done` — extension-owned explicit finalizer, работающий **после** passing verification:
 
 - Проверяет, что active work прошёл verify (verdict `pass` или `pass-with-notes`).
-- В OpenSpec-native mode follows OpenSpec archive policy and writes only finalizer/runtime state until #33 completes concrete archive integration.
+- В OpenSpec-native mode archives through OpenSpec CLI with `openspec archive <change-id> --yes`, supports `--skip-specs`, writes final QA evidence to `.ai-factory/qa/<change-id>/`, writes final summaries to `.ai-factory/state/<change-id>/`, and does not use custom archive logic.
 - В legacy AI Factory-only mode архивирует plan folder и companion plan file в `.ai-factory/specs/<plan-id>/`.
 - Готовит commit message draft.
 - Если есть feature branch и `gh` доступен — готовит PR summary draft. Без `gh` — выводит manual PR instructions.

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -1,0 +1,1322 @@
+// openspec-done-finalizer.mjs - shared OpenSpec done/finalization runtime helpers
+import { execFile } from 'node:child_process';
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+import {
+  ensureRuntimeLayout as defaultEnsureRuntimeLayout,
+  normalizeChangeId,
+  resolveActiveChange as defaultResolveActiveChange
+} from './active-change-resolver.mjs';
+import {
+  archiveOpenSpecChange as defaultArchiveOpenSpecChange,
+  detectOpenSpec as defaultDetectOpenSpec,
+  getOpenSpecStatus as defaultGetOpenSpecStatus
+} from './openspec-runner.mjs';
+import {
+  readLatestVerificationEvidence as defaultReadLatestVerificationEvidence
+} from './openspec-verification-context.mjs';
+import {
+  collectCanonicalChangeArtifacts,
+  collectGeneratedRules
+} from './openspec-execution-context.mjs';
+
+const execFileAsync = promisify(execFile);
+const MODE = 'openspec-native';
+const DEFAULT_STATE_DIR = path.join('.ai-factory', 'state');
+const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
+const ARCHIVE_JSON = 'openspec-archive.json';
+const DONE_MARKDOWN = 'done.md';
+const FINAL_SUMMARY_MARKDOWN = 'final-summary.md';
+
+export async function finalizeOpenSpecChange(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const context = await buildDoneContext({ ...options, rootDir });
+
+  if (!context.ok) {
+    return {
+      ...context,
+      status: 'FAIL',
+      archive: createSkippedArchiveSummary(context.changeId, options, 'context-failed'),
+      workingTree: null,
+      commitMessage: context.changeId ? createCommitMessage(context.changeId) : '',
+      prSummary: '',
+      summaryFiles: []
+    };
+  }
+
+  const workingTree = await detectWorkingTreeState({
+    ...options,
+    rootDir
+  });
+
+  if (!workingTree.ok) {
+    return createFinalizeFailure({
+      context,
+      workingTree,
+      archive: createSkippedArchiveSummary(context.changeId, options, 'dirty-working-tree'),
+      errors: workingTree.errors
+    });
+  }
+
+  const archive = await archiveChangeWithOpenSpec(context.changeId, {
+    ...options,
+    rootDir
+  });
+
+  const baseResult = {
+    ok: archive.ok,
+    mode: MODE,
+    changeId: context.changeId,
+    status: archive.ok ? archive.status : 'FAIL',
+    context,
+    verification: context.verification,
+    workingTree,
+    archive,
+    commitMessage: createCommitMessage(context.changeId),
+    prSummary: createPrSummary({
+      changeId: context.changeId,
+      context,
+      archive
+    }),
+    warnings: dedupeDiagnostics([
+      ...context.warnings,
+      ...workingTree.warnings,
+      ...archive.warnings
+    ]),
+    errors: archive.errors,
+    summaryFiles: []
+  };
+
+  if (!archive.ok) {
+    return baseResult;
+  }
+
+  const summary = await writeDoneSummary(context.changeId, baseResult, {
+    ...options,
+    rootDir,
+    qaPath: context.paths.qa,
+    statePath: context.paths.state
+  });
+
+  return {
+    ...baseResult,
+    summaryFiles: summary.files
+  };
+}
+
+export async function buildDoneContext(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const resolveActiveChange = options.resolveActiveChange ?? defaultResolveActiveChange;
+  const ensureRuntimeLayout = options.ensureRuntimeLayout ?? defaultEnsureRuntimeLayout;
+  const changeIdInput = options.changeId;
+  const resolverResult = await resolveActiveChange({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId: changeIdInput,
+    getCurrentBranch: options.getCurrentBranch
+  });
+
+  if (!resolverResult.ok) {
+    const archived = await detectArchivedFromFailedResolution(rootDir, changeIdInput, resolverResult);
+    if (archived !== null) {
+      const existingSummaries = await readExistingFinalSummaries(rootDir, archived.changeId);
+      return createContextFailure({
+        changeId: archived.changeId,
+        source: resolverResult.source,
+        candidates: resolverResult.candidates,
+        warnings: resolverResult.warnings,
+        existingSummaries,
+        errors: [
+          {
+            code: 'change-already-archived',
+            message: 'This change appears to be already archived.',
+            path: archived.path
+          }
+        ]
+      });
+    }
+
+    return createContextFailure({
+      changeId: resolverResult.changeId,
+      source: resolverResult.source,
+      candidates: resolverResult.candidates,
+      warnings: resolverResult.warnings,
+      errors: resolverResult.errors
+    });
+  }
+
+  const archived = await detectArchivedActiveChange(rootDir, resolverResult);
+  if (archived !== null) {
+    const existingSummaries = await readExistingFinalSummaries(rootDir, resolverResult.changeId);
+    return createContextFailure({
+      changeId: resolverResult.changeId,
+      source: resolverResult.source,
+      candidates: resolverResult.candidates,
+      warnings: resolverResult.warnings,
+      existingSummaries,
+      errors: [
+        {
+          code: 'change-already-archived',
+          message: 'This change appears to be already archived.',
+          path: archived.path
+        }
+      ]
+    });
+  }
+
+  const layout = await ensureRuntimeLayout(resolverResult.changeId, {
+    rootDir,
+    cwd: options.cwd,
+    stateDir: options.stateDir,
+    qaDir: options.qaDir
+  });
+  assertSafeRuntimePath(rootDir, layout.qaPath, 'QA evidence path');
+  assertSafeRuntimePath(rootDir, layout.statePath, 'State summary path');
+
+  const canonical = await collectCanonicalChangeArtifacts(resolverResult.changeId, {
+    ...options,
+    rootDir
+  });
+  const generatedRules = await collectGeneratedRules(resolverResult.changeId, {
+    ...options,
+    rootDir
+  });
+  const verification = await assertVerificationPassed(resolverResult.changeId, {
+    ...options,
+    rootDir
+  });
+  const runtimeTraces = await collectRuntimeTraces(rootDir, layout.statePath);
+  const openspec = await detectOpenSpecCapability(options, rootDir);
+  const warnings = dedupeDiagnostics([
+    ...resolverResult.warnings,
+    ...canonical.warnings,
+    ...generatedRules.warnings,
+    ...verification.warnings,
+    ...runtimeTraces.warnings,
+    ...openspec.warnings
+  ]);
+  const errors = [
+    ...canonical.errors,
+    ...generatedRules.errors,
+    ...verification.errors,
+    ...runtimeTraces.errors,
+    ...openspec.errors
+  ];
+
+  return {
+    ok: errors.length === 0,
+    mode: MODE,
+    changeId: resolverResult.changeId,
+    resolver: createResolverSummary(resolverResult),
+    paths: {
+      change: resolverResult.changePath,
+      state: layout.statePath,
+      qa: layout.qaPath
+    },
+    verification: verification.verification,
+    openspec: openspec.openspec,
+    canonicalArtifacts: canonical.canonicalArtifacts,
+    runtimeTraces: runtimeTraces.runtimeTraces,
+    generatedRules: generatedRules.generatedRules,
+    warnings,
+    errors
+  };
+}
+
+export async function assertVerificationPassed(changeId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return createVerificationFailure({
+      changeId: null,
+      code: normalized.error.code,
+      message: normalized.error.message,
+      evidence: null
+    });
+  }
+
+  const readLatestVerificationEvidence = options.readLatestVerificationEvidence ?? defaultReadLatestVerificationEvidence;
+  const evidence = await readLatestVerificationEvidence(normalized.changeId, {
+    ...options,
+    rootDir
+  });
+
+  if (!evidence?.verify?.exists) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-evidence-missing',
+      message: `Run /aif-verify ${normalized.changeId} before /aif-done.`,
+      evidence
+    });
+  }
+
+  if (evidence.changeId !== null && evidence.changeId !== undefined && evidence.changeId !== normalized.changeId) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-ambiguous',
+      message: 'Verification evidence is ambiguous; rerun /aif-verify before finalizing.',
+      evidence
+    });
+  }
+
+  if (Array.isArray(evidence.errors) && evidence.errors.length > 0) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-not-passed',
+      message: 'Refusing to archive because verification did not pass.',
+      evidence
+    });
+  }
+
+  const validation = evidence.validation;
+  if (validation === null || validation === undefined) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-ambiguous',
+      message: 'Verification evidence is ambiguous; rerun /aif-verify before finalizing.',
+      evidence
+    });
+  }
+
+  if (!validation.ok) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-not-passed',
+      message: 'Refusing to archive because verification did not pass.',
+      evidence
+    });
+  }
+
+  const verifyContent = evidence.verify.content ?? '';
+  if (/\b(Code verification:\s*PENDING|Code verification:\s*BLOCKED)\b/i.test(verifyContent)) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-ambiguous',
+      message: 'Verification evidence is ambiguous; rerun /aif-verify before finalizing.',
+      evidence
+    });
+  }
+
+  if (/\b(Verdict:\s*FAIL|OpenSpec validation:\s*FAIL|\/aif-verify:\s*FAIL)\b/i.test(verifyContent)) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-not-passed',
+      message: 'Refusing to archive because verification did not pass.',
+      evidence
+    });
+  }
+
+  if (!hasFinalPassSignal(verifyContent)) {
+    return createVerificationFailure({
+      changeId: normalized.changeId,
+      code: 'verification-ambiguous',
+      message: 'Verification evidence is ambiguous; rerun /aif-verify before finalizing.',
+      evidence
+    });
+  }
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    passed: true,
+    verification: normalizeVerificationSummary(evidence, true),
+    warnings: evidence.warnings ?? [],
+    errors: []
+  };
+}
+
+export async function archiveChangeWithOpenSpec(changeId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return createArchiveFailure({
+      changeId: null,
+      skipSpecs: Boolean(options.skipSpecs),
+      error: normalized.error
+    });
+  }
+
+  const skipSpecs = Boolean(options.skipSpecs);
+
+  if (options.skipArchive || options.dryRun || options.summaryOnly) {
+    const archive = {
+      ok: true,
+      changeId: normalized.changeId,
+      status: 'DRY-RUN',
+      archived: false,
+      skipSpecs,
+      command: null,
+      args: [],
+      exitCode: null,
+      rawStdoutPath: null,
+      rawStderrPath: null,
+      stdout: '',
+      stderr: '',
+      preArchiveStatus: null,
+      warnings: [
+        {
+          code: 'archive-skipped',
+          message: 'Archive did not run because dry-run or summary-only mode was explicitly requested.'
+        }
+      ],
+      errors: []
+    };
+
+    await writeArchiveEvidence(normalized.changeId, archive, { ...options, rootDir });
+    return archive;
+  }
+
+  const detectOpenSpec = options.detectOpenSpec ?? defaultDetectOpenSpec;
+  const detection = await detectOpenSpec(createRunOptions(options, rootDir));
+
+  if (!detection?.available || !detection?.canArchive) {
+    const archive = createArchiveFailure({
+      changeId: normalized.changeId,
+      skipSpecs,
+      error: {
+        code: 'openspec-cli-required-for-archive',
+        message: 'OpenSpec CLI is required to archive this change.',
+        detail: detection?.errors?.[0]?.message ?? detection?.reason ?? null
+      }
+    });
+    await writeArchiveEvidence(normalized.changeId, archive, { ...options, rootDir });
+    return archive;
+  }
+
+  const preArchiveStatus = await readPreArchiveStatus(normalized.changeId, options, rootDir);
+  const archiveOpenSpecChange = options.archiveOpenSpecChange ?? defaultArchiveOpenSpecChange;
+  const archiveOptions = createRunOptions(options, rootDir);
+
+  if (skipSpecs) {
+    archiveOptions.skipSpecs = true;
+  }
+
+  if (options.noValidate) {
+    archiveOptions.noValidate = true;
+  }
+
+  const rawArchive = await archiveOpenSpecChange(normalized.changeId, archiveOptions);
+  const archive = normalizeArchiveResult(normalized.changeId, rawArchive, {
+    rootDir,
+    skipSpecs,
+    preArchiveStatus
+  });
+
+  await writeArchiveEvidence(normalized.changeId, archive, { ...options, rootDir });
+
+  return archive;
+}
+
+export async function writeDoneSummary(changeId, summary, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error.message);
+  }
+
+  const qaPath = options.qaPath !== undefined
+    ? path.resolve(options.qaPath)
+    : path.join(rootDir, DEFAULT_QA_DIR, normalized.changeId);
+  const statePath = options.statePath !== undefined
+    ? path.resolve(options.statePath)
+    : path.join(rootDir, DEFAULT_STATE_DIR, normalized.changeId);
+
+  assertSafeRuntimePath(rootDir, qaPath, 'QA evidence path');
+  assertSafeRuntimePath(rootDir, statePath, 'State summary path');
+
+  await mkdir(qaPath, { recursive: true });
+  await mkdir(statePath, { recursive: true });
+
+  const donePath = path.join(qaPath, DONE_MARKDOWN);
+  const finalSummaryPath = path.join(statePath, FINAL_SUMMARY_MARKDOWN);
+  await writeFile(donePath, `${renderDoneMarkdown(normalized.changeId, summary)}\n`, 'utf8');
+  await writeFile(finalSummaryPath, `${renderFinalSummaryMarkdown(summary)}\n`, 'utf8');
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    files: [
+      toPosix(path.relative(rootDir, donePath)),
+      toPosix(path.relative(rootDir, finalSummaryPath))
+    ],
+    warnings: [],
+    errors: []
+  };
+}
+
+export async function detectWorkingTreeState(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const gitStatus = options.gitStatus ?? defaultGitStatus;
+  let status;
+
+  try {
+    status = await gitStatus({ cwd: rootDir });
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      return createNonGitWorkingTree(err.message);
+    }
+
+    throw err;
+  }
+
+  const exitCode = status?.exitCode ?? 0;
+  const stdout = normalizeOutput(status?.stdout);
+  const stderr = normalizeOutput(status?.stderr);
+
+  if (exitCode !== 0) {
+    if (/not a git repository/i.test(stderr) || /not a git repository/i.test(stdout)) {
+      return createNonGitWorkingTree(stderr || stdout);
+    }
+
+    return {
+      ok: false,
+      isGitRepo: true,
+      dirty: false,
+      entries: [],
+      warnings: [],
+      errors: [
+        {
+          code: 'git-status-failed',
+          message: 'Unable to inspect working tree state.',
+          detail: stderr || stdout || null
+        }
+      ]
+    };
+  }
+
+  const entries = stdout.split(/\r?\n/).filter((line) => line.length > 0);
+  const dirty = entries.length > 0;
+
+  if (!dirty) {
+    return {
+      ok: true,
+      isGitRepo: true,
+      dirty: false,
+      entries: [],
+      warnings: [],
+      errors: []
+    };
+  }
+
+  if (options.allowDirty || options.recordDirtyState) {
+    return {
+      ok: true,
+      isGitRepo: true,
+      dirty: true,
+      entries,
+      warnings: [
+        {
+          code: 'dirty-working-tree-recorded',
+          message: 'Working tree dirty state was recorded because explicit dirty-state recording is enabled.'
+        }
+      ],
+      errors: []
+    };
+  }
+
+  return {
+    ok: false,
+    isGitRepo: true,
+    dirty: true,
+    entries,
+    warnings: [],
+    errors: [
+      {
+        code: 'dirty-working-tree',
+        message: 'Working tree has uncommitted changes. Commit/stash or run with explicit dirty-state recording.'
+      }
+    ]
+  };
+}
+
+export function summarizeDoneResult(result, options = {}) {
+  const status = result?.status ?? (result?.ok ? 'PASS' : 'FAIL');
+  const changeId = result?.changeId ?? '<change-id>';
+  const archived = result?.archive?.archived ? 'yes' : 'no';
+  const skipSpecs = result?.archive?.skipSpecs ? 'yes' : 'no';
+  const lines = [
+    `Finalization status: ${status}`,
+    `Change: ${changeId}`,
+    `Archived: ${archived}`,
+    `Skip specs: ${skipSpecs}`
+  ];
+
+  if (Array.isArray(result?.summaryFiles) && result.summaryFiles.length > 0) {
+    lines.push('Summary files:');
+    lines.push(...result.summaryFiles.map((file) => `- ${file}`));
+  }
+
+  if (options.includeErrors && Array.isArray(result?.errors) && result.errors.length > 0) {
+    lines.push('Errors:');
+    lines.push(...result.errors.map((error) => `- ${error.code}: ${error.message}`));
+  }
+
+  return lines.join('\n');
+}
+
+async function writeArchiveEvidence(changeId, archive, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const qaPath = resolveQaPath(rootDir, changeId, options);
+  assertSafeRuntimePath(rootDir, qaPath, 'QA evidence path');
+
+  const rawDir = path.join(qaPath, 'raw');
+  await mkdir(rawDir, { recursive: true });
+
+  const stdout = normalizeOutput(archive.stdout);
+  const stderr = normalizeOutput(archive.stderr);
+  const stdoutPath = archive.command !== null
+    ? path.join(rawDir, 'openspec-archive.stdout')
+    : null;
+  const stderrPath = archive.command !== null
+    ? path.join(rawDir, 'openspec-archive.stderr')
+    : null;
+
+  if (stdoutPath !== null) {
+    await writeFile(stdoutPath, stdout, 'utf8');
+  }
+
+  if (stderrPath !== null) {
+    await writeFile(stderrPath, stderr, 'utf8');
+  }
+
+  const evidence = {
+    changeId,
+    archived: Boolean(archive.archived),
+    skipSpecs: Boolean(archive.skipSpecs),
+    command: archive.command,
+    args: Array.from(archive.args ?? []),
+    exitCode: archive.exitCode ?? null,
+    ok: Boolean(archive.ok),
+    status: archive.status ?? (archive.ok ? 'PASS' : 'FAIL'),
+    preArchiveStatus: archive.preArchiveStatus ?? null,
+    rawStdoutPath: stdoutPath === null ? null : toPosix(path.relative(rootDir, stdoutPath)),
+    rawStderrPath: stderrPath === null ? null : toPosix(path.relative(rootDir, stderrPath)),
+    error: archive.error ?? null,
+    warnings: archive.warnings ?? [],
+    errors: archive.errors ?? []
+  };
+
+  await writeFile(path.join(qaPath, ARCHIVE_JSON), `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+
+  archive.rawStdoutPath = evidence.rawStdoutPath;
+  archive.rawStderrPath = evidence.rawStderrPath;
+
+  return {
+    ok: true,
+    path: toPosix(path.relative(rootDir, path.join(qaPath, ARCHIVE_JSON)))
+  };
+}
+
+async function readPreArchiveStatus(changeId, options, rootDir) {
+  const getOpenSpecStatus = options.getOpenSpecStatus ?? defaultGetOpenSpecStatus;
+
+  try {
+    const status = await getOpenSpecStatus(changeId, createRunOptions(options, rootDir));
+    return {
+      ok: Boolean(status?.ok),
+      command: status?.command ?? null,
+      args: Array.from(status?.args ?? []),
+      exitCode: status?.exitCode ?? null,
+      json: status?.json ?? null,
+      stdout: normalizeOutput(status?.stdout),
+      stderr: normalizeOutput(status?.stderr),
+      error: status?.error ?? null
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      command: 'openspec',
+      args: ['status', '--change', changeId, '--json', '--no-color'],
+      exitCode: null,
+      json: null,
+      stdout: '',
+      stderr: '',
+      error: {
+        code: err?.code ?? 'openspec-status-failed',
+        message: err?.message ?? 'OpenSpec status failed before archive.'
+      }
+    };
+  }
+}
+
+function normalizeArchiveResult(changeId, result, { skipSpecs, preArchiveStatus }) {
+  const ok = Boolean(result?.ok);
+  const error = result?.error ?? null;
+  const warnings = [];
+
+  if (preArchiveStatus !== null && preArchiveStatus.ok === false) {
+    warnings.push({
+      code: 'openspec-status-unavailable',
+      message: 'OpenSpec status was unavailable before archive; archive result is still authoritative.',
+      detail: preArchiveStatus.error?.message ?? null
+    });
+  }
+
+  return {
+    ok,
+    changeId,
+    status: ok ? 'PASS' : 'FAIL',
+    archived: ok,
+    skipSpecs,
+    command: result?.command ?? 'openspec',
+    args: Array.from(result?.args ?? []),
+    exitCode: result?.exitCode ?? null,
+    stdout: normalizeOutput(result?.stdout),
+    stderr: normalizeOutput(result?.stderr),
+    rawStdoutPath: null,
+    rawStderrPath: null,
+    preArchiveStatus,
+    error,
+    warnings,
+    errors: ok ? [] : [
+      error ?? {
+        code: 'openspec-archive-failed',
+        message: 'OpenSpec archive command failed.'
+      }
+    ]
+  };
+}
+
+function createArchiveFailure({ changeId, skipSpecs, error }) {
+  return {
+    ok: false,
+    changeId,
+    status: 'FAIL',
+    archived: false,
+    skipSpecs,
+    command: null,
+    args: [],
+    exitCode: null,
+    stdout: '',
+    stderr: '',
+    rawStdoutPath: null,
+    rawStderrPath: null,
+    preArchiveStatus: null,
+    error,
+    warnings: [],
+    errors: [error]
+  };
+}
+
+function createSkippedArchiveSummary(changeId, options, reason) {
+  return {
+    ok: false,
+    changeId,
+    status: 'SKIPPED',
+    archived: false,
+    skipSpecs: Boolean(options?.skipSpecs),
+    command: null,
+    args: [],
+    exitCode: null,
+    rawStdoutPath: null,
+    rawStderrPath: null,
+    warnings: [
+      {
+        code: reason,
+        message: 'Archive did not run.'
+      }
+    ],
+    errors: []
+  };
+}
+
+function createFinalizeFailure({ context, workingTree, archive, errors }) {
+  return {
+    ok: false,
+    mode: MODE,
+    changeId: context.changeId,
+    status: 'FAIL',
+    context,
+    verification: context.verification,
+    workingTree,
+    archive,
+    commitMessage: createCommitMessage(context.changeId),
+    prSummary: createPrSummary({
+      changeId: context.changeId,
+      context,
+      archive
+    }),
+    warnings: dedupeDiagnostics([
+      ...context.warnings,
+      ...(workingTree?.warnings ?? []),
+      ...(archive?.warnings ?? [])
+    ]),
+    errors,
+    summaryFiles: []
+  };
+}
+
+function createVerificationFailure({ changeId, code, message, evidence }) {
+  return {
+    ok: false,
+    changeId,
+    passed: false,
+    verification: normalizeVerificationSummary(evidence, false),
+    warnings: evidence?.warnings ?? [],
+    errors: [
+      {
+        code,
+        message
+      }
+    ]
+  };
+}
+
+function normalizeVerificationSummary(evidence, passed) {
+  return {
+    exists: Boolean(evidence?.verify?.exists || evidence?.validation),
+    passed,
+    validation: evidence?.validation ?? null,
+    status: evidence?.status ?? null,
+    verify: {
+      exists: Boolean(evidence?.verify?.exists),
+      path: evidence?.verify?.path ?? null,
+      content: evidence?.verify?.content ?? ''
+    },
+    warnings: evidence?.warnings ?? [],
+    errors: evidence?.errors ?? []
+  };
+}
+
+function hasFinalPassSignal(content) {
+  return /\bVerdict:\s*PASS(?:-with-notes)?\b/i.test(content)
+    || /\b\/aif-verify:\s*PASS\b/i.test(content)
+    || /\bCode verification:\s*PASS\b/i.test(content);
+}
+
+async function detectOpenSpecCapability(options, rootDir) {
+  const detectOpenSpec = options.detectOpenSpec ?? defaultDetectOpenSpec;
+
+  try {
+    const detection = await detectOpenSpec(createRunOptions(options, rootDir));
+    return {
+      openspec: {
+        available: Boolean(detection?.available),
+        canArchive: Boolean(detection?.canArchive),
+        canValidate: Boolean(detection?.canValidate),
+        version: detection?.version ?? null,
+        command: detection?.command ?? 'openspec',
+        reason: detection?.reason ?? null,
+        errors: detection?.errors ?? []
+      },
+      warnings: [],
+      errors: []
+    };
+  } catch (err) {
+    return {
+      openspec: {
+        available: false,
+        canArchive: false,
+        canValidate: false,
+        version: null,
+        command: 'openspec',
+        reason: 'detection-failed',
+        errors: [
+          {
+            code: err?.code ?? 'openspec-detection-failed',
+            message: err?.message ?? 'OpenSpec detection failed.'
+          }
+        ]
+      },
+      warnings: [
+        {
+          code: 'openspec-detection-failed',
+          message: 'OpenSpec detection failed; archive may not be available.'
+        }
+      ],
+      errors: []
+    };
+  }
+}
+
+async function collectRuntimeTraces(rootDir, statePath) {
+  const implementation = await collectTextFiles(rootDir, path.join(statePath, 'implementation'));
+  const fixes = await collectTextFiles(rootDir, path.join(statePath, 'fixes'));
+
+  return {
+    runtimeTraces: [...fixes, ...implementation].sort((left, right) => left.path.localeCompare(right.path)),
+    warnings: [],
+    errors: []
+  };
+}
+
+async function collectTextFiles(rootDir, directoryPath) {
+  if (!await isDirectory(directoryPath)) {
+    return [];
+  }
+
+  const paths = [];
+  await collectFilePaths(directoryPath, paths);
+  const sorted = paths.sort((left, right) => toPosix(path.relative(rootDir, left)).localeCompare(toPosix(path.relative(rootDir, right))));
+  const result = [];
+
+  for (const filePath of sorted) {
+    result.push({
+      path: toPosix(path.relative(rootDir, filePath)),
+      content: await readFile(filePath, 'utf8')
+    });
+  }
+
+  return result;
+}
+
+async function collectFilePaths(directoryPath, filePaths) {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const childPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      await collectFilePaths(childPath, filePaths);
+    } else if (entry.isFile()) {
+      filePaths.push(childPath);
+    }
+  }
+}
+
+async function detectArchivedFromFailedResolution(rootDir, changeIdInput, resolverResult) {
+  if (
+    resolverResult?.errors?.[0]?.code !== 'explicit-change-not-found'
+    || changeIdInput === undefined
+    || changeIdInput === null
+  ) {
+    return null;
+  }
+
+  const normalized = normalizeChangeId(String(changeIdInput));
+
+  if (!normalized.ok) {
+    return null;
+  }
+
+  return findArchivedChange(rootDir, normalized.changeId);
+}
+
+async function detectArchivedActiveChange(rootDir, resolverResult) {
+  const archiveDir = path.join(rootDir, 'openspec', 'changes', 'archive');
+  const changePath = resolverResult?.changePath;
+
+  if (typeof changePath === 'string' && isWithinDirectory(path.resolve(changePath), archiveDir)) {
+    return {
+      changeId: resolverResult.changeId,
+      path: toPosix(path.relative(rootDir, changePath))
+    };
+  }
+
+  if (!await pathExists(changePath)) {
+    return findArchivedChange(rootDir, resolverResult.changeId);
+  }
+
+  return null;
+}
+
+async function findArchivedChange(rootDir, changeId) {
+  const archiveDir = path.join(rootDir, 'openspec', 'changes', 'archive');
+
+  if (!await isDirectory(archiveDir)) {
+    return null;
+  }
+
+  const matches = [];
+  await collectArchivedMatches(rootDir, archiveDir, changeId, matches);
+  matches.sort((left, right) => left.path.localeCompare(right.path));
+  return matches[0] ?? null;
+}
+
+async function collectArchivedMatches(rootDir, directoryPath, changeId, matches) {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const childPath = path.join(directoryPath, entry.name);
+
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    if (entry.name === changeId) {
+      matches.push({
+        changeId,
+        path: toPosix(path.relative(rootDir, childPath))
+      });
+    }
+
+    await collectArchivedMatches(rootDir, childPath, changeId, matches);
+  }
+}
+
+async function readExistingFinalSummaries(rootDir, changeId) {
+  const candidates = [
+    path.join(rootDir, DEFAULT_QA_DIR, changeId, DONE_MARKDOWN),
+    path.join(rootDir, DEFAULT_STATE_DIR, changeId, FINAL_SUMMARY_MARKDOWN)
+  ];
+  const summaries = [];
+
+  for (const filePath of candidates) {
+    if (!await pathExists(filePath)) {
+      continue;
+    }
+
+    summaries.push({
+      path: toPosix(path.relative(rootDir, filePath)),
+      content: await readFile(filePath, 'utf8')
+    });
+  }
+
+  return summaries;
+}
+
+function createContextFailure({ changeId, source, candidates = [], warnings = [], errors = [], existingSummaries = [] }) {
+  return {
+    ok: false,
+    mode: MODE,
+    changeId,
+    resolver: {
+      source: source ?? null,
+      candidates,
+      warnings
+    },
+    paths: {},
+    verification: {
+      exists: false,
+      passed: false,
+      validation: null,
+      status: null,
+      verify: {
+        exists: false,
+        path: null,
+        content: ''
+      }
+    },
+    openspec: {
+      available: false,
+      canArchive: false,
+      canValidate: false,
+      version: null,
+      command: 'openspec',
+      reason: null,
+      errors: []
+    },
+    canonicalArtifacts: {},
+    runtimeTraces: [],
+    generatedRules: [],
+    existingSummaries,
+    warnings: dedupeDiagnostics(warnings),
+    errors
+  };
+}
+
+function createResolverSummary(result) {
+  return {
+    source: result?.source ?? null,
+    candidates: result?.candidates ?? [],
+    warnings: result?.warnings ?? []
+  };
+}
+
+function createCommitMessage(changeId) {
+  return `feat: finalize ${changeId}`;
+}
+
+function createPrSummary({ changeId, context, archive }) {
+  const validationState = summarizeValidationState(context?.verification?.validation);
+  const codeState = summarizeCodeState(context?.verification?.verify?.content);
+  return [
+    '## Summary',
+    '',
+    `- Finalized OpenSpec change \`${changeId}\`.`,
+    `- Prepared final QA and state summaries for \`${changeId}\`.`,
+    '',
+    '## OpenSpec',
+    '',
+    `- Change: ${changeId}`,
+    `- Archived: ${archive?.archived ? 'yes' : 'no'}`,
+    `- Skip specs: ${archive?.skipSpecs ? 'yes' : 'no'}`,
+    '',
+    '## Verification',
+    '',
+    '- /aif-verify: PASS',
+    `- OpenSpec validation: ${validationState}`,
+    `- Code verification: ${codeState}`,
+    '',
+    '## Artifacts',
+    '',
+    `- .ai-factory/qa/${changeId}/done.md`,
+    `- .ai-factory/qa/${changeId}/openspec-archive.json`,
+    `- .ai-factory/state/${changeId}/final-summary.md`,
+    ''
+  ].join('\n');
+}
+
+function renderDoneMarkdown(changeId, summary) {
+  const context = summary.context ?? {};
+  const archive = summary.archive ?? {};
+  const verificationGate = context?.verification?.passed ? 'PASS' : 'FAIL';
+  const finalizationStatus = summary.status ?? (summary.ok ? 'PASS' : 'FAIL');
+  const canonicalPaths = collectCanonicalArtifactPaths(context.canonicalArtifacts);
+  const qaEvidencePaths = collectQaEvidencePaths(changeId, context.verification);
+  const runtimeTracePaths = Array.isArray(context.runtimeTraces)
+    ? context.runtimeTraces.map((trace) => trace.path)
+    : [];
+
+  return [
+    `# Done: ${changeId}`,
+    '',
+    '## Finalization status',
+    '',
+    finalizationStatus,
+    '',
+    '## Verification gate',
+    '',
+    verificationGate,
+    '',
+    '## OpenSpec archive',
+    '',
+    `Archived: ${archive.archived ? 'yes' : 'no'}`,
+    `Skip specs: ${archive.skipSpecs ? 'yes' : 'no'}`,
+    '',
+    '## Canonical artifacts finalized',
+    '',
+    ...renderList(canonicalPaths),
+    '',
+    '## QA evidence',
+    '',
+    ...renderList(qaEvidencePaths),
+    '',
+    '## Runtime traces',
+    '',
+    ...renderList(runtimeTracePaths),
+    '',
+    '## Working tree',
+    '',
+    ...renderList(summary.workingTree?.entries ?? ['clean']),
+    '',
+    '## Suggested commit message',
+    '',
+    summary.commitMessage ?? createCommitMessage(changeId),
+    '',
+    '## Suggested PR summary',
+    '',
+    summary.prSummary ?? createPrSummary({ changeId, context, archive })
+  ].join('\n');
+}
+
+function renderFinalSummaryMarkdown(summary) {
+  return [
+    `# Final Summary: ${summary.changeId}`,
+    '',
+    '## Suggested commit message',
+    '',
+    summary.commitMessage ?? createCommitMessage(summary.changeId),
+    '',
+    '## Suggested PR summary',
+    '',
+    summary.prSummary ?? ''
+  ].join('\n');
+}
+
+function collectCanonicalArtifactPaths(canonicalArtifacts = {}) {
+  const paths = [];
+
+  for (const key of ['proposal', 'design', 'tasks']) {
+    if (canonicalArtifacts?.[key]?.path !== undefined) {
+      paths.push(canonicalArtifacts[key].path);
+    }
+  }
+
+  for (const listKey of ['baseSpecs', 'deltaSpecs']) {
+    for (const item of canonicalArtifacts?.[listKey] ?? []) {
+      paths.push(item.path);
+    }
+  }
+
+  return paths;
+}
+
+function collectQaEvidencePaths(changeId, verification) {
+  const paths = [
+    verification?.verify?.path,
+    `.ai-factory/qa/${changeId}/${ARCHIVE_JSON}`,
+    `.ai-factory/qa/${changeId}/${DONE_MARKDOWN}`
+  ].filter(Boolean);
+
+  if (verification?.validation !== null && verification?.validation !== undefined) {
+    paths.push(`.ai-factory/qa/${changeId}/openspec-validation.json`);
+  }
+
+  if (verification?.status !== null && verification?.status !== undefined) {
+    paths.push(`.ai-factory/qa/${changeId}/openspec-status.json`);
+  }
+
+  return Array.from(new Set(paths));
+}
+
+function summarizeValidationState(validation) {
+  if (validation === null || validation === undefined) {
+    return 'UNKNOWN';
+  }
+
+  if (validation.skipped && validation.ok) {
+    return 'SKIPPED';
+  }
+
+  return validation.ok ? 'PASS' : 'FAIL';
+}
+
+function summarizeCodeState(content = '') {
+  const match = String(content).match(/Code verification:\s*([A-Z-]+)/i);
+  return match?.[1]?.toUpperCase() ?? 'UNKNOWN';
+}
+
+function renderList(values) {
+  const items = Array.isArray(values) ? values.filter((value) => String(value).trim().length > 0) : [];
+
+  if (items.length === 0) {
+    return ['- none'];
+  }
+
+  return items.map((item) => `- ${item}`);
+}
+
+function createRunOptions(options, rootDir) {
+  const runOptions = {
+    cwd: rootDir,
+    command: options.command,
+    env: options.env,
+    executor: options.executor,
+    nodeVersion: options.nodeVersion
+  };
+
+  for (const key of Object.keys(runOptions)) {
+    if (runOptions[key] === undefined) {
+      delete runOptions[key];
+    }
+  }
+
+  return runOptions;
+}
+
+function resolveQaPath(rootDir, changeId, options) {
+  if (options.qaPath !== undefined) {
+    return path.resolve(options.qaPath);
+  }
+
+  const qaRoot = path.resolve(rootDir, options.qaDir ?? DEFAULT_QA_DIR);
+  return path.join(qaRoot, changeId);
+}
+
+async function defaultGitStatus({ cwd }) {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd,
+      windowsHide: true
+    });
+
+    return {
+      exitCode: 0,
+      stdout,
+      stderr
+    };
+  } catch (err) {
+    return {
+      exitCode: typeof err?.code === 'number' ? err.code : (err?.status ?? 1),
+      stdout: normalizeOutput(err?.stdout),
+      stderr: normalizeOutput(err?.stderr ?? err?.message)
+    };
+  }
+}
+
+function createNonGitWorkingTree(detail) {
+  return {
+    ok: true,
+    isGitRepo: false,
+    dirty: false,
+    entries: [],
+    warnings: [
+      {
+        code: 'not-a-git-repository',
+        message: 'Working tree state could not be checked because this is not a git repository.',
+        detail
+      }
+    ],
+    errors: []
+  };
+}
+
+function assertSafeRuntimePath(rootDir, targetPath, label) {
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedTarget = path.resolve(targetPath);
+
+  if (!isWithinDirectory(resolvedTarget, resolvedRoot)) {
+    throw new Error(`${label} escapes repository root: ${resolvedTarget}`);
+  }
+
+  for (const forbiddenDir of [
+    path.join(resolvedRoot, 'openspec', 'changes'),
+    path.join(resolvedRoot, '.ai-factory', 'plans')
+  ]) {
+    if (isWithinDirectory(resolvedTarget, forbiddenDir)) {
+      throw new Error(`${label} must stay outside canonical OpenSpec changes and legacy plan folders: ${resolvedTarget}`);
+    }
+  }
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(targetPath) {
+  try {
+    const item = await stat(targetPath);
+    return item.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isWithinDirectory(targetPath, directoryPath) {
+  const relative = path.relative(directoryPath, targetPath);
+  return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function resolveRootDir(options = {}) {
+  return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function normalizeOutput(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  const result = [];
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic?.code ?? ''}:${diagnostic?.message ?? ''}:${diagnostic?.path ?? ''}`;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(diagnostic);
+    }
+  }
+
+  return result;
+}

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -186,7 +186,8 @@ export async function buildDoneContext(options = {}) {
   });
   const verification = await assertVerificationPassed(resolverResult.changeId, {
     ...options,
-    rootDir
+    rootDir,
+    qaPath: layout.qaPath
   });
   const runtimeTraces = await collectRuntimeTraces(rootDir, layout.statePath);
   const openspec = await detectOpenSpecCapability(options, rootDir);

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -1,0 +1,445 @@
+// openspec-done-finalizer.test.mjs - tests for OpenSpec done/finalization runtime
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  archiveChangeWithOpenSpec,
+  assertVerificationPassed,
+  buildDoneContext,
+  detectWorkingTreeState,
+  finalizeOpenSpecChange,
+  summarizeDoneResult,
+  writeDoneSummary
+} from './openspec-done-finalizer.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-openspec-done-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createOpenSpecChange(rootDir, changeId = 'add-oauth') {
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, '# Tasks\n\n- [x] Implement\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/specs/auth/spec.md`, '# Auth Delta\n');
+  await writeFixture(rootDir, 'openspec/specs/auth/spec.md', '# Auth Base\n');
+}
+
+async function createRuntimeEvidence(rootDir, changeId = 'add-oauth') {
+  await writeFixture(rootDir, `.ai-factory/state/${changeId}/implementation/run-001.md`, '# Implementation Trace\n');
+  await writeFixture(rootDir, `.ai-factory/state/${changeId}/fixes/fix-001.md`, '# Fix Trace\n');
+  await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md', '# Base Rules\n');
+  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-change-${changeId}.md`, '# Change Rules\n');
+  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-merged-${changeId}.md`, '# Merged Rules\n');
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(targetPath) {
+  return JSON.parse(await readFile(targetPath, 'utf8'));
+}
+
+function availableCliDetection() {
+  return {
+    available: true,
+    canArchive: true,
+    canValidate: true,
+    version: '1.3.1',
+    command: 'openspec',
+    reason: null,
+    errors: []
+  };
+}
+
+function missingCliDetection() {
+  return {
+    available: false,
+    canArchive: false,
+    canValidate: false,
+    version: null,
+    command: 'openspec',
+    reason: 'missing-cli',
+    errors: [
+      {
+        code: 'missing-cli',
+        message: 'OpenSpec CLI is not available on PATH.'
+      }
+    ]
+  };
+}
+
+function archiveResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? true,
+    command: 'openspec',
+    args: overrides.args ?? ['archive', 'add-oauth', '--yes', '--no-color'],
+    exitCode: overrides.exitCode ?? 0,
+    stdout: overrides.stdout ?? 'Archived add-oauth\n',
+    stderr: overrides.stderr ?? '',
+    json: null,
+    jsonParseError: null,
+    error: overrides.error ?? null
+  };
+}
+
+function statusResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? true,
+    command: 'openspec',
+    args: ['status', '--change', 'add-oauth', '--json', '--no-color'],
+    exitCode: overrides.exitCode ?? 0,
+    stdout: overrides.stdout ?? '{"change":"add-oauth"}',
+    stderr: overrides.stderr ?? '',
+    json: overrides.json ?? { change: 'add-oauth' },
+    jsonParseError: null,
+    error: overrides.error ?? null
+  };
+}
+
+function verificationEvidence(overrides = {}) {
+  const codeState = overrides.codeState ?? 'PASS';
+  const validationOk = overrides.validationOk ?? true;
+  const verifyExists = overrides.verifyExists ?? true;
+  const content = overrides.content ?? [
+    '# Verify: add-oauth',
+    '',
+    '## AIF Verify Gate',
+    '',
+    'Verdict: PASS',
+    `Code verification: ${codeState}`,
+    ''
+  ].join('\n');
+
+  return {
+    ok: overrides.ok ?? true,
+    changeId: overrides.changeId ?? 'add-oauth',
+    validation: overrides.validation ?? {
+      changeId: 'add-oauth',
+      ok: validationOk,
+      skipped: false,
+      error: validationOk ? null : {
+        code: 'openspec-validation-failed',
+        message: 'OpenSpec validation failed.'
+      }
+    },
+    status: overrides.status ?? {
+      changeId: 'add-oauth',
+      ok: true
+    },
+    verify: {
+      exists: verifyExists,
+      path: '.ai-factory/qa/add-oauth/verify.md',
+      content: verifyExists ? content : ''
+    },
+    warnings: overrides.warnings ?? [],
+    errors: overrides.errors ?? []
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec done finalizer API', () => {
+  it('exports the required public functions', () => {
+    for (const fn of [
+      finalizeOpenSpecChange,
+      buildDoneContext,
+      assertVerificationPassed,
+      archiveChangeWithOpenSpec,
+      writeDoneSummary,
+      detectWorkingTreeState,
+      summarizeDoneResult
+    ]) {
+      assert.equal(typeof fn, 'function', 'done finalizer public API should export functions');
+    }
+  });
+
+  it('builds context for an explicit change id and reads canonical/runtime evidence', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await createRuntimeEvidence(rootDir);
+
+    const context = await buildDoneContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => availableCliDetection(),
+      readLatestVerificationEvidence: async () => verificationEvidence()
+    });
+
+    assert.equal(context.ok, true);
+    assert.equal(context.mode, 'openspec-native');
+    assert.equal(context.changeId, 'add-oauth');
+    assert.equal(context.verification.exists, true);
+    assert.equal(context.verification.passed, true);
+    assert.equal(context.openspec.available, true);
+    assert.equal(context.openspec.canArchive, true);
+    assert.deepEqual(context.canonicalArtifacts.deltaSpecs.map((item) => item.path), [
+      'openspec/changes/add-oauth/specs/auth/spec.md'
+    ]);
+    assert.deepEqual(context.runtimeTraces.map((item) => item.path), [
+      '.ai-factory/state/add-oauth/fixes/fix-001.md',
+      '.ai-factory/state/add-oauth/implementation/run-001.md'
+    ]);
+    assert.deepEqual(context.generatedRules.map((item) => item.path), [
+      '.ai-factory/rules/generated/openspec-merged-add-oauth.md',
+      '.ai-factory/rules/generated/openspec-change-add-oauth.md',
+      '.ai-factory/rules/generated/openspec-base.md'
+    ]);
+  });
+
+  it('refuses missing, failed, and pending verification evidence', async () => {
+    const missing = await assertVerificationPassed('add-oauth', {
+      readLatestVerificationEvidence: async () => ({
+        ok: false,
+        changeId: 'add-oauth',
+        validation: null,
+        status: null,
+        verify: { exists: false, path: null, content: '' },
+        warnings: [],
+        errors: []
+      })
+    });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.errors[0].code, 'verification-evidence-missing');
+
+    const failed = await assertVerificationPassed('add-oauth', {
+      readLatestVerificationEvidence: async () => verificationEvidence({
+        validationOk: false,
+        content: '# Verify\n\nOpenSpec validation: FAIL\nCode verification: BLOCKED\n'
+      })
+    });
+    assert.equal(failed.ok, false);
+    assert.equal(failed.errors[0].code, 'verification-not-passed');
+
+    const pending = await assertVerificationPassed('add-oauth', {
+      readLatestVerificationEvidence: async () => verificationEvidence({
+        codeState: 'PENDING',
+        content: '# Verify\n\nOpenSpec validation: PASS\nCode verification: PENDING\n'
+      })
+    });
+    assert.equal(pending.ok, false);
+    assert.equal(pending.errors[0].code, 'verification-ambiguous');
+
+    const passed = await assertVerificationPassed('add-oauth', {
+      readLatestVerificationEvidence: async () => verificationEvidence()
+    });
+    assert.equal(passed.ok, true);
+    assert.equal(passed.passed, true);
+  });
+
+  it('detects dirty working tree state and records it only when explicit', async () => {
+    const clean = await detectWorkingTreeState({
+      gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' })
+    });
+    assert.equal(clean.ok, true);
+    assert.equal(clean.dirty, false);
+
+    const dirty = await detectWorkingTreeState({
+      gitStatus: async () => ({ exitCode: 0, stdout: ' M openspec/changes/add-oauth/tasks.md\n', stderr: '' })
+    });
+    assert.equal(dirty.ok, false);
+    assert.equal(dirty.dirty, true);
+    assert.equal(dirty.errors[0].code, 'dirty-working-tree');
+    assert.deepEqual(dirty.entries, [' M openspec/changes/add-oauth/tasks.md']);
+
+    const recorded = await detectWorkingTreeState({
+      recordDirtyState: true,
+      gitStatus: async () => ({ exitCode: 0, stdout: ' M README.md\n', stderr: '' })
+    });
+    assert.equal(recorded.ok, true);
+    assert.equal(recorded.dirty, true);
+    assert.deepEqual(recorded.entries, [' M README.md']);
+
+    const nonGit = await detectWorkingTreeState({
+      gitStatus: async () => ({ exitCode: 128, stdout: '', stderr: 'not a git repository' })
+    });
+    assert.equal(nonGit.ok, true);
+    assert.equal(nonGit.isGitRepo, false);
+    assert.equal(nonGit.warnings[0].code, 'not-a-git-repository');
+  });
+
+  it('archives normal and skip-specs changes through OpenSpec runner and writes archive evidence', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    const calls = [];
+
+    const normal = await archiveChangeWithOpenSpec('add-oauth', {
+      rootDir,
+      detectOpenSpec: async () => availableCliDetection(),
+      getOpenSpecStatus: async () => statusResult(),
+      archiveOpenSpecChange: async (changeId, options) => {
+        calls.push({ changeId, options });
+        return archiveResult();
+      }
+    });
+
+    assert.equal(normal.ok, true);
+    assert.equal(normal.archived, true);
+    assert.equal(normal.skipSpecs, false);
+    assert.equal(calls[0].changeId, 'add-oauth');
+    assert.equal(calls[0].options.skipSpecs, undefined);
+
+    const archiveEvidencePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'openspec-archive.json');
+    const archiveEvidence = await readJson(archiveEvidencePath);
+    assert.equal(archiveEvidence.archived, true);
+    assert.equal(archiveEvidence.skipSpecs, false);
+    assert.equal(archiveEvidence.rawStdoutPath, '.ai-factory/qa/add-oauth/raw/openspec-archive.stdout');
+    assert.equal(
+      await readFile(path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'raw', 'openspec-archive.stdout'), 'utf8'),
+      'Archived add-oauth\n'
+    );
+
+    await archiveChangeWithOpenSpec('add-oauth', {
+      rootDir,
+      skipSpecs: true,
+      detectOpenSpec: async () => availableCliDetection(),
+      archiveOpenSpecChange: async (changeId, options) => {
+        calls.push({ changeId, options });
+        return archiveResult({
+          args: ['archive', 'add-oauth', '--yes', '--skip-specs', '--no-color']
+        });
+      }
+    });
+
+    assert.equal(calls[1].changeId, 'add-oauth');
+    assert.equal(calls[1].options.skipSpecs, true);
+    assert.equal((await readJson(archiveEvidencePath)).skipSpecs, true);
+  });
+
+  it('requires CLI for archive but allows explicit dry-run summary-only mode', async () => {
+    const rootDir = await createTempRoot();
+    let archiveCalls = 0;
+
+    const required = await archiveChangeWithOpenSpec('add-oauth', {
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      archiveOpenSpecChange: async () => {
+        archiveCalls += 1;
+        return archiveResult();
+      }
+    });
+
+    assert.equal(required.ok, false);
+    assert.equal(required.archived, false);
+    assert.equal(required.errors[0].code, 'openspec-cli-required-for-archive');
+    assert.equal(archiveCalls, 0);
+
+    const dryRun = await archiveChangeWithOpenSpec('add-oauth', {
+      rootDir,
+      skipArchive: true,
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(dryRun.ok, true);
+    assert.equal(dryRun.archived, false);
+    assert.equal(dryRun.status, 'DRY-RUN');
+    assert.ok(
+      dryRun.warnings.some((warning) => warning.code === 'archive-skipped'),
+      'dry-run mode should explicitly report skipped archive'
+    );
+  });
+
+  it('handles already archived changes explicitly and does not re-archive', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, 'openspec/changes/archive/add-oauth/proposal.md', '# Archived\n');
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth/done.md', '# Done: add-oauth\n');
+    await writeFixture(rootDir, '.ai-factory/state/add-oauth/final-summary.md', '# Final Summary: add-oauth\n');
+
+    const result = await finalizeOpenSpecChange({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => availableCliDetection(),
+      gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      archiveOpenSpecChange: async () => {
+        throw new Error('archive should not run for already archived changes');
+      },
+      readLatestVerificationEvidence: async () => verificationEvidence()
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errors[0].code, 'change-already-archived');
+    assert.deepEqual(result.existingSummaries.map((summary) => summary.path), [
+      '.ai-factory/qa/add-oauth/done.md',
+      '.ai-factory/state/add-oauth/final-summary.md'
+    ]);
+  });
+
+  it('finalizes passing changes, writes done summaries, and stays out of canonical/legacy paths', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await createRuntimeEvidence(rootDir);
+
+    const result = await finalizeOpenSpecChange({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => availableCliDetection(),
+      getOpenSpecStatus: async () => statusResult(),
+      gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      readLatestVerificationEvidence: async () => verificationEvidence(),
+      archiveOpenSpecChange: async () => archiveResult()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.archive.archived, true);
+    assert.match(result.commitMessage, /^feat: finalize add-oauth$/);
+    assert.match(result.prSummary, /## OpenSpec/);
+    assert.match(summarizeDoneResult(result), /Finalization status: PASS/);
+
+    const donePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done.md');
+    const finalSummaryPath = path.join(rootDir, '.ai-factory', 'state', 'add-oauth', 'final-summary.md');
+    assert.equal(await pathExists(donePath), true, 'done.md should be written under QA path');
+    assert.equal(await pathExists(finalSummaryPath), true, 'final-summary.md should be written under state path');
+    assert.match(await readFile(donePath, 'utf8'), /# Done: add-oauth/);
+    assert.match(await readFile(donePath, 'utf8'), /Archived: yes/);
+    assert.match(await readFile(finalSummaryPath, 'utf8'), /## Suggested PR summary/);
+    assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'done.md')), false);
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'plans', 'add-oauth')), false);
+  });
+
+  it('records dirty state and still writes summaries when explicitly allowed', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const result = await finalizeOpenSpecChange({
+      rootDir,
+      changeId: 'add-oauth',
+      allowDirty: true,
+      detectOpenSpec: async () => availableCliDetection(),
+      gitStatus: async () => ({ exitCode: 0, stdout: ' M README.md\n', stderr: '' }),
+      readLatestVerificationEvidence: async () => verificationEvidence(),
+      archiveOpenSpecChange: async () => archiveResult()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.workingTree.dirty, true);
+    assert.deepEqual(result.workingTree.entries, [' M README.md']);
+    assert.match(
+      await readFile(path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done.md'), 'utf8'),
+      /M README\.md/
+    );
+  });
+});

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -211,6 +211,43 @@ describe('OpenSpec done finalizer API', () => {
     ]);
   });
 
+  it('builds context using the configured QA evidence path', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'paths:',
+      '  qa: custom-qa',
+      '  state: custom-state',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'custom-qa/add-oauth/openspec-validation.json', JSON.stringify({
+      changeId: 'add-oauth',
+      ok: true,
+      skipped: false,
+      error: null
+    }, null, 2));
+    await writeFixture(rootDir, 'custom-qa/add-oauth/verify.md', [
+      '# Verify: add-oauth',
+      '',
+      '## AIF Verify Gate',
+      '',
+      'Verdict: PASS',
+      'Code verification: PASS',
+      ''
+    ].join('\n'));
+
+    const context = await buildDoneContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => availableCliDetection()
+    });
+
+    assert.equal(context.ok, true);
+    assert.equal(context.verification.passed, true);
+    assert.match(context.paths.qa, /custom-qa[\\/]add-oauth$/);
+    assert.equal(context.verification.verify.path, 'custom-qa/add-oauth/verify.md');
+  });
+
   it('refuses missing, failed, and pending verification evidence', async () => {
     const missing = await assertVerificationPassed('add-oauth', {
       readLatestVerificationEvidence: async () => ({

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -28,6 +28,13 @@ const VERIFY_PROMPT_ASSETS = [
   'agent-files/claude/aifhub-verifier.md'
 ];
 
+const DONE_PROMPT_ASSETS = [
+  'skills/aif-done/SKILL.md',
+  'skills/aif-done/references/finalization-contract.md',
+  'agent-files/codex/aifhub-done-finalizer.toml',
+  'agent-files/claude/aifhub-done-finalizer.md'
+];
+
 const CANONICAL_CHANGE_FILES = [
   'openspec/changes/<change-id>/proposal.md',
   'openspec/changes/<change-id>/design.md',
@@ -312,20 +319,65 @@ describe('OpenSpec-native prompt asset contract', () => {
     }
   });
 
-  it('documents prompt-asset migration as current scope without claiming runtime integrations', async () => {
+  it('requires done prompts to archive verified OpenSpec changes through the done finalizer', async () => {
+    for (const relativePath of DONE_PROMPT_ASSETS) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      for (const expected of [
+        'scripts/openspec-done-finalizer.mjs',
+        'archiveOpenSpecChange',
+        '--skip-specs',
+        '.ai-factory/qa/<change-id>/',
+        '.ai-factory/state/<change-id>/',
+        'dirty',
+        'openspec archive <change-id> --yes'
+      ]) {
+        assertIncludes(asset, expected, relativePath);
+      }
+
+      assert.match(
+        asset,
+        /refus(?:e|es).*unverified|refus(?:e|es).*\/aif-verify.*passed|verification.*passed/i,
+        `${relativePath} should refuse unverified changes`
+      );
+      assert.match(
+        asset,
+        /does not archive in `?\/aif-verify`?|\/aif-verify`? does not archive|never archive from `?\/aif-verify`?/i,
+        `${relativePath} should keep archive out of /aif-verify`
+      );
+      assert.match(
+        asset,
+        /does not use legacy `?\.ai-factory\/specs`?.*OpenSpec-native|OpenSpec-native.*does not use legacy `?\.ai-factory\/specs`?/i,
+        `${relativePath} should forbid legacy specs archive in OpenSpec-native mode`
+      );
+      assert.doesNotMatch(
+        asset,
+        /archive integration (?:is )?deferred to issue #33|deferred archive status/i,
+        `${relativePath} should no longer describe OpenSpec archive integration as deferred`
+      );
+    }
+  });
+
+  it('documents scoped OpenSpec runtime integrations without deferred done archive wording', async () => {
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
 
     assertIncludes(compatibility, 'prompt assets', 'docs/openspec-compatibility.md');
+    assertIncludes(compatibility, 'openspec archive <change-id> --yes', 'docs/openspec-compatibility.md');
+    assertIncludes(compatibility, 'done finalization covers archive/finalizer integration', 'docs/openspec-compatibility.md');
     assertNotIncludes(
       compatibility,
       'broader prompt rewrites remain separate follow-up work',
       'docs/openspec-compatibility.md'
     );
+    assert.doesNotMatch(
+      compatibility,
+      /archive integration (?:is )?deferred to issue #33/i,
+      'docs/openspec-compatibility.md should not describe done archive as deferred'
+    );
 
     for (const expected of [
       '#31',
-      '#32',
-      '#33'
+      '#32'
     ]) {
       assertIncludes(compatibility, expected, 'docs/openspec-compatibility.md');
     }

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -18,14 +18,16 @@ Resolve mode from `.ai-factory/config.yaml`:
 
 ## OpenSpec-native mode
 
-OpenSpec-native mode finalizes the verified change state without implementing archive integration from issue #33.
+OpenSpec-native mode finalizes the verified change state through `scripts/openspec-done-finalizer.mjs`. It is the only OpenSpec-native archive/finalization step after `/aif-verify` passes.
 
 ### Preconditions
 
 - Resolve exactly one active change or explicit `<change-id>`.
 - Read QA evidence from `.ai-factory/qa/<change-id>/`.
-- Treat verification as passing only when QA evidence records `pass` or `pass-with-notes`.
+- Treat verification as passing only when QA evidence clearly records a final PASS or PASS-with-notes for this change.
 - If verification has not run or verdict is `fail`, stop and suggest `/aif-verify` or `/aif-fix`.
+- Refuse unverified changes; do not accept `Code verification: PENDING` as final verification.
+- Check dirty working tree state before archive and either fail or record it only when explicit dirty-state recording is requested.
 
 ### Canonical Context
 
@@ -50,21 +52,32 @@ Runtime state and QA evidence live outside canonical changes:
 
 ### Archive Policy
 
+- Archive through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs`; this corresponds to `openspec archive <change-id> --yes`.
+- Use `archiveOpenSpecChange(changeId)` for normal finalization.
+- Use `archiveOpenSpecChange(changeId, { skipSpecs: true })` for docs/tooling-only finalization; this corresponds to `openspec archive <change-id> --yes --skip-specs --no-color`.
+- Support the user-facing `--skip-specs` path while still writing final QA evidence and final summaries.
+- If OpenSpec CLI is missing or unsupported and archive is required, fail with an explicit OpenSpec CLI requirement.
+- Do not archive in `/aif-verify`; `/aif-verify` does not archive and only records verification evidence.
+- Do not use legacy `.ai-factory/specs` archive in OpenSpec-native mode.
+- OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
 - Do not silently archive OpenSpec changes through legacy `.ai-factory/specs`.
-- Do not run `openspec archive <change-id> --yes` in this issue. Full archive integration belongs to issue #33 or later runtime integration.
-- If the user requests archive/finalization before #33 exists, report that archive integration is deferred and prepare commit/PR/governance outputs from verified evidence only.
 - Do not write runtime-only output into `openspec/changes/<change-id>/`.
+- Do not directly mutate `openspec/specs/**` or manually move OpenSpec change folders.
 
 ### OpenSpec-Native Output
 
 Normal output must report:
 
 - selected `change-id`;
-- precondition state and QA verdict;
+- verification status and refusal reason when unverified;
+- dirty working tree state;
+- archive result;
 - canonical artifacts inspected;
 - generated rules state when relevant;
 - runtime state and QA evidence paths;
-- archive integration status: deferred to #33 unless a later runtime integration explicitly owns it.
+- final evidence under `.ai-factory/qa/<change-id>/`;
+- final summaries under `.ai-factory/state/<change-id>/`;
+- commit/PR summary draft.
 
 ## Legacy AI Factory-only mode
 
@@ -148,10 +161,10 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 
 | Artifact | Owner | This Skill |
 |----------|-------|------------|
-| `openspec/changes/<change-id>/` | OpenSpec-native workflow | Reads only until #33 archive integration exists |
-| `.ai-factory/qa/<change-id>/` | `/aif-verify` | Reads precondition and QA evidence |
-| `.ai-factory/state/<change-id>/` | OpenSpec-native runtime | Reads finalization context when present |
-| `.ai-factory/specs/<plan-id>/` | **aif-done** | Creates or refreshes on finalization |
+| `openspec/changes/<change-id>/` | OpenSpec-native workflow | Reads before archive; OpenSpec CLI owns lifecycle mutation |
+| `.ai-factory/qa/<change-id>/` | `/aif-verify` and **aif-done** | Reads verification evidence; writes `done.md`, `openspec-archive.json`, and raw archive output |
+| `.ai-factory/state/<change-id>/` | OpenSpec-native runtime and **aif-done** | Reads traces; writes `final-summary.md` |
+| `.ai-factory/specs/<plan-id>/` | **aif-done** legacy mode only | Creates or refreshes on legacy finalization |
 | `.ai-factory/specs/index.yaml` | **aif-done** | Updates |
 | `.ai-factory/plans/<plan-id>/status.yaml` | **aif-done** | Updates `status: done` |
 | Commit/PR drafts | **aif-done** | Outputs to user |
@@ -162,7 +175,9 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 ## Rules
 
 - Never finalize a plan that has not passed verification.
-- In OpenSpec-native mode, never silently archive through legacy `.ai-factory/specs`; report archive integration as deferred to #33.
+- In OpenSpec-native mode, never finalize an unverified change.
+- In OpenSpec-native mode, archive only through `archiveOpenSpecChange`; never use custom OpenSpec archive logic.
+- In OpenSpec-native mode, never silently archive through legacy `.ai-factory/specs`.
 - Never invent governance changes without evidence from the verified plan.
 - When governance updates belong to another owner, use the owning path or return an exact handoff instead of silently skipping the change.
 - Never auto-create a PR — always present drafts for user approval.

--- a/skills/aif-done/references/finalization-contract.md
+++ b/skills/aif-done/references/finalization-contract.md
@@ -9,8 +9,10 @@ Reference for the `aif-done` skill and `aifhub-done-finalizer` agents.
 - `.ai-factory/config.yaml` has `aifhub.artifactProtocol: openspec`.
 - Exactly one active change or explicit `<change-id>` is selected.
 - QA evidence exists under `.ai-factory/qa/<change-id>/`.
-- Verification verdict in QA evidence is `pass` or `pass-with-notes`.
-- No uncommitted changes outside the selected change scope unless the user confirms.
+- Verification evidence clearly records final PASS or PASS-with-notes for this change.
+- OpenSpec-native `/aif-done` refuses unverified changes.
+- `Code verification: PENDING` is ambiguous and must refuse finalization.
+- Dirty working tree state is empty, or explicit dirty-state recording is enabled.
 
 ### Canonical Context
 
@@ -31,17 +33,41 @@ openspec/changes/<change-id>/specs/**/spec.md
 
 ### Archive Policy
 
-Do not archive OpenSpec changes through legacy `.ai-factory/specs`. Full archival through:
+OpenSpec-native `/aif-done` uses `scripts/openspec-done-finalizer.mjs`. Archive lifecycle mutation must happen through `archiveOpenSpecChange(changeId, options)` and never through custom folder movement or direct `openspec/specs` edits. Normal archive is `openspec archive <change-id> --yes`.
+
+Normal archival corresponds to:
 
 ```bash
 openspec archive <change-id> --yes
 ```
 
-is deferred to issue #33 or later runtime integration. Until then, finalization prepares commit/PR/governance outputs from verified QA evidence and reports archive integration as deferred.
+Docs/tooling-only archival uses `--skip-specs`:
+
+```bash
+openspec archive <change-id> --yes --skip-specs --no-color
+```
+
+`--skip-specs` still writes final QA evidence and final summaries. Missing or unsupported OpenSpec CLI fails when archive is required. `/aif-verify` does not archive.
+
+OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
+
+### Final Evidence
+
+Write:
+
+```text
+.ai-factory/qa/<change-id>/done.md
+.ai-factory/qa/<change-id>/openspec-archive.json
+.ai-factory/qa/<change-id>/raw/openspec-archive.stdout
+.ai-factory/qa/<change-id>/raw/openspec-archive.stderr
+.ai-factory/state/<change-id>/final-summary.md
+```
+
+Do not write runtime-only files into `openspec/changes/<change-id>/`.
 
 ### Output
 
-Report selected `change-id`, precondition state, QA evidence path, canonical artifacts inspected, generated rules state, runtime state path, and archive integration status.
+Report selected `change-id`, verification status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, `--skip-specs` state, commit draft, and PR draft.
 
 ## Legacy AI Factory-only mode
 


### PR DESCRIPTION
## Summary
- Adds a shared OpenSpec done-finalizer runtime module that resolves the active change, enforces `/aif-verify` pass evidence, guards dirty trees, and archives through the OpenSpec CLI.
- Supports normal archive and `--skip-specs`, writes QA evidence and final summaries under `.ai-factory/qa/<change-id>/` and `.ai-factory/state/<change-id>/`, and handles already-archived changes explicitly.
- Updates `/aif-done` prompt assets and focused docs to describe OpenSpec-native finalization instead of deferred archive handling.

## Testing
- Added focused unit coverage for verification gating, archive orchestration, dirty-tree handling, already-archived changes, and evidence writing.
- Updated prompt-contract tests for `/aif-done` behavior and ran validation; targeted tests, `npm run validate`, `npm test`, and diff checks passed.