### PR TITLE
Add legacy plan migration to OpenSpec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ OpenSpec compatibility is tracked as optional adapter metadata, not as a hard ex
 | [Context Loading Policy](context-loading-policy.md) | Runtime context contract, ownership boundaries, and artifact rules |
 | [OpenSpec Compatibility](openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
 | [Active Change Resolver](active-change-resolver.md) | Shared active OpenSpec change selection, runtime paths, pointer behavior, and ambiguity diagnostics |
+| [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration from legacy `.ai-factory/plans` artifacts to OpenSpec-native changes |
 | [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) | v1 source-of-truth contract for OpenSpec canonical artifacts and AI Factory runtime state |
 
 ## Recommended Reading Order
@@ -37,7 +38,8 @@ OpenSpec compatibility is tracked as optional adapter metadata, not as a hard ex
 4. Read [Context Loading Policy](context-loading-policy.md) for ownership and runtime path rules.
 5. Read [OpenSpec Compatibility](openspec-compatibility.md) for optional OpenSpec CLI adapter policy and degraded-mode behavior.
 6. Read [Active Change Resolver](active-change-resolver.md) for shared change selection and runtime state paths.
-7. Read [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership contract.
+7. Read [Legacy Plan Migration](legacy-plan-migration.md) if you still have `.ai-factory/plans` artifacts to migrate.
+8. Read [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership contract.
 
 ## Scope
 
@@ -59,5 +61,6 @@ Project-level AI Factory planning and archived specs remain under `.ai-factory/`
 - [Context Loading Policy](context-loading-policy.md) - context-loading and ownership rules
 - [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter policy and future capability flags
 - [Active Change Resolver](active-change-resolver.md) - active change selection and runtime state layout
+- [Legacy Plan Migration](legacy-plan-migration.md) - explicit migration commands and artifact mapping
 - [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) - canonical OpenSpec artifacts and runtime AI Factory state
 - [Project README](../README.md) - landing page and quick start

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -103,6 +103,7 @@ Special ownership case:
 - In OpenSpec-native mode, `aif-implement` and `aif-fix` may change implementation source files within the selected task/finding scope; they do not rewrite canonical OpenSpec artifacts unless explicitly requested
 - In OpenSpec-native mode, `aif-verify` reads canonical OpenSpec artifacts, validates the active change before code checks when validation is enabled, writes OpenSpec validation/status evidence plus QA findings under `.ai-factory/qa/<change-id>/`, treats missing CLI as degraded mode unless strict config requires CLI, hard-fails invalid OpenSpec before lint/tests/review, and must not archive
 - In OpenSpec-native mode, `aif-done` requires passing `/aif-verify` evidence, archives through `openspec archive <change-id> --yes` via the OpenSpec CLI runner, supports `--skip-specs`, writes final evidence under `.ai-factory/qa/<change-id>/`, writes final summaries under `.ai-factory/state/<change-id>/`, and does not use custom archive logic or legacy `.ai-factory/specs` finalization
+- Legacy plan migration is explicit and is not part of normal improve, implement, or verify execution. The migration reads legacy `.ai-factory/plans` artifacts, writes canonical migrated planning artifacts only under `openspec/changes/<change-id>/`, preserves runtime notes under `.ai-factory/state/<change-id>/`, preserves legacy verification evidence under `.ai-factory/qa/<change-id>/`, and never deletes the legacy source artifacts.
 - Legacy `task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, and `explore.md` apply only to legacy AI Factory-only plan folders, not OpenSpec-native changes
 - no consumer skill may use bridge files as a substitute for these runtime paths
 
@@ -181,4 +182,5 @@ If `config.yaml` is missing or incomplete for the requested operation:
 
 - [Documentation Index](README.md) - docs overview and reading order
 - [Usage](usage.md) - command flow and current workflow behavior
+- [Legacy Plan Migration](legacy-plan-migration.md) - explicit migration commands and artifact mapping
 - [Project README](../README.md) - landing page and install path

--- a/docs/legacy-plan-migration.md
+++ b/docs/legacy-plan-migration.md
@@ -1,0 +1,108 @@
+[← Previous Page](active-change-resolver.md) · [Back to README](README.md)
+
+# Legacy Plan Migration
+
+Use this migration when a project has legacy AI Factory plan artifacts but the active workflow expects OpenSpec-native changes.
+
+Legacy sources are read from `.ai-factory/plans/<id>.md` and `.ai-factory/plans/<id>/`. The migration creates canonical OpenSpec change artifacts under `openspec/changes/<change-id>/` and preserves runtime-only material under `.ai-factory/state/<change-id>/` or `.ai-factory/qa/<change-id>/`.
+
+## Commands
+
+List legacy plans:
+
+```bash
+node scripts/migrate-legacy-plans.mjs --list
+```
+
+Preview one migration without writing files:
+
+```bash
+node scripts/migrate-legacy-plans.mjs add-oauth --dry-run
+```
+
+Migrate one plan:
+
+```bash
+node scripts/migrate-legacy-plans.mjs add-oauth
+```
+
+Preview or migrate all discovered plans:
+
+```bash
+node scripts/migrate-legacy-plans.mjs --all --dry-run
+node scripts/migrate-legacy-plans.mjs --all
+```
+
+The package script is an optional convenience:
+
+```bash
+npm run migrate:legacy-plans -- add-oauth --dry-run
+```
+
+Use `--json` when automation needs structured output.
+
+## Collision Behavior
+
+Default collision behavior is `fail`: if `openspec/changes/<id>` already exists, migration stops without overwriting it.
+
+Supported modes:
+
+| Mode | Behavior |
+|------|----------|
+| `fail` | Stop when the target OpenSpec change exists |
+| `suffix` | Create a distinct target such as `<id>-migrated` |
+| `merge-safe` | Create only missing files and report skipped existing files |
+| `overwrite` | Overwrite generated targets only when explicitly requested |
+
+Example:
+
+```bash
+node scripts/migrate-legacy-plans.mjs add-oauth --on-collision suffix
+```
+
+## Artifact Mapping
+
+Canonical OpenSpec artifacts:
+
+| Legacy source | OpenSpec target |
+|---------------|-----------------|
+| `.ai-factory/plans/<id>.md` | `openspec/changes/<id>/proposal.md` |
+| `.ai-factory/plans/<id>/task.md` | `openspec/changes/<id>/tasks.md` |
+| Design-like `context.md` | `openspec/changes/<id>/design.md` |
+| Clear behavioral requirements | `openspec/changes/<id>/specs/migrated/spec.md` |
+
+Runtime and QA preservation:
+
+| Legacy source | Runtime target |
+|---------------|----------------|
+| `context.md` | `.ai-factory/state/<id>/legacy-context.md` |
+| `rules.md` | `.ai-factory/state/<id>/legacy-rules.md` |
+| `status.yaml` | `.ai-factory/state/<id>/legacy-status.yaml` |
+| `explore.md` | `.ai-factory/state/<id>/legacy-explore.md` |
+| `verify.md` | `.ai-factory/qa/<id>/legacy-verify.md` |
+
+`verify.md` and `status.yaml` are never copied into `openspec/changes/<id>/`. The migration never mutates `openspec/specs/**`.
+
+## Validation and Reports
+
+After a non-dry-run migration, the script writes:
+
+```text
+.ai-factory/state/<id>/migration-report.md
+```
+
+The report lists source artifacts, generated OpenSpec artifacts, runtime artifacts, validation status, diagnostics, and manual follow-ups.
+
+When a compatible OpenSpec CLI is available, migration runs change validation through the shared runner. Missing or unsupported OpenSpec CLI records `SKIPPED` and does not block migration.
+
+If validation fails, generated files remain in place and the report records `FAIL`; the script does not rollback by deleting migrated or legacy artifacts.
+
+## After Migration
+
+Legacy artifacts are not deleted. Review the generated OpenSpec change and refine it before implementation:
+
+```bash
+/aif-improve <change-id>
+```
+
+Generated delta specs are conservative. Review them before relying on them as product requirements.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,6 +114,33 @@ npm test
 
 CI автоматически запускает валидаторы на каждом PR (`.github/workflows/validate.yml`).
 
+## Legacy Plan Migration
+
+If OpenSpec-native commands cannot resolve `openspec/changes/<change-id>` but matching legacy AI Factory plan artifacts still exist, run an explicit migration. Migration never runs automatically from improve, implement, or verify.
+
+Preview:
+
+```bash
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+```
+
+Migrate:
+
+```bash
+node scripts/migrate-legacy-plans.mjs <change-id>
+```
+
+Migrate all discovered legacy plans:
+
+```bash
+node scripts/migrate-legacy-plans.mjs --all --dry-run
+node scripts/migrate-legacy-plans.mjs --all
+```
+
+The migration maps `proposal.md`, `tasks.md`, `design.md`, and optional delta specs into `openspec/changes/<change-id>/`. Runtime-only legacy files are preserved under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`; legacy sources are not deleted. Review generated specs and run `/aif-improve <change-id>` after migration.
+
+See [Legacy Plan Migration](legacy-plan-migration.md) for collision modes and the full artifact map.
+
 ## Installation
 
 ```bash

--- a/injections/core/aif-implement-plan-folder.md
+++ b/injections/core/aif-implement-plan-folder.md
@@ -36,6 +36,15 @@ Resolve the active change using `scripts/active-change-resolver.mjs` when availa
 - Prefer an explicit `<change-id>` or `@openspec/changes/<change-id>` input when provided.
 - Otherwise use `resolveActiveChange` behavior: current working directory, current branch mapping, current pointer, then single active change.
 - Treat selected source, candidate list, warnings, and errors as user-visible implementation context.
+- If an explicit or inferred `<change-id>` cannot be resolved as an OpenSpec change, check for matching legacy AI Factory plan artifacts through `detectMigrationNeed(options)` from `scripts/legacy-plan-migration.mjs` or equivalent read-only detection. If migration is suggested, do not auto-migrate. Show exactly:
+
+```text
+Found legacy AI Factory plan artifacts for `<change-id>` but no OpenSpec change at `openspec/changes/<change-id>`.
+Run the legacy migration script with:
+
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id>
+```
 
 Read canonical OpenSpec artifacts before editing implementation files:
 

--- a/injections/core/aif-improve-plan-folder.md
+++ b/injections/core/aif-improve-plan-folder.md
@@ -35,6 +35,15 @@ Resolve the active change using the shared vocabulary from `scripts/active-chang
 - Otherwise use `resolveActiveChange` behavior: current working directory, current branch mapping, current pointer, then single active change.
 - Treat the selected change ID, selected source, candidate list, warnings, and errors as user-visible refinement context.
 - If the resolved path is under `openspec/changes/archive/**`, do not edit silently. Archived changes are immutable by default; report the archived target clearly and suggest creating a new change for further work.
+- If an explicit or inferred `<change-id>` cannot be resolved as an OpenSpec change, check for matching legacy AI Factory plan artifacts through `detectMigrationNeed(options)` from `scripts/legacy-plan-migration.mjs` or equivalent read-only detection. If migration is suggested, do not auto-migrate. Show exactly:
+
+```text
+Found legacy AI Factory plan artifacts for `<change-id>` but no OpenSpec change at `openspec/changes/<change-id>`.
+Run the legacy migration script with:
+
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id>
+```
 
 Refine only these canonical OpenSpec artifacts for the active change:
 

--- a/injections/core/aif-verify-plan-folder.md
+++ b/injections/core/aif-verify-plan-folder.md
@@ -36,6 +36,15 @@ Resolve the active change using `scripts/active-change-resolver.mjs` when availa
 - Prefer an explicit `<change-id>` or `@openspec/changes/<change-id>` input when provided.
 - Otherwise use `resolveActiveChange` behavior: current working directory, current branch mapping, current pointer, then single active change.
 - Treat selected source, candidate list, warnings, and errors as user-visible verification context.
+- If an explicit or inferred `<change-id>` cannot be resolved as an OpenSpec change, check for matching legacy AI Factory plan artifacts through `detectMigrationNeed(options)` from `scripts/legacy-plan-migration.mjs` or equivalent read-only detection. If migration is suggested, do not auto-migrate. Show exactly:
+
+```text
+Found legacy AI Factory plan artifacts for `<change-id>` but no OpenSpec change at `openspec/changes/<change-id>`.
+Run the legacy migration script with:
+
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id>
+```
 
 Validate and review against canonical OpenSpec artifacts:
 

--- a/openspec/changes/migrate-legacy-plan-artifacts/design.md
+++ b/openspec/changes/migrate-legacy-plan-artifacts/design.md
@@ -1,0 +1,160 @@
+# Design: Migrate Legacy Plan Artifacts to OpenSpec
+
+## Technical Approach
+
+Add `scripts/legacy-plan-migration.mjs` as a library-first migration module. It should expose pure mapping behavior separately from filesystem writes so tests can cover discovery, mapping, collision handling, dry-run behavior, and OpenSpec validation without depending on a real OpenSpec CLI.
+
+The module should use these layers:
+
+- Path and ID safety: normalize legacy plan IDs, normalize OpenSpec change IDs, and keep all paths inside the configured root.
+- Discovery: scan `.ai-factory/plans/` for `<id>.md`, `<id>/`, or both, excluding hidden, archived, backup, and unrelated entries.
+- Source loading: read only known legacy files and retain relative source paths for reports.
+- Mapping: convert source content into canonical OpenSpec artifacts and runtime preservation files.
+- Operation planning: produce ordered `write`, `mkdir`, `skip`, and `validate` operations without side effects.
+- Path guarding: verify each planned target is inside the repository and inside the expected canonical, state, or QA boundary before writing.
+- Execution: apply the operation plan only when `dryRun` is false.
+- Reporting and validation: write the migration report and run OpenSpec validation when available.
+
+The CLI wrapper, `scripts/migrate-legacy-plans.mjs`, should parse arguments without adding dependencies and delegate all behavior to the module.
+
+## Data / Artifact Model
+
+Use stable plain objects so tests and CLI JSON output can assert behavior directly.
+
+Suggested `LegacyPlan` shape:
+
+```js
+{
+  id: 'add-oauth',
+  planFile: '.ai-factory/plans/add-oauth.md',
+  planDir: '.ai-factory/plans/add-oauth',
+  files: {
+    task: '.ai-factory/plans/add-oauth/task.md',
+    context: '.ai-factory/plans/add-oauth/context.md',
+    rules: '.ai-factory/plans/add-oauth/rules.md',
+    verify: '.ai-factory/plans/add-oauth/verify.md',
+    status: '.ai-factory/plans/add-oauth/status.yaml',
+    explore: '.ai-factory/plans/add-oauth/explore.md'
+  },
+  contents: {
+    plan: '# Legacy plan...',
+    task: '- [ ] Do work',
+    context: '...',
+    rules: '...',
+    verify: '...',
+    status: '...',
+    explore: '...'
+  },
+  hasCanonicalTarget: false,
+  targetChangePath: 'openspec/changes/add-oauth'
+}
+```
+
+When one legacy form is absent, use `null` for `planFile` or `planDir` and omit only the missing file entries from `files`. Paths returned from public functions should be repository-relative POSIX paths; absolute paths may be used internally but should not leak into reports unless an error needs the resolved path for safety diagnostics.
+
+Suggested migration result shape:
+
+```js
+{
+  ok: true,
+  dryRun: false,
+  planId: 'add-oauth',
+  changeId: 'add-oauth',
+  targetChangePath: 'openspec/changes/add-oauth',
+  operations: [
+    { action: 'write', target: 'openspec/changes/add-oauth/proposal.md', source: '.ai-factory/plans/add-oauth.md' }
+  ],
+  validation: {
+    status: 'PASS',
+    available: true,
+    result: {}
+  },
+  reportPath: '.ai-factory/state/add-oauth/migration-report.md',
+  warnings: [],
+  errors: []
+}
+```
+
+Canonical writes may target only:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+
+Runtime preservation writes may target only:
+
+- `.ai-factory/state/<change-id>/legacy-context.md`
+- `.ai-factory/state/<change-id>/legacy-rules.md`
+- `.ai-factory/state/<change-id>/legacy-status.yaml`
+- `.ai-factory/state/<change-id>/legacy-explore.md`
+- `.ai-factory/state/<change-id>/migration-report.md`
+- `.ai-factory/qa/<change-id>/legacy-verify.md`
+
+The migration must never write legacy `verify.md` or `status.yaml` into `openspec/changes/<change-id>/`.
+
+The implementation should include local guards equivalent to:
+
+- `assertWithinRoot(rootDir, targetPath)`
+- `assertCanonicalChangePath(rootDir, changeId, targetPath)`
+- `assertRuntimeStatePath(rootDir, changeId, targetPath)`
+- `assertRuntimeQaPath(rootDir, changeId, targetPath)`
+- `assertNotLegacyPlanPath(rootDir, targetPath)`
+- `assertNotBaseSpecPath(rootDir, targetPath)`
+
+These guards should run for planned writes and executed writes so a bug in mapping cannot escape the intended boundaries.
+
+## Integration Points
+
+`scripts/active-change-resolver.mjs`:
+
+- Reuse `normalizeChangeId(changeId)` for target safety.
+- Reuse `ensureRuntimeLayout(changeId, options)` only in write mode.
+
+`scripts/openspec-runner.mjs`:
+
+- Reuse `detectOpenSpec(options)` before validation.
+- Reuse `validateOpenSpecChange(changeId, options)` when detection reports `canValidate: true`.
+- Treat missing or unsupported CLI as `SKIPPED`, not a migration failure.
+
+`package.json`:
+
+- Add `migrate:legacy-plans` only after `scripts/migrate-legacy-plans.mjs` exists.
+- Preserve the existing `test` and `validate` scripts.
+- Document `npm run migrate:legacy-plans -- <args>` as an optional convenience, not the only supported invocation.
+
+Prompt assets:
+
+- Update `injections/core/aif-improve-plan-folder.md`.
+- Update `injections/core/aif-implement-plan-folder.md`.
+- Update `injections/core/aif-verify-plan-folder.md`.
+- Add focused prompt-asset tests that require the migration suggestion message.
+
+Docs:
+
+- Add `docs/legacy-plan-migration.md`.
+- Link it from `docs/usage.md`, `docs/context-loading-policy.md`, and the docs index when appropriate.
+
+Tests and fixtures:
+
+- Add `scripts/legacy-plan-migration.test.mjs`.
+- Add fixture files under `test/fixtures/legacy-plan-basic/` unless an existing convention emerges during implementation.
+- Keep tests in `node:test` style and use temp directories plus injected runner functions.
+- Add a small fixture-copy helper in the test file rather than importing extra dependencies.
+- Add an exported-API test before behavior tests so missing named exports fail clearly.
+
+## Alternatives Considered
+
+- Auto-migrate in improve, implement, or verify: rejected because the issue requires explicit migration and forbids silent changes.
+- Move legacy files instead of copying: rejected because preserving originals is safer and satisfies the no-delete requirement.
+- Always generate delta specs from legacy prose: rejected because weak extraction can create fake product requirements. The mapper should generate specs only for clear behavior or mark generated requirements for review.
+- Put all legacy notes into `design.md`: rejected because `rules.md`, `status.yaml`, `verify.md`, and exploration logs are runtime or QA evidence, not canonical OpenSpec change artifacts.
+
+## Risks
+
+- Collision behavior can accidentally overwrite existing OpenSpec work if handled at directory granularity only. Implement file-level checks and tests for every collision mode.
+- `suffix` collision behavior can produce an unsafe or ambiguous change ID. Normalize every generated suffix and keep suffix generation deterministic.
+- Documentation can drift if the CLI examples and package script disagree. If a package script is added, docs should mention both the direct `node` command and `npm run migrate:legacy-plans -- ...`.
+- Validation failures after write must not trigger rollback that deletes migrated artifacts. Record the failure in the result and report instead.
+- `migrateAllLegacyPlans` can produce mixed outcomes. Return a top-level result that distinguishes full success, partial success, and total failure without hiding per-plan errors.
+- `--json` output can become noisy if it includes full migrated artifact content. Prefer operation and artifact paths, diagnostics, validation summaries, and report paths.

--- a/openspec/changes/migrate-legacy-plan-artifacts/proposal.md
+++ b/openspec/changes/migrate-legacy-plan-artifacts/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: Migrate Legacy Plan Artifacts to OpenSpec
+
+## Intent
+
+Existing users may still have legacy AI Factory plan artifacts in the dual `.ai-factory/plans` model:
+
+- `.ai-factory/plans/<id>.md`
+- `.ai-factory/plans/<id>/task.md`
+- `.ai-factory/plans/<id>/context.md`
+- `.ai-factory/plans/<id>/rules.md`
+- `.ai-factory/plans/<id>/verify.md`
+- `.ai-factory/plans/<id>/status.yaml`
+- `.ai-factory/plans/<id>/explore.md`
+
+The current workflow is OpenSpec-native, with canonical change artifacts under `openspec/changes/<change-id>/` and runtime or QA evidence under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`. Users need an explicit, safe, reversible migration path that preserves legacy files, avoids silent overwrites, and makes runtime-only artifacts non-canonical.
+
+## Scope
+
+In scope:
+
+- Add `scripts/legacy-plan-migration.mjs` with the required exported API:
+  - `discoverLegacyPlans(options = {})`
+  - `migrateLegacyPlan(planId, options = {})`
+  - `migrateAllLegacyPlans(options = {})`
+  - `mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {})`
+  - `writeMigrationReport(planId, report, options = {})`
+  - `detectMigrationNeed(options = {})`
+  - `normalizeLegacyPlanId(input)`
+- Add an explicit dependency-free CLI wrapper, `scripts/migrate-legacy-plans.mjs`.
+- Support `--list`, single-plan migration, `--all`, `--dry-run`, `--on-collision`, and optional `--json`.
+- Return stable machine-readable results and CLI exit codes for success, partial success, validation failure, invalid arguments, and migration errors.
+- Convert legacy plan summary and task artifacts into canonical OpenSpec change artifacts.
+- Preserve runtime-only legacy artifacts under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`.
+- Write a migration report for each non-dry-run migration.
+- Run OpenSpec validation after migration when a compatible CLI is available.
+- Detect matching legacy plans in improve, implement, and verify guidance, then suggest the migration command without auto-migrating.
+- Add tests with temp directories, injected OpenSpec runner behavior, and at least one legacy fixture.
+- Update user-facing docs for the migration flow.
+
+Out of scope:
+
+- Automatic migration during install, validation, improve, implement, or verify.
+- Deleting, archiving, or moving legacy files.
+- Mutating `openspec/specs` directly.
+- Installing OpenSpec skills or slash commands.
+- Rewriting repository OpenSpec bootstrap configuration outside the migration feature.
+- CI matrix expansion, full v1 docs rewrite, custom OpenSpec schemas, registry work, or PR/commit creation.
+
+## Approach
+
+Implement the migration as an explicit filesystem operation planner. The core module should discover legacy plans, read source artifacts, map them into canonical and runtime targets, resolve collisions, and return the same operation plan for both dry-run and write modes. Dry-run should execute no writes or directory creation.
+
+Use existing helpers where they fit:
+
+- `normalizeChangeId` from `scripts/active-change-resolver.mjs` for target change IDs.
+- `ensureRuntimeLayout` from `scripts/active-change-resolver.mjs` when writes are enabled.
+- `detectOpenSpec` and `validateOpenSpecChange` from `scripts/openspec-runner.mjs` for degraded validation behavior.
+
+Add migration-local path guards before every planned or executed write. Canonical targets must stay under `openspec/changes/<change-id>/`, runtime targets must stay under `.ai-factory/state/<change-id>/` or `.ai-factory/qa/<change-id>/`, and no operation may target `openspec/specs/**` or `.ai-factory/plans/**`.
+
+Keep the mapping conservative. Generate `proposal.md`, `design.md`, `tasks.md`, and a delta spec only when legacy text provides enough intent. Preserve raw legacy content under labeled sections or runtime notes when confident structured extraction is not possible. Never copy `verify.md` or `status.yaml` into `openspec/changes/<change-id>/`.
+
+The CLI should be a thin wrapper around the exported API. Human-readable output should summarize sources, targets, collision behavior, dry-run operations, report path, and validation status. `--json` should print the result object for automation and tests.
+
+## Risks / Open Questions
+
+- Requirement extraction from old markdown can create false confidence. Default behavior should prefer preserving notes and marking review-required output over inventing fake requirements.
+- A migration can write valid files while strict OpenSpec validation still fails because a legacy plan lacks delta spec content or the repository has no full OpenSpec project scaffold. The report must record `FAIL` or `SKIPPED` clearly.
+- `merge-safe` needs precise file-level behavior: create missing canonical/runtime files, never overwrite existing files, and report skipped targets.
+- The repository currently has older local `.ai-factory` descriptions alongside OpenSpec-native prompt and script support. This change should update only the docs and prompt guidance needed for migration, not perform a full context rewrite.

--- a/openspec/changes/migrate-legacy-plan-artifacts/specs/legacy-plan-migration/spec.md
+++ b/openspec/changes/migrate-legacy-plan-artifacts/specs/legacy-plan-migration/spec.md
@@ -1,0 +1,317 @@
+# Delta for Legacy Plan Migration
+
+## ADDED Requirements
+
+### Requirement: Migration API Surface
+
+The system MUST expose the legacy migration behavior through the required public functions in `scripts/legacy-plan-migration.mjs`.
+
+#### Scenario: Required functions are exported
+
+- GIVEN `scripts/legacy-plan-migration.mjs`
+- WHEN the module is imported
+- THEN it exports `discoverLegacyPlans`
+- AND it exports `migrateLegacyPlan`
+- AND it exports `migrateAllLegacyPlans`
+- AND it exports `mapLegacyPlanToOpenSpecArtifacts`
+- AND it exports `writeMigrationReport`
+- AND it exports `detectMigrationNeed`
+- AND it exports `normalizeLegacyPlanId`
+
+#### Scenario: Importing the module has no migration side effects
+
+- GIVEN the migration module is imported in a test process
+- WHEN no exported function is called
+- THEN no directories are created
+- AND no files are written
+
+### Requirement: Legacy Plan Discovery
+
+The system MUST discover migratable legacy AI Factory plans from `.ai-factory/plans/` in both parent markdown and companion directory forms.
+
+#### Scenario: Both legacy forms exist
+
+- GIVEN `.ai-factory/plans/add-oauth.md`
+- AND `.ai-factory/plans/add-oauth/task.md`
+- WHEN legacy plans are discovered
+- THEN the result includes one plan with ID `add-oauth`
+- AND the result includes both the parent plan file and known companion files
+- AND the result includes `targetChangePath: openspec/changes/add-oauth`
+
+#### Scenario: Only one legacy form exists
+
+- GIVEN `.ai-factory/plans/add-oauth.md` exists without `.ai-factory/plans/add-oauth/`
+- WHEN legacy plans are discovered
+- THEN the result includes plan ID `add-oauth`
+- AND `planFile` references `.ai-factory/plans/add-oauth.md`
+- AND `planDir` is `null`
+
+#### Scenario: Discovery paths are stable and relative
+
+- GIVEN legacy plans are discovered from a repository root
+- WHEN the discovery result is returned
+- THEN source and target paths use repository-relative POSIX paths
+- AND results do not expose absolute paths except in safety diagnostics
+
+#### Scenario: Non-plan entries are ignored
+
+- GIVEN hidden entries, archive folders, backup folders, and unrelated non-markdown files under `.ai-factory/plans/`
+- WHEN legacy plans are discovered
+- THEN those entries are excluded from the returned plan list
+- AND valid plan results remain sorted by plan ID
+
+### Requirement: Canonical OpenSpec Mapping
+
+The system MUST map legacy planning intent into canonical OpenSpec change artifacts without placing runtime-only files in `openspec/changes/<change-id>/`.
+
+#### Scenario: Legacy plan summary is migrated
+
+- GIVEN `.ai-factory/plans/add-oauth.md` contains legacy plan text
+- WHEN plan `add-oauth` is migrated
+- THEN `openspec/changes/add-oauth/proposal.md` is written
+- AND the proposal references `.ai-factory/plans/add-oauth.md` as a legacy source
+- AND the original legacy text remains represented either through structured sections or a clearly labeled legacy notes section
+
+#### Scenario: Legacy tasks are migrated
+
+- GIVEN `.ai-factory/plans/add-oauth/task.md` contains checklist tasks
+- WHEN plan `add-oauth` is migrated
+- THEN `openspec/changes/add-oauth/tasks.md` contains checkbox tasks preserving the intended work
+
+#### Scenario: Runtime-only legacy files stay outside canonical artifacts
+
+- GIVEN a legacy plan folder contains `verify.md` and `status.yaml`
+- WHEN plan `add-oauth` is migrated
+- THEN no `verify.md` is written under `openspec/changes/add-oauth/`
+- AND no `status.yaml` is written under `openspec/changes/add-oauth/`
+- AND `verify.md` is preserved as `.ai-factory/qa/add-oauth/legacy-verify.md`
+- AND `status.yaml` is preserved as `.ai-factory/state/add-oauth/legacy-status.yaml`
+
+### Requirement: Runtime Preservation
+
+The system MUST preserve legacy context, rules, status, exploration, and verification evidence in runtime or QA locations.
+
+#### Scenario: Context and rules are preserved
+
+- GIVEN `.ai-factory/plans/add-oauth/context.md` and `.ai-factory/plans/add-oauth/rules.md`
+- WHEN plan `add-oauth` is migrated
+- THEN full context is preserved as `.ai-factory/state/add-oauth/legacy-context.md`
+- AND rules are preserved as `.ai-factory/state/add-oauth/legacy-rules.md`
+- AND design-relevant context may also be summarized in `openspec/changes/add-oauth/design.md`
+
+#### Scenario: Exploration notes are preserved
+
+- GIVEN `.ai-factory/plans/add-oauth/explore.md`
+- WHEN plan `add-oauth` is migrated
+- THEN the notes are preserved as `.ai-factory/state/add-oauth/legacy-explore.md`
+- AND the notes are not copied into canonical OpenSpec change artifacts as runtime research logs
+
+### Requirement: Migration Path Safety
+
+The system MUST reject any planned write that escapes its allowed canonical, runtime state, or QA boundary.
+
+#### Scenario: Canonical writes stay inside the change folder
+
+- GIVEN a mapped canonical artifact target outside `openspec/changes/add-oauth/`
+- WHEN migration operations are planned
+- THEN migration fails before writing files
+- AND no legacy artifacts are deleted or modified
+
+#### Scenario: Runtime writes stay outside canonical and legacy folders
+
+- GIVEN a mapped runtime artifact target under `openspec/changes/add-oauth/` or `.ai-factory/plans/add-oauth/`
+- WHEN migration operations are planned
+- THEN migration fails before writing files
+- AND no runtime-only legacy file is written into a canonical OpenSpec folder
+
+#### Scenario: Base specs are never mutated
+
+- GIVEN a migrated plan generates canonical change artifacts
+- WHEN migration runs
+- THEN no operation targets `openspec/specs/**`
+
+### Requirement: Dry-Run Migration
+
+The system MUST support dry-run migration that performs no filesystem writes while returning a complete operation plan.
+
+#### Scenario: Single-plan dry-run
+
+- GIVEN a legacy plan `add-oauth`
+- WHEN `migrateLegacyPlan('add-oauth', { dryRun: true })` runs
+- THEN no directories are created
+- AND no files are written
+- AND the result includes write operations for the canonical, runtime, QA, and report targets that would be produced
+- AND runtime layout helpers are not called in a way that creates directories
+
+#### Scenario: All-plan dry-run
+
+- GIVEN multiple legacy plans
+- WHEN all legacy plans are migrated with `dryRun: true`
+- THEN no directories are created
+- AND the result includes one dry-run migration plan per discovered legacy plan
+
+### Requirement: Collision Handling
+
+The system MUST never silently overwrite existing OpenSpec change artifacts.
+
+#### Scenario: Default collision fails
+
+- GIVEN `openspec/changes/add-oauth` already exists
+- WHEN plan `add-oauth` is migrated without explicit collision options
+- THEN migration fails with a `target-exists` error
+- AND the result identifies the legacy source and existing target
+
+#### Scenario: Suffix collision creates distinct target
+
+- GIVEN `openspec/changes/add-oauth` already exists
+- WHEN plan `add-oauth` is migrated with `onCollision: 'suffix'`
+- THEN migration writes to a distinct safe change ID such as `add-oauth-migrated`
+- AND no existing canonical artifact is overwritten
+
+#### Scenario: Merge-safe collision preserves existing files
+
+- GIVEN `openspec/changes/add-oauth/proposal.md` already exists
+- WHEN plan `add-oauth` is migrated with `onCollision: 'merge-safe'`
+- THEN the existing proposal is not overwritten
+- AND missing target files are created
+- AND skipped existing files are reported
+
+### Requirement: All-Plan Migration
+
+The system MUST migrate all discovered legacy plans in stable order when explicitly requested.
+
+#### Scenario: All plans migrate successfully
+
+- GIVEN multiple legacy plans
+- WHEN `migrateAllLegacyPlans()` runs
+- THEN each discovered plan is migrated once in sorted ID order
+- AND the top-level result reports all migrated plan IDs
+
+#### Scenario: All-plan migration reports partial failure
+
+- GIVEN multiple legacy plans
+- AND one plan collides with an existing OpenSpec change using default collision behavior
+- WHEN `migrateAllLegacyPlans()` runs
+- THEN non-colliding plans still return their own migration results
+- AND the top-level result reports partial failure with per-plan errors
+
+### Requirement: Migration Report
+
+The system MUST write a migration report for every non-dry-run migration.
+
+#### Scenario: Report records artifacts and validation
+
+- GIVEN plan `add-oauth` is migrated without `dryRun`
+- WHEN migration completes
+- THEN `.ai-factory/state/add-oauth/migration-report.md` is written
+- AND the report lists source artifacts
+- AND the report lists generated OpenSpec artifacts
+- AND the report lists runtime and QA artifacts
+- AND the report records OpenSpec validation as `PASS`, `FAIL`, or `SKIPPED`
+- AND the report includes manual follow-ups
+
+### Requirement: OpenSpec Validation Integration
+
+The system MUST validate migrated OpenSpec changes when a compatible OpenSpec CLI is available and degrade gracefully when it is not.
+
+#### Scenario: Compatible CLI validates change
+
+- GIVEN OpenSpec detection reports validation support
+- WHEN plan `add-oauth` is migrated
+- THEN `validateOpenSpecChange('add-oauth')` is called after artifact writes
+- AND the validation result is recorded in the migration result and report
+
+#### Scenario: Missing CLI skips validation
+
+- GIVEN OpenSpec CLI detection reports missing or unsupported CLI
+- WHEN plan `add-oauth` is migrated
+- THEN migration does not fail only because the CLI is missing
+- AND validation is recorded as `SKIPPED`
+
+#### Scenario: Validation failure is recorded
+
+- GIVEN OpenSpec validation fails after artifacts are written
+- WHEN plan `add-oauth` is migrated
+- THEN the migration result records the validation failure
+- AND the migration report records `FAIL`
+- AND the migration does not delete generated or legacy artifacts as rollback
+
+### Requirement: Migration Command
+
+The system MUST provide an explicit command for listing and migrating legacy plans.
+
+#### Scenario: CLI lists legacy plans
+
+- GIVEN legacy plan artifacts exist
+- WHEN `node scripts/migrate-legacy-plans.mjs --list` runs
+- THEN the command prints discovered legacy plans and target paths
+- AND exits with code `0`
+
+#### Scenario: CLI migrates with collision option
+
+- GIVEN legacy plan `add-oauth`
+- WHEN `node scripts/migrate-legacy-plans.mjs add-oauth --on-collision suffix` runs
+- THEN migration uses suffix collision behavior
+- AND the command reports the created target change ID
+
+#### Scenario: CLI rejects invalid arguments
+
+- GIVEN an unsupported collision mode
+- WHEN `node scripts/migrate-legacy-plans.mjs add-oauth --on-collision unsafe` runs
+- THEN the command prints a concise argument error
+- AND exits with code `2`
+
+#### Scenario: CLI emits JSON metadata
+
+- GIVEN legacy plan `add-oauth`
+- WHEN `node scripts/migrate-legacy-plans.mjs add-oauth --dry-run --json` runs
+- THEN stdout is parseable JSON
+- AND the JSON includes operation paths, diagnostics, dry-run status, and target change ID
+- AND the JSON does not include full generated artifact content by default
+
+### Requirement: Migration Suggestions
+
+The system MUST suggest migration when OpenSpec-native improve, implement, or verify cannot resolve a change but matching legacy plan artifacts exist.
+
+#### Scenario: Improve detects matching legacy plan
+
+- GIVEN no `openspec/changes/add-oauth` exists
+- AND `.ai-factory/plans/add-oauth.md` exists
+- WHEN `/aif-improve add-oauth` cannot resolve an OpenSpec change
+- THEN guidance suggests running `node scripts/migrate-legacy-plans.mjs add-oauth --dry-run`
+- AND guidance suggests running `node scripts/migrate-legacy-plans.mjs add-oauth`
+- AND no automatic migration occurs
+
+#### Scenario: Detection API returns exact suggestion commands
+
+- GIVEN no `openspec/changes/add-oauth` exists
+- AND legacy artifacts for `add-oauth` exist
+- WHEN `detectMigrationNeed({ changeId: 'add-oauth' })` runs
+- THEN the result identifies the legacy source artifacts
+- AND includes dry-run and migration commands
+- AND marks migration as suggested but not executed
+
+#### Scenario: Implement and verify use same suggestion
+
+- GIVEN matching legacy artifacts exist for an unresolved OpenSpec change ID
+- WHEN `/aif-implement add-oauth` or `/aif-verify add-oauth` cannot resolve an OpenSpec change
+- THEN each command presents the same explicit migration suggestion
+- AND neither command mutates legacy or OpenSpec artifacts as part of suggestion
+
+### Requirement: Documentation and Fixture Coverage
+
+The system MUST document migration behavior and include fixture-backed tests proving intended meaning is preserved.
+
+#### Scenario: User documentation describes migration
+
+- GIVEN user-facing docs are generated
+- WHEN a user reads the migration guide
+- THEN it explains when migration is needed
+- AND it explains dry-run, single-plan migration, all-plan migration, collision behavior, canonical mapping, runtime and QA preservation, validation, and post-migration review with `/aif-improve <id>`
+
+#### Scenario: Fixture migration preserves meaning
+
+- GIVEN the `legacy-plan-basic` fixture contains summary, tasks, design context, rules, verify evidence, status, and exploration notes
+- WHEN the fixture is migrated in a temp directory
+- THEN generated `proposal.md`, `tasks.md`, `design.md`, runtime notes, QA evidence, and the report preserve the intended meaning of the source artifacts
+- AND original legacy fixture artifacts remain present

--- a/openspec/changes/migrate-legacy-plan-artifacts/tasks.md
+++ b/openspec/changes/migrate-legacy-plan-artifacts/tasks.md
@@ -1,0 +1,105 @@
+﻿# Tasks
+
+## 1. Discovery and fixture setup
+
+- [x] 1.1 Add an exported-API test in `scripts/legacy-plan-migration.test.mjs` for every required public function.
+- [x] 1.2 Create `test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth.md` with a clear legacy summary, scope, approach, and behavioral requirement.
+- [x] 1.3 Create `test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/task.md` with checklist-shaped legacy tasks.
+- [x] 1.4 Create `test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/context.md` with design-like architecture and implementation notes.
+- [x] 1.5 Create `test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/rules.md`, `verify.md`, `status.yaml`, and `explore.md` so runtime and QA preservation can be tested.
+- [x] 1.6 Add a fixture-copy helper in `scripts/legacy-plan-migration.test.mjs` that copies fixture files into a temp root without adding dependencies.
+- [x] 1.7 Add initial discovery tests in `scripts/legacy-plan-migration.test.mjs` for `<id>.md`, `<id>/`, both forms together, partial folders, hidden entries, archive or backup folders, stable sorting, and target path diagnostics.
+- [x] 1.8 Assert discovery returns `null` for absent `planFile` or `planDir`, omits absent known files, and reports repository-relative POSIX paths.
+
+## 2. Core migration module
+
+- [x] 2.1 Create `scripts/legacy-plan-migration.mjs` exporting all required API functions and no side-effectful top-level execution.
+- [x] 2.2 Implement `normalizeLegacyPlanId(input)` using the same safety constraints as OpenSpec change IDs, rejecting path traversal, absolute paths, slashes, backslashes, empty values, hidden IDs, and `archive`.
+- [x] 2.3 Implement `discoverLegacyPlans(options = {})` with `rootDir`, `plansDir`, and `changesDir` options, returning stable relative POSIX paths, warnings, and errors.
+- [x] 2.4 Implement source loading for known legacy files only. Unknown files inside detected plan folders may be reported but must not become canonical artifacts.
+- [x] 2.5 Keep library functions quiet by default. They should return structured warnings and errors instead of logging; CLI logging belongs only in `scripts/migrate-legacy-plans.mjs`.
+- [x] 2.6 Implement path guard helpers for canonical change writes, state writes, QA writes, root containment, legacy-plan exclusion, and `openspec/specs` exclusion.
+- [x] 2.7 Add tests that unsafe mapped targets are rejected before any write happens.
+
+## 3. Mapping behavior
+
+- [x] 3.1 Implement `mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {})` as a pure function that returns canonical artifacts, runtime artifacts, QA artifacts, source references, warnings, and manual follow-ups.
+- [x] 3.2 Map `.ai-factory/plans/<id>.md` to `openspec/changes/<change-id>/proposal.md` with `Intent`, `Scope`, `Approach`, `Legacy source`, and `Legacy plan notes` fallback sections.
+- [x] 3.3 Map `task.md` to `openspec/changes/<change-id>/tasks.md`, preserving safe checkboxes and wrapping non-checklist prose under `## Migrated legacy tasks`.
+- [x] 3.4 Map design-like `context.md` into `design.md` and always preserve full raw context as `.ai-factory/state/<change-id>/legacy-context.md`.
+- [x] 3.5 Preserve `rules.md` as `.ai-factory/state/<change-id>/legacy-rules.md`; only add review-labeled candidate requirement notes when the content clearly contains product behavior.
+- [x] 3.6 Preserve `verify.md` only as `.ai-factory/qa/<change-id>/legacy-verify.md`.
+- [x] 3.7 Preserve `status.yaml` only as `.ai-factory/state/<change-id>/legacy-status.yaml`.
+- [x] 3.8 Preserve `explore.md` only as `.ai-factory/state/<change-id>/legacy-explore.md`.
+- [x] 3.9 Generate `openspec/changes/<change-id>/specs/migrated/spec.md` only when clear behavioral requirements can be extracted. Otherwise omit the delta spec and record the manual spec-authoring follow-up.
+
+## 4. Write, dry-run, and collision handling
+
+- [x] 4.1 Implement an operation planner that produces a full `operations` list for both dry-run and write mode.
+- [x] 4.2 Implement `migrateLegacyPlan(planId, options = {})` with default `onCollision: 'fail'`.
+- [x] 4.3 Ensure `dryRun: true` creates no directories, writes no files, and does not call `ensureRuntimeLayout`, while returning all planned writes and warnings.
+- [x] 4.4 Implement `onCollision: 'fail'` so an existing `openspec/changes/<change-id>` returns `target-exists` with source and target paths.
+- [x] 4.5 Implement `onCollision: 'suffix'` using a deterministic safe target such as `<id>-migrated`, with numbered fallback if needed.
+- [x] 4.6 Implement `onCollision: 'merge-safe'` so only missing canonical and runtime files are written and existing files are reported as skipped.
+- [x] 4.7 Implement `onCollision: 'overwrite'` only when explicitly passed, still preserving legacy sources and writing a migration report.
+- [x] 4.8 Assert in tests that no migration path deletes legacy artifacts and no operation mutates `openspec/specs`.
+- [x] 4.9 Implement `migrateAllLegacyPlans(options = {})` with per-plan results, stable ordering, and a top-level `ok`, `partial`, `migrated`, `failed`, `warnings`, and `errors` summary.
+- [x] 4.10 Add tests for `migrateAllLegacyPlans` full success, partial failure, and dry-run behavior.
+
+## 5. Reports and OpenSpec validation
+
+- [x] 5.1 Implement `writeMigrationReport(planId, report, options = {})` writing `.ai-factory/state/<change-id>/migration-report.md`.
+- [x] 5.2 Include summary, source artifacts, generated OpenSpec artifacts, runtime artifacts, validation status, warnings, errors, and manual follow-ups in the report.
+- [x] 5.3 Integrate `detectOpenSpec` and `validateOpenSpecChange` with dependency injection so tests do not require a real OpenSpec CLI.
+- [x] 5.4 Record missing or unsupported CLI as validation `SKIPPED` and keep migration result `ok: true` unless other errors exist.
+- [x] 5.5 Record validation failure in the result and report. Default to `ok: false` after files are written, without rollback or deletion.
+- [x] 5.6 Add tests for missing CLI, validation called when available, validation pass, validation fail, and report content.
+
+## 6. CLI wrapper and package script
+
+- [x] 6.1 Create `scripts/migrate-legacy-plans.mjs` with dependency-free argument parsing.
+- [x] 6.2 Support `node scripts/migrate-legacy-plans.mjs --list`.
+- [x] 6.3 Support `node scripts/migrate-legacy-plans.mjs add-oauth --dry-run` and `node scripts/migrate-legacy-plans.mjs add-oauth`.
+- [x] 6.4 Support `node scripts/migrate-legacy-plans.mjs --all --dry-run` and `node scripts/migrate-legacy-plans.mjs --all`.
+- [x] 6.5 Support `--on-collision fail|merge-safe|suffix|overwrite` and reject unknown values.
+- [x] 6.6 Support `--json` for machine-readable output.
+- [x] 6.7 Add `migrate:legacy-plans` to `package.json` only if the wrapper is added and the repo convention remains package-script based.
+- [x] 6.8 Keep CLI output concise, human-readable, and explicit about dry-run, created targets, skipped targets, report path, and validation status.
+- [x] 6.9 Define and test exit codes: `0` for success or list success, `1` for migration or validation failure, and `2` for invalid CLI arguments.
+- [x] 6.10 Keep `--json` output focused on result metadata, operation paths, diagnostics, validation summaries, and report paths; do not dump full artifact contents by default.
+
+## 7. Improve, implement, and verify migration suggestions
+
+- [x] 7.1 Implement `detectMigrationNeed(options = {})` so prompt/runtime consumers can detect a missing OpenSpec change with a matching legacy plan and return a suggestion object with exact commands.
+- [x] 7.2 Update `injections/core/aif-improve-plan-folder.md` to suggest the migration script when an explicit or resolved `<id>` has legacy artifacts but no `openspec/changes/<id>`.
+- [x] 7.3 Update `injections/core/aif-implement-plan-folder.md` with the same suggestion and a clear "do not auto-migrate" instruction.
+- [x] 7.4 Update `injections/core/aif-verify-plan-folder.md` with the same suggestion before verification scope fails.
+- [x] 7.5 Add prompt-asset tests that require the dry-run and migration commands to appear in improve, implement, and verify guidance.
+- [x] 7.6 Add module tests for `detectMigrationNeed` covering match found, no legacy match, existing OpenSpec change, unsafe ID, and command rendering.
+
+## 8. Documentation
+
+- [x] 8.1 Add `docs/legacy-plan-migration.md` explaining when migration is needed, dry-run, single-plan migration, all-plan migration, collision behavior, canonical mapping, runtime/QA preservation, validation, and review follow-ups.
+- [x] 8.2 Update `docs/usage.md` with a short migration section and link to the dedicated migration guide.
+- [x] 8.3 Update `docs/context-loading-policy.md` to describe legacy migration boundaries between canonical OpenSpec artifacts, runtime state, and QA evidence.
+- [x] 8.4 Update `docs/README.md` or the appropriate docs index so the new migration guide is discoverable.
+- [x] 8.5 Mention that legacy artifacts are not deleted and `/aif-improve <id>` should run after migration to refine generated artifacts.
+
+## 9. Verification
+
+- [x] 9.1 Run `npm run validate` and fix any manifest, agent, or doc-link failures.
+- [x] 9.2 Run `npm test` and fix failures.
+- [x] 9.3 Run at least one CLI dry-run against a temp copy of the fixture and confirm it writes nothing.
+- [x] 9.4 Run at least one non-dry-run migration in a temp directory and confirm intended meaning is preserved in `proposal.md`, `tasks.md`, `design.md`, runtime notes, QA notes, and the migration report.
+- [x] 9.5 Confirm final implementation does not create, delete, or mutate legacy source artifacts except for optional reads.
+- [x] 9.6 Confirm final `git diff --stat` shows only the intended migration module, CLI wrapper, fixtures, prompt assets, docs, package metadata, and tests.
+
+## Suggested Commit Plan
+
+Not executed as part of implementation because issue scope excludes git commit creation.
+
+- Commit 1: `feat: add legacy plan migration module`
+- Commit 2: `feat: add legacy migration cli and fixture coverage`
+- Commit 3: `docs: document legacy plan migration`
+- Commit 4: `test: cover migration prompts and validation behavior`
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "migrate:legacy-plans": "node scripts/migrate-legacy-plans.mjs",
     "test": "node --test scripts/*.test.mjs",
     "validate": "node scripts/validate-extension.mjs && node scripts/validate-codex-agents.mjs && node scripts/validate-claude-agents.mjs && node scripts/validate-doc-links.mjs"
   }

--- a/scripts/legacy-plan-migration.mjs
+++ b/scripts/legacy-plan-migration.mjs
@@ -170,6 +170,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
 
   const changeId = options.changeId ?? normalized.planId;
   const normalizedChange = normalizeChangeId(changeId);
+  const paths = getMigrationPathConfig(options);
   if (!normalizedChange.ok) {
     return {
       ok: false,
@@ -191,13 +192,13 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   const canonicalArtifacts = [
     {
       kind: 'proposal',
-      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'proposal.md')),
+      target: toPosix(path.join(paths.changesDir, normalizedChange.changeId, 'proposal.md')),
       source: legacyPlan.planFile ?? sourceArtifacts[0] ?? null,
       content: renderProposal({ title, legacyPlan, contents, sourceArtifacts })
     },
     {
       kind: 'tasks',
-      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'tasks.md')),
+      target: toPosix(path.join(paths.changesDir, normalizedChange.changeId, 'tasks.md')),
       source: legacyPlan.files?.task ?? null,
       content: renderTasks(contents.task)
     }
@@ -213,7 +214,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (isDesignLike(contents.context)) {
     canonicalArtifacts.push({
       kind: 'design',
-      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'design.md')),
+      target: toPosix(path.join(paths.changesDir, normalizedChange.changeId, 'design.md')),
       source: legacyPlan.files?.context ?? null,
       content: renderDesign({ title, legacyPlan, contents })
     });
@@ -222,7 +223,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (hasText(contents.context)) {
     runtimeArtifacts.push({
       kind: 'legacy-context',
-      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-context.md')),
+      target: toPosix(path.join(paths.stateDir, normalizedChange.changeId, 'legacy-context.md')),
       source: legacyPlan.files?.context ?? null,
       content: renderPreservedMarkdown('Legacy Context', legacyPlan.files?.context, contents.context)
     });
@@ -231,7 +232,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (hasText(contents.rules)) {
     runtimeArtifacts.push({
       kind: 'legacy-rules',
-      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-rules.md')),
+      target: toPosix(path.join(paths.stateDir, normalizedChange.changeId, 'legacy-rules.md')),
       source: legacyPlan.files?.rules ?? null,
       content: renderPreservedMarkdown('Legacy Rules', legacyPlan.files?.rules, contents.rules)
     });
@@ -244,7 +245,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (hasText(contents.status)) {
     runtimeArtifacts.push({
       kind: 'legacy-status',
-      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-status.yaml')),
+      target: toPosix(path.join(paths.stateDir, normalizedChange.changeId, 'legacy-status.yaml')),
       source: legacyPlan.files?.status ?? null,
       content: contents.status
     });
@@ -253,7 +254,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (hasText(contents.explore)) {
     runtimeArtifacts.push({
       kind: 'legacy-explore',
-      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-explore.md')),
+      target: toPosix(path.join(paths.stateDir, normalizedChange.changeId, 'legacy-explore.md')),
       source: legacyPlan.files?.explore ?? null,
       content: renderPreservedMarkdown('Legacy Exploration Notes', legacyPlan.files?.explore, contents.explore)
     });
@@ -262,7 +263,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (hasText(contents.verify)) {
     qaArtifacts.push({
       kind: 'legacy-verify',
-      target: toPosix(path.join(DEFAULT_QA_DIR, normalizedChange.changeId, 'legacy-verify.md')),
+      target: toPosix(path.join(paths.qaDir, normalizedChange.changeId, 'legacy-verify.md')),
       source: legacyPlan.files?.verify ?? null,
       content: contents.verify
     });
@@ -277,7 +278,7 @@ export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
   if (requirements.length > 0) {
     canonicalArtifacts.push({
       kind: 'delta-spec',
-      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'specs', 'migrated', 'spec.md')),
+      target: toPosix(path.join(paths.changesDir, normalizedChange.changeId, 'specs', 'migrated', 'spec.md')),
       source: sourceArtifacts[0] ?? null,
       content: renderDeltaSpec(requirements)
     });
@@ -308,6 +309,7 @@ export async function migrateLegacyPlan(planId, options = {}) {
   const normalized = normalizeLegacyPlanId(planId);
   const dryRun = Boolean(options.dryRun);
   const onCollision = options.onCollision ?? 'fail';
+  const paths = getMigrationPathConfig(options);
 
   if (!normalized.ok) {
     return createMigrationFailure({
@@ -364,12 +366,15 @@ export async function migrateLegacyPlan(planId, options = {}) {
       dryRun,
       planId: normalized.planId,
       changeId: normalized.planId,
-      targetChangePath: toPosix(path.join(DEFAULT_CHANGES_DIR, normalized.planId)),
+      targetChangePath: toPosix(path.join(paths.changesDir, normalized.planId)),
       errors: collision.errors
     });
   }
 
-  const mapped = mapLegacyPlanToOpenSpecArtifacts(legacyPlan, { changeId: collision.changeId });
+  const mapped = mapLegacyPlanToOpenSpecArtifacts(legacyPlan, {
+    ...paths,
+    changeId: collision.changeId
+  });
   if (!mapped.ok) {
     return createMigrationFailure({
       dryRun,
@@ -389,7 +394,7 @@ export async function migrateLegacyPlan(planId, options = {}) {
 
   for (const artifact of plannedArtifacts) {
     try {
-      assertSafeArtifactTarget(rootDir, collision.changeId, artifact);
+      assertSafeArtifactTarget(rootDir, collision.changeId, artifact, paths);
     } catch (err) {
       errors.push({
         code: 'unsafe-target',
@@ -417,6 +422,7 @@ export async function migrateLegacyPlan(planId, options = {}) {
   }
 
   const reportPath = await resolveMigrationReportPath(rootDir, collision.changeId, {
+    ...paths,
     onCollision
   });
   operations.push({
@@ -429,7 +435,7 @@ export async function migrateLegacyPlan(planId, options = {}) {
     assertSafeArtifactTarget(rootDir, collision.changeId, {
       target: reportPath,
       bucket: 'state'
-    });
+    }, paths);
   } catch (err) {
     errors.push({
       code: 'unsafe-target',
@@ -443,7 +449,7 @@ export async function migrateLegacyPlan(planId, options = {}) {
       dryRun,
       planId: normalized.planId,
       changeId: collision.changeId,
-      targetChangePath: toPosix(path.join(DEFAULT_CHANGES_DIR, collision.changeId)),
+      targetChangePath: toPosix(path.join(paths.changesDir, collision.changeId)),
       operations,
       warnings: mapped.warnings,
       errors
@@ -455,7 +461,7 @@ export async function migrateLegacyPlan(planId, options = {}) {
     dryRun,
     planId: normalized.planId,
     changeId: collision.changeId,
-    targetChangePath: toPosix(path.join(DEFAULT_CHANGES_DIR, collision.changeId)),
+    targetChangePath: toPosix(path.join(paths.changesDir, collision.changeId)),
     operations,
     validation: createValidationSummary('SKIPPED', false, null),
     reportPath,
@@ -564,6 +570,7 @@ export async function writeMigrationReport(planId, report, options = {}) {
   const rootDir = resolveRootDir(options);
   const changeId = options.changeId ?? report?.changeId ?? planId;
   const normalized = normalizeChangeId(changeId);
+  const paths = getMigrationPathConfig(options);
 
   if (!normalized.ok) {
     throw new Error(normalized.error.message);
@@ -571,7 +578,7 @@ export async function writeMigrationReport(planId, report, options = {}) {
 
   const reportPath = options.reportPath
     ? toPosix(options.reportPath)
-    : toPosix(path.join(DEFAULT_STATE_DIR, normalized.changeId, 'migration-report.md'));
+    : toPosix(path.join(paths.stateDir, normalized.changeId, 'migration-report.md'));
   const artifact = {
     bucket: 'state',
     target: reportPath,
@@ -581,7 +588,7 @@ export async function writeMigrationReport(planId, report, options = {}) {
       ...report
     })
   };
-  assertSafeArtifactTarget(rootDir, normalized.changeId, artifact);
+  assertSafeArtifactTarget(rootDir, normalized.changeId, artifact, paths);
 
   if (options.dryRun) {
     return {
@@ -642,7 +649,8 @@ export async function detectMigrationNeed(options = {}) {
 
 async function resolveCollisionTarget(planId, options) {
   const rootDir = resolveRootDir(options);
-  const changesDir = options.changesDir ?? DEFAULT_CHANGES_DIR;
+  const paths = getMigrationPathConfig(options);
+  const changesDir = paths.changesDir;
   const onCollision = options.onCollision ?? 'fail';
   const target = resolveFromRoot(rootDir, path.join(changesDir, planId));
   const exists = await pathExists(target);
@@ -663,7 +671,7 @@ async function resolveCollisionTarget(planId, options) {
         {
           code: 'target-exists',
           message: `OpenSpec change target already exists: ${toPosix(path.join(changesDir, planId))}.`,
-          source: toPosix(path.join(DEFAULT_PLANS_DIR, `${planId}.md`)),
+          source: toPosix(path.join(paths.plansDir, `${planId}.md`)),
           target: toPosix(path.join(changesDir, planId))
         }
       ]
@@ -700,7 +708,8 @@ async function resolveCollisionTarget(planId, options) {
 }
 
 async function resolveMigrationReportPath(rootDir, changeId, options = {}) {
-  const defaultReportPath = toPosix(path.join(DEFAULT_STATE_DIR, changeId, 'migration-report.md'));
+  const paths = getMigrationPathConfig(options);
+  const defaultReportPath = toPosix(path.join(paths.stateDir, changeId, 'migration-report.md'));
 
   if (options.onCollision === 'overwrite' || !await pathExists(resolveFromRoot(rootDir, defaultReportPath))) {
     return defaultReportPath;
@@ -708,7 +717,7 @@ async function resolveMigrationReportPath(rootDir, changeId, options = {}) {
 
   for (let index = 0; index < 100; index += 1) {
     const suffix = index === 0 ? '-migrated' : `-migrated-${index + 1}`;
-    const candidate = toPosix(path.join(DEFAULT_STATE_DIR, changeId, `migration-report${suffix}.md`));
+    const candidate = toPosix(path.join(paths.stateDir, changeId, `migration-report${suffix}.md`));
     if (!await pathExists(resolveFromRoot(rootDir, candidate))) {
       return candidate;
     }
@@ -786,6 +795,15 @@ function ensureDiscoveredPlan(plansById, id, rootDir, changesRoot) {
   }
 
   return plansById.get(id);
+}
+
+function getMigrationPathConfig(options = {}) {
+  return {
+    plansDir: options.plansDir ?? DEFAULT_PLANS_DIR,
+    changesDir: options.changesDir ?? DEFAULT_CHANGES_DIR,
+    stateDir: options.stateDir ?? DEFAULT_STATE_DIR,
+    qaDir: options.qaDir ?? DEFAULT_QA_DIR
+  };
 }
 
 async function readLegacyPlanContents(rootDir, plan) {
@@ -1119,24 +1137,25 @@ async function writeArtifact(rootDir, artifact) {
   await writeFile(targetPath, artifact.content, 'utf8');
 }
 
-function assertSafeArtifactTarget(rootDir, changeId, artifact) {
+function assertSafeArtifactTarget(rootDir, changeId, artifact, options = {}) {
+  const paths = getMigrationPathConfig(options);
   const targetPath = resolveFromRoot(rootDir, artifact.target);
   assertWithinRoot(rootDir, targetPath);
-  assertNotLegacyPlanPath(rootDir, targetPath);
+  assertNotLegacyPlanPath(rootDir, targetPath, paths);
   assertNotBaseSpecPath(rootDir, targetPath);
 
   if (artifact.bucket === 'canonical') {
-    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(DEFAULT_CHANGES_DIR, changeId)), 'Canonical migration target must stay inside the OpenSpec change folder.');
+    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(paths.changesDir, changeId)), 'Canonical migration target must stay inside the OpenSpec change folder.');
     return;
   }
 
   if (artifact.bucket === 'state') {
-    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(DEFAULT_STATE_DIR, changeId)), 'Runtime state migration target must stay inside the change state folder.');
+    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(paths.stateDir, changeId)), 'Runtime state migration target must stay inside the change state folder.');
     return;
   }
 
   if (artifact.bucket === 'qa') {
-    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(DEFAULT_QA_DIR, changeId)), 'QA migration target must stay inside the change QA folder.');
+    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(paths.qaDir, changeId)), 'QA migration target must stay inside the change QA folder.');
     return;
   }
 
@@ -1147,8 +1166,9 @@ function assertWithinRoot(rootDir, targetPath) {
   assertWithinDirectory(targetPath, path.resolve(rootDir), 'Migration target escapes repository root.');
 }
 
-function assertNotLegacyPlanPath(rootDir, targetPath) {
-  const legacyPlansPath = resolveFromRoot(rootDir, DEFAULT_PLANS_DIR);
+function assertNotLegacyPlanPath(rootDir, targetPath, options = {}) {
+  const paths = getMigrationPathConfig(options);
+  const legacyPlansPath = resolveFromRoot(rootDir, paths.plansDir);
   if (isWithinDirectory(targetPath, legacyPlansPath)) {
     throw new Error('Migration target must not write under legacy plan folders.');
   }

--- a/scripts/legacy-plan-migration.mjs
+++ b/scripts/legacy-plan-migration.mjs
@@ -1,0 +1,1259 @@
+// legacy-plan-migration.mjs - explicit migration from legacy AI Factory plans to OpenSpec changes
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  ensureRuntimeLayout as defaultEnsureRuntimeLayout,
+  normalizeChangeId
+} from './active-change-resolver.mjs';
+import {
+  detectOpenSpec as defaultDetectOpenSpec,
+  validateOpenSpecChange as defaultValidateOpenSpecChange
+} from './openspec-runner.mjs';
+
+const DEFAULT_PLANS_DIR = path.join('.ai-factory', 'plans');
+const DEFAULT_CHANGES_DIR = path.join('openspec', 'changes');
+const DEFAULT_STATE_DIR = path.join('.ai-factory', 'state');
+const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
+const KNOWN_PLAN_FILES = {
+  task: 'task.md',
+  context: 'context.md',
+  rules: 'rules.md',
+  verify: 'verify.md',
+  status: 'status.yaml',
+  explore: 'explore.md'
+};
+const COLLISION_MODES = new Set(['fail', 'merge-safe', 'suffix', 'overwrite']);
+const EXCLUDED_PLAN_NAMES = new Set(['archive', 'archives', 'archived', 'backup', 'backups']);
+
+export function normalizeLegacyPlanId(input) {
+  const normalized = normalizeChangeId(String(input ?? '').trim());
+
+  if (
+    !normalized.ok
+    || normalized.changeId.startsWith('.')
+    || EXCLUDED_PLAN_NAMES.has(normalized.changeId.toLowerCase())
+  ) {
+    return {
+      ok: false,
+      planId: null,
+      error: {
+        code: 'invalid-legacy-plan-id',
+        message: `Invalid legacy plan id: ${JSON.stringify(input)}.`
+      }
+    };
+  }
+
+  return {
+    ok: true,
+    planId: normalized.changeId,
+    error: null
+  };
+}
+
+export async function discoverLegacyPlans(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const plansRoot = resolveFromRoot(rootDir, options.plansDir ?? DEFAULT_PLANS_DIR);
+  const changesRoot = resolveFromRoot(rootDir, options.changesDir ?? DEFAULT_CHANGES_DIR);
+  const plansById = new Map();
+  const warnings = [];
+
+  let entries;
+  try {
+    entries = await readdir(plansRoot, { withFileTypes: true });
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      return {
+        ok: true,
+        plans: [],
+        warnings: [],
+        errors: []
+      };
+    }
+
+    return {
+      ok: false,
+      plans: [],
+      warnings: [],
+      errors: [
+        {
+          code: 'filesystem-error',
+          message: `Unable to read legacy plans directory: ${toPosix(path.relative(rootDir, plansRoot))}.`,
+          detail: err?.message ?? 'Unknown filesystem error.'
+        }
+      ]
+    };
+  }
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (shouldExcludePlanEntry(entry.name)) {
+      continue;
+    }
+
+    if (entry.isFile()) {
+      if (path.extname(entry.name) !== '.md') {
+        continue;
+      }
+
+      const id = path.basename(entry.name, '.md');
+      const normalized = normalizeLegacyPlanId(id);
+      if (!normalized.ok) {
+        warnings.push(createSkippedUnsafeWarning(entry.name));
+        continue;
+      }
+
+      const plan = ensureDiscoveredPlan(plansById, normalized.planId, rootDir, changesRoot);
+      plan.planFile = toPosix(path.relative(rootDir, path.join(plansRoot, entry.name)));
+      continue;
+    }
+
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const normalized = normalizeLegacyPlanId(entry.name);
+    if (!normalized.ok) {
+      warnings.push(createSkippedUnsafeWarning(entry.name));
+      continue;
+    }
+
+    const planDirPath = path.join(plansRoot, entry.name);
+    const plan = ensureDiscoveredPlan(plansById, normalized.planId, rootDir, changesRoot);
+    plan.planDir = toPosix(path.relative(rootDir, planDirPath));
+
+    for (const [key, fileName] of Object.entries(KNOWN_PLAN_FILES)) {
+      const filePath = path.join(planDirPath, fileName);
+      if (await isFile(filePath)) {
+        plan.files[key] = toPosix(path.relative(rootDir, filePath));
+      }
+    }
+  }
+
+  const plans = [];
+  for (const plan of [...plansById.values()].sort((left, right) => left.id.localeCompare(right.id))) {
+    plan.hasCanonicalTarget = await isDirectory(path.join(changesRoot, plan.id));
+
+    if (options.includeContent) {
+      plan.contents = await readLegacyPlanContents(rootDir, plan);
+    }
+
+    plans.push(plan);
+  }
+
+  return {
+    ok: true,
+    plans,
+    warnings,
+    errors: []
+  };
+}
+
+export function mapLegacyPlanToOpenSpecArtifacts(legacyPlan, options = {}) {
+  const planId = legacyPlan?.id;
+  const normalized = normalizeLegacyPlanId(planId);
+
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      planId: null,
+      changeId: null,
+      canonicalArtifacts: [],
+      runtimeArtifacts: [],
+      qaArtifacts: [],
+      sourceArtifacts: [],
+      manualFollowUps: [],
+      warnings: [],
+      errors: [normalized.error]
+    };
+  }
+
+  const changeId = options.changeId ?? normalized.planId;
+  const normalizedChange = normalizeChangeId(changeId);
+  if (!normalizedChange.ok) {
+    return {
+      ok: false,
+      planId: normalized.planId,
+      changeId: null,
+      canonicalArtifacts: [],
+      runtimeArtifacts: [],
+      qaArtifacts: [],
+      sourceArtifacts: [],
+      manualFollowUps: [],
+      warnings: [],
+      errors: [normalizedChange.error]
+    };
+  }
+
+  const contents = legacyPlan.contents ?? {};
+  const sourceArtifacts = collectSourceArtifacts(legacyPlan);
+  const title = extractTitle(contents.plan) ?? titleFromId(normalized.planId);
+  const canonicalArtifacts = [
+    {
+      kind: 'proposal',
+      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'proposal.md')),
+      source: legacyPlan.planFile ?? sourceArtifacts[0] ?? null,
+      content: renderProposal({ title, legacyPlan, contents, sourceArtifacts })
+    },
+    {
+      kind: 'tasks',
+      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'tasks.md')),
+      source: legacyPlan.files?.task ?? null,
+      content: renderTasks(contents.task)
+    }
+  ];
+  const runtimeArtifacts = [];
+  const qaArtifacts = [];
+  const manualFollowUps = [
+    'Review generated OpenSpec artifacts before implementation.',
+    `Run /aif-improve ${normalizedChange.changeId} after migration to refine proposal, design, tasks, and specs.`
+  ];
+  const warnings = [];
+
+  if (isDesignLike(contents.context)) {
+    canonicalArtifacts.push({
+      kind: 'design',
+      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'design.md')),
+      source: legacyPlan.files?.context ?? null,
+      content: renderDesign({ title, legacyPlan, contents })
+    });
+  }
+
+  if (hasText(contents.context)) {
+    runtimeArtifacts.push({
+      kind: 'legacy-context',
+      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-context.md')),
+      source: legacyPlan.files?.context ?? null,
+      content: renderPreservedMarkdown('Legacy Context', legacyPlan.files?.context, contents.context)
+    });
+  }
+
+  if (hasText(contents.rules)) {
+    runtimeArtifacts.push({
+      kind: 'legacy-rules',
+      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-rules.md')),
+      source: legacyPlan.files?.rules ?? null,
+      content: renderPreservedMarkdown('Legacy Rules', legacyPlan.files?.rules, contents.rules)
+    });
+    warnings.push({
+      code: 'legacy-rules-preserved',
+      message: 'Legacy rules were preserved as runtime notes. Regenerate OpenSpec-derived rules after migration.'
+    });
+  }
+
+  if (hasText(contents.status)) {
+    runtimeArtifacts.push({
+      kind: 'legacy-status',
+      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-status.yaml')),
+      source: legacyPlan.files?.status ?? null,
+      content: contents.status
+    });
+  }
+
+  if (hasText(contents.explore)) {
+    runtimeArtifacts.push({
+      kind: 'legacy-explore',
+      target: toPosix(path.join(DEFAULT_STATE_DIR, normalizedChange.changeId, 'legacy-explore.md')),
+      source: legacyPlan.files?.explore ?? null,
+      content: renderPreservedMarkdown('Legacy Exploration Notes', legacyPlan.files?.explore, contents.explore)
+    });
+  }
+
+  if (hasText(contents.verify)) {
+    qaArtifacts.push({
+      kind: 'legacy-verify',
+      target: toPosix(path.join(DEFAULT_QA_DIR, normalizedChange.changeId, 'legacy-verify.md')),
+      source: legacyPlan.files?.verify ?? null,
+      content: contents.verify
+    });
+  }
+
+  const requirements = extractClearRequirements([
+    contents.plan,
+    contents.context,
+    contents.rules
+  ]);
+
+  if (requirements.length > 0) {
+    canonicalArtifacts.push({
+      kind: 'delta-spec',
+      target: toPosix(path.join(DEFAULT_CHANGES_DIR, normalizedChange.changeId, 'specs', 'migrated', 'spec.md')),
+      source: sourceArtifacts[0] ?? null,
+      content: renderDeltaSpec(requirements)
+    });
+  } else {
+    warnings.push({
+      code: 'manual-spec-authoring-needed',
+      message: 'No clear behavioral requirements were extracted; write or refine delta specs manually.'
+    });
+    manualFollowUps.push('Author or refine OpenSpec delta specs manually if validation requires them.');
+  }
+
+  return {
+    ok: true,
+    planId: normalized.planId,
+    changeId: normalizedChange.changeId,
+    canonicalArtifacts,
+    runtimeArtifacts,
+    qaArtifacts,
+    sourceArtifacts,
+    manualFollowUps,
+    warnings,
+    errors: []
+  };
+}
+
+export async function migrateLegacyPlan(planId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeLegacyPlanId(planId);
+  const dryRun = Boolean(options.dryRun);
+  const onCollision = options.onCollision ?? 'fail';
+
+  if (!normalized.ok) {
+    return createMigrationFailure({
+      dryRun,
+      planId: null,
+      changeId: null,
+      errors: [normalized.error]
+    });
+  }
+
+  if (!COLLISION_MODES.has(onCollision)) {
+    return createMigrationFailure({
+      dryRun,
+      planId: normalized.planId,
+      changeId: normalized.planId,
+      errors: [
+        {
+          code: 'invalid-collision-mode',
+          message: `Invalid collision mode: ${onCollision}.`
+        }
+      ]
+    });
+  }
+
+  const discovery = await discoverLegacyPlans({ ...options, rootDir, includeContent: true });
+  if (!discovery.ok) {
+    return createMigrationFailure({
+      dryRun,
+      planId: normalized.planId,
+      changeId: normalized.planId,
+      warnings: discovery.warnings,
+      errors: discovery.errors
+    });
+  }
+
+  const legacyPlan = discovery.plans.find((plan) => plan.id === normalized.planId);
+  if (legacyPlan === undefined) {
+    return createMigrationFailure({
+      dryRun,
+      planId: normalized.planId,
+      changeId: normalized.planId,
+      errors: [
+        {
+          code: 'legacy-plan-not-found',
+          message: `Legacy plan '${normalized.planId}' was not found.`
+        }
+      ]
+    });
+  }
+
+  const collision = await resolveCollisionTarget(normalized.planId, { ...options, rootDir, onCollision });
+  if (!collision.ok) {
+    return createMigrationFailure({
+      dryRun,
+      planId: normalized.planId,
+      changeId: normalized.planId,
+      targetChangePath: toPosix(path.join(DEFAULT_CHANGES_DIR, normalized.planId)),
+      errors: collision.errors
+    });
+  }
+
+  const mapped = mapLegacyPlanToOpenSpecArtifacts(legacyPlan, { changeId: collision.changeId });
+  if (!mapped.ok) {
+    return createMigrationFailure({
+      dryRun,
+      planId: normalized.planId,
+      changeId: collision.changeId,
+      errors: mapped.errors
+    });
+  }
+
+  const plannedArtifacts = [
+    ...mapped.canonicalArtifacts.map((artifact) => ({ ...artifact, bucket: 'canonical' })),
+    ...mapped.runtimeArtifacts.map((artifact) => ({ ...artifact, bucket: 'state' })),
+    ...mapped.qaArtifacts.map((artifact) => ({ ...artifact, bucket: 'qa' }))
+  ];
+  const operations = [];
+  const errors = [];
+
+  for (const artifact of plannedArtifacts) {
+    try {
+      assertSafeArtifactTarget(rootDir, collision.changeId, artifact);
+    } catch (err) {
+      errors.push({
+        code: 'unsafe-target',
+        message: err?.message ?? 'Unsafe migration target.',
+        target: artifact.target
+      });
+    }
+
+    const exists = await pathExists(resolveFromRoot(rootDir, artifact.target));
+    if (exists && onCollision === 'merge-safe') {
+      operations.push({
+        action: 'skip',
+        target: artifact.target,
+        source: artifact.source,
+        reason: 'target-exists'
+      });
+      continue;
+    }
+
+    operations.push({
+      action: 'write',
+      target: artifact.target,
+      source: artifact.source
+    });
+  }
+
+  const reportPath = await resolveMigrationReportPath(rootDir, collision.changeId, {
+    onCollision
+  });
+  operations.push({
+    action: 'write',
+    target: reportPath,
+    source: 'migration-result'
+  });
+
+  try {
+    assertSafeArtifactTarget(rootDir, collision.changeId, {
+      target: reportPath,
+      bucket: 'state'
+    });
+  } catch (err) {
+    errors.push({
+      code: 'unsafe-target',
+      message: err?.message ?? 'Unsafe migration report target.',
+      target: reportPath
+    });
+  }
+
+  if (errors.length > 0) {
+    return createMigrationFailure({
+      dryRun,
+      planId: normalized.planId,
+      changeId: collision.changeId,
+      targetChangePath: toPosix(path.join(DEFAULT_CHANGES_DIR, collision.changeId)),
+      operations,
+      warnings: mapped.warnings,
+      errors
+    });
+  }
+
+  const baseResult = {
+    ok: true,
+    dryRun,
+    planId: normalized.planId,
+    changeId: collision.changeId,
+    targetChangePath: toPosix(path.join(DEFAULT_CHANGES_DIR, collision.changeId)),
+    operations,
+    validation: createValidationSummary('SKIPPED', false, null),
+    reportPath,
+    warnings: [...discovery.warnings, ...mapped.warnings],
+    errors: []
+  };
+
+  if (dryRun) {
+    return baseResult;
+  }
+
+  const ensureRuntimeLayout = options.ensureRuntimeLayout ?? defaultEnsureRuntimeLayout;
+  await ensureRuntimeLayout(collision.changeId, {
+    rootDir,
+    cwd: options.cwd,
+    stateDir: options.stateDir,
+    qaDir: options.qaDir
+  });
+
+  for (const artifact of plannedArtifacts) {
+    if (operations.some((operation) => operation.action === 'skip' && operation.target === artifact.target)) {
+      continue;
+    }
+
+    await writeArtifact(rootDir, artifact);
+  }
+
+  const validation = await validateMigratedChange(collision.changeId, { ...options, rootDir });
+  const result = {
+    ...baseResult,
+    ok: validation.status !== 'FAIL',
+    validation,
+    errors: validation.status === 'FAIL'
+      ? [
+          {
+            code: 'openspec-validation-failed',
+            message: 'OpenSpec validation failed after migration.'
+          }
+        ]
+      : []
+  };
+
+  const report = await writeMigrationReport(normalized.planId, {
+    ...result,
+    sourceArtifacts: mapped.sourceArtifacts,
+    generatedOpenSpecArtifacts: mapped.canonicalArtifacts.map((artifact) => artifact.target),
+    runtimeArtifacts: [
+      ...mapped.runtimeArtifacts.map((artifact) => artifact.target),
+      ...mapped.qaArtifacts.map((artifact) => artifact.target)
+    ],
+    manualFollowUps: mapped.manualFollowUps
+  }, {
+    ...options,
+    rootDir,
+    changeId: collision.changeId,
+    reportPath
+  });
+
+  return {
+    ...result,
+    reportPath: report.path
+  };
+}
+
+export async function migrateAllLegacyPlans(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const discovery = await discoverLegacyPlans({ ...options, rootDir });
+
+  if (!discovery.ok) {
+    return {
+      ok: false,
+      partial: false,
+      dryRun: Boolean(options.dryRun),
+      results: [],
+      migrated: [],
+      failed: [],
+      warnings: discovery.warnings,
+      errors: discovery.errors
+    };
+  }
+
+  const results = [];
+  for (const plan of discovery.plans) {
+    results.push(await migrateLegacyPlan(plan.id, { ...options, rootDir }));
+  }
+
+  const migrated = results.filter((result) => result.ok).map((result) => result.planId);
+  const failed = results.filter((result) => !result.ok).map((result) => result.planId);
+
+  return {
+    ok: failed.length === 0,
+    partial: migrated.length > 0 && failed.length > 0,
+    dryRun: Boolean(options.dryRun),
+    results,
+    migrated,
+    failed,
+    warnings: dedupeDiagnostics([
+      ...discovery.warnings,
+      ...results.flatMap((result) => result.warnings ?? [])
+    ]),
+    errors: results.flatMap((result) => result.errors ?? [])
+  };
+}
+
+export async function writeMigrationReport(planId, report, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const changeId = options.changeId ?? report?.changeId ?? planId;
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error.message);
+  }
+
+  const reportPath = options.reportPath
+    ? toPosix(options.reportPath)
+    : toPosix(path.join(DEFAULT_STATE_DIR, normalized.changeId, 'migration-report.md'));
+  const artifact = {
+    bucket: 'state',
+    target: reportPath,
+    content: renderMigrationReport({
+      planId,
+      changeId: normalized.changeId,
+      ...report
+    })
+  };
+  assertSafeArtifactTarget(rootDir, normalized.changeId, artifact);
+
+  if (options.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      path: reportPath
+    };
+  }
+
+  await writeArtifact(rootDir, artifact);
+
+  return {
+    ok: true,
+    path: reportPath
+  };
+}
+
+export async function detectMigrationNeed(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const input = options.changeId ?? options.planId;
+  const normalized = normalizeLegacyPlanId(input);
+
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      migrationSuggested: false,
+      changeId: null,
+      changeExists: false,
+      legacyPlan: null,
+      commands: [],
+      warnings: [],
+      errors: [normalized.error]
+    };
+  }
+
+  const changePath = resolveFromRoot(rootDir, path.join(options.changesDir ?? DEFAULT_CHANGES_DIR, normalized.planId));
+  const changeExists = await pathExists(changePath);
+  const discovery = await discoverLegacyPlans({ ...options, rootDir });
+  const legacyPlan = discovery.plans.find((plan) => plan.id === normalized.planId) ?? null;
+  const migrationSuggested = !changeExists && legacyPlan !== null;
+
+  return {
+    ok: discovery.ok,
+    migrationSuggested,
+    changeId: normalized.planId,
+    changeExists,
+    legacyPlan,
+    commands: migrationSuggested
+      ? [
+          `node scripts/migrate-legacy-plans.mjs ${normalized.planId} --dry-run`,
+          `node scripts/migrate-legacy-plans.mjs ${normalized.planId}`
+        ]
+      : [],
+    warnings: discovery.warnings,
+    errors: discovery.errors
+  };
+}
+
+async function resolveCollisionTarget(planId, options) {
+  const rootDir = resolveRootDir(options);
+  const changesDir = options.changesDir ?? DEFAULT_CHANGES_DIR;
+  const onCollision = options.onCollision ?? 'fail';
+  const target = resolveFromRoot(rootDir, path.join(changesDir, planId));
+  const exists = await pathExists(target);
+
+  if (!exists || onCollision === 'merge-safe' || onCollision === 'overwrite') {
+    return {
+      ok: true,
+      changeId: planId,
+      errors: []
+    };
+  }
+
+  if (onCollision === 'fail') {
+    return {
+      ok: false,
+      changeId: null,
+      errors: [
+        {
+          code: 'target-exists',
+          message: `OpenSpec change target already exists: ${toPosix(path.join(changesDir, planId))}.`,
+          source: toPosix(path.join(DEFAULT_PLANS_DIR, `${planId}.md`)),
+          target: toPosix(path.join(changesDir, planId))
+        }
+      ]
+    };
+  }
+
+  for (let index = 0; index < 100; index += 1) {
+    const suffix = index === 0 ? '-migrated' : `-migrated-${index + 1}`;
+    const candidate = `${planId}${suffix}`;
+    const normalized = normalizeChangeId(candidate);
+    if (!normalized.ok) {
+      continue;
+    }
+
+    if (!await pathExists(resolveFromRoot(rootDir, path.join(changesDir, candidate)))) {
+      return {
+        ok: true,
+        changeId: candidate,
+        errors: []
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    changeId: null,
+    errors: [
+      {
+        code: 'suffix-exhausted',
+        message: `Unable to find available migration suffix for '${planId}'.`
+      }
+    ]
+  };
+}
+
+async function resolveMigrationReportPath(rootDir, changeId, options = {}) {
+  const defaultReportPath = toPosix(path.join(DEFAULT_STATE_DIR, changeId, 'migration-report.md'));
+
+  if (options.onCollision === 'overwrite' || !await pathExists(resolveFromRoot(rootDir, defaultReportPath))) {
+    return defaultReportPath;
+  }
+
+  for (let index = 0; index < 100; index += 1) {
+    const suffix = index === 0 ? '-migrated' : `-migrated-${index + 1}`;
+    const candidate = toPosix(path.join(DEFAULT_STATE_DIR, changeId, `migration-report${suffix}.md`));
+    if (!await pathExists(resolveFromRoot(rootDir, candidate))) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Unable to find available migration report path for '${changeId}'.`);
+}
+
+async function validateMigratedChange(changeId, options) {
+  const detectOpenSpec = options.detectOpenSpec ?? defaultDetectOpenSpec;
+  const validateOpenSpecChange = options.validateOpenSpecChange ?? defaultValidateOpenSpecChange;
+  let detection;
+
+  try {
+    detection = await detectOpenSpec(createRunOptions(options));
+  } catch (err) {
+    return createValidationSummary('SKIPPED', false, null, {
+      code: 'openspec-detection-failed',
+      message: err?.message ?? 'OpenSpec detection failed.'
+    });
+  }
+
+  if (!detection?.available || !detection?.canValidate) {
+    return createValidationSummary('SKIPPED', Boolean(detection?.available), detection);
+  }
+
+  const result = await validateOpenSpecChange(changeId, createRunOptions(options));
+  return createValidationSummary(result?.ok ? 'PASS' : 'FAIL', true, result);
+}
+
+function createValidationSummary(status, available, result, error = null) {
+  return {
+    status,
+    available,
+    result,
+    error
+  };
+}
+
+function createRunOptions(options) {
+  return {
+    cwd: options.rootDir ?? process.cwd(),
+    command: options.command,
+    env: options.env,
+    executor: options.executor,
+    nodeVersion: options.nodeVersion
+  };
+}
+
+function createMigrationFailure({ dryRun, planId, changeId, targetChangePath = null, operations = [], warnings = [], errors = [] }) {
+  return {
+    ok: false,
+    dryRun,
+    planId,
+    changeId,
+    targetChangePath,
+    operations,
+    validation: createValidationSummary('SKIPPED', false, null),
+    reportPath: null,
+    warnings,
+    errors
+  };
+}
+
+function ensureDiscoveredPlan(plansById, id, rootDir, changesRoot) {
+  if (!plansById.has(id)) {
+    plansById.set(id, {
+      id,
+      planFile: null,
+      planDir: null,
+      files: {},
+      hasCanonicalTarget: false,
+      targetChangePath: toPosix(path.relative(rootDir, path.join(changesRoot, id)))
+    });
+  }
+
+  return plansById.get(id);
+}
+
+async function readLegacyPlanContents(rootDir, plan) {
+  const contents = {};
+
+  if (plan.planFile !== null) {
+    contents.plan = await readFile(resolveFromRoot(rootDir, plan.planFile), 'utf8');
+  }
+
+  for (const key of Object.keys(KNOWN_PLAN_FILES)) {
+    if (plan.files[key] !== undefined) {
+      contents[key] = await readFile(resolveFromRoot(rootDir, plan.files[key]), 'utf8');
+    }
+  }
+
+  return contents;
+}
+
+function collectSourceArtifacts(legacyPlan) {
+  return [
+    legacyPlan.planFile,
+    ...Object.values(legacyPlan.files ?? {})
+  ].filter(Boolean);
+}
+
+function renderProposal({ title, legacyPlan, contents, sourceArtifacts }) {
+  const summary = extractSection(contents.plan, ['Intent', 'Summary', 'Overview']) ?? firstMeaningfulParagraph(contents.plan) ?? 'Migrated legacy plan. Review and refine this proposal before implementation.';
+  const scope = extractSection(contents.plan, ['Scope']) ?? '- Review migrated legacy scope.';
+  const approach = extractSection(contents.plan, ['Approach', 'Implementation', 'Plan']) ?? 'Review legacy plan notes and refine the OpenSpec change design.';
+  const notes = hasText(contents.plan) ? contents.plan.trim() : 'No top-level legacy plan file was present.';
+
+  return [
+    `# Proposal: ${title}`,
+    '',
+    '## Intent',
+    '',
+    summary.trim(),
+    '',
+    '## Scope',
+    '',
+    scope.trim(),
+    '',
+    '## Approach',
+    '',
+    approach.trim(),
+    '',
+    '## Legacy source',
+    '',
+    'Migrated from:',
+    ...sourceArtifacts.map((source) => `- ${source}`),
+    '',
+    '## Legacy plan notes',
+    '',
+    notes,
+    ''
+  ].join('\n');
+}
+
+function renderTasks(taskContent) {
+  if (!hasText(taskContent)) {
+    return [
+      '# Tasks',
+      '',
+      '## Migrated legacy tasks',
+      '',
+      '- [ ] Review migrated legacy artifacts and author implementation tasks.',
+      ''
+    ].join('\n');
+  }
+
+  const checklist = [];
+  for (const line of taskContent.split(/\r?\n/)) {
+    const match = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.+?)\s*$/);
+    if (match) {
+      checklist.push(`- [${match[1].toLowerCase() === 'x' ? 'x' : ' '}] ${match[2]}`);
+    }
+  }
+
+  if (checklist.length > 0) {
+    return [
+      '# Tasks',
+      '',
+      '## Migrated legacy tasks',
+      '',
+      ...checklist,
+      ''
+    ].join('\n');
+  }
+
+  return [
+    '# Tasks',
+    '',
+    '## Migrated legacy tasks',
+    '',
+    taskContent.trim(),
+    ''
+  ].join('\n');
+}
+
+function renderDesign({ title, legacyPlan, contents }) {
+  const designContext = extractSection(contents.context, ['Design', 'Architecture', 'Technical Approach']) ?? contents.context.trim();
+
+  return [
+    `# Design: ${title}`,
+    '',
+    '## Technical Approach',
+    '',
+    designContext,
+    '',
+    '## Data / Artifact Model',
+    '',
+    'Migrated from legacy AI Factory plan artifacts. Preserve runtime-only source material under `.ai-factory/state/<change-id>/` and QA evidence under `.ai-factory/qa/<change-id>/`.',
+    '',
+    '## Integration Points',
+    '',
+    `- Legacy source: ${legacyPlan.files?.context ?? 'none'}`,
+    '',
+    '## Alternatives Considered',
+    '',
+    '- Preserve raw context only as runtime notes. Rejected when the context contains design-relevant implementation guidance.',
+    '',
+    '## Risks',
+    '',
+    '- Migrated context may include raw notes that need manual refinement before implementation.',
+    ''
+  ].join('\n');
+}
+
+function renderDeltaSpec(requirements) {
+  const lines = [
+    '# Delta for Migrated Legacy Plan',
+    '',
+    '## ADDED Requirements',
+    ''
+  ];
+
+  for (const requirement of requirements) {
+    lines.push(
+      `### Requirement: ${requirement.name}`,
+      '',
+      requirement.text,
+      '',
+      '#### Scenario: Migrated legacy behavior',
+      '',
+      '- GIVEN the migrated legacy plan context',
+      '- WHEN the migrated change is implemented',
+      `- THEN ${scenarioThenText(requirement.text)}`,
+      ''
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function renderPreservedMarkdown(title, source, content) {
+  return [
+    `# ${title}`,
+    '',
+    '## Legacy source',
+    '',
+    source === undefined || source === null ? '- unknown' : `- ${source}`,
+    '',
+    '## Preserved content',
+    '',
+    content.trim(),
+    ''
+  ].join('\n');
+}
+
+function renderMigrationReport(report) {
+  return [
+    `# Legacy Plan Migration: ${report.changeId ?? report.planId}`,
+    '',
+    '## Summary',
+    '',
+    'Migrated from legacy `.ai-factory/plans` artifacts to OpenSpec-native artifacts.',
+    '',
+    '## Source artifacts',
+    '',
+    ...renderList(report.sourceArtifacts),
+    '',
+    '## Generated OpenSpec artifacts',
+    '',
+    ...renderList(report.generatedOpenSpecArtifacts),
+    '',
+    '## Runtime artifacts',
+    '',
+    ...renderList(report.runtimeArtifacts),
+    '',
+    '## Validation',
+    '',
+    `OpenSpec validation: ${report.validation?.status ?? 'SKIPPED'}`,
+    '',
+    '## Diagnostics',
+    '',
+    ...renderDiagnostics('Warnings', report.warnings ?? []),
+    '',
+    ...renderDiagnostics('Errors', report.errors ?? []),
+    '',
+    '## Manual follow-ups',
+    '',
+    ...renderList(report.manualFollowUps ?? [
+      'Review generated delta specs.',
+      `Run /aif-improve ${report.changeId ?? report.planId} to refine proposal/design/tasks/specs.`,
+      'Run rules compiler if needed.'
+    ]),
+    ''
+  ].join('\n');
+}
+
+function renderList(items) {
+  const values = Array.isArray(items) ? items.filter(Boolean) : [];
+  return values.length === 0 ? ['- none'] : values.map((item) => `- ${item}`);
+}
+
+function renderDiagnostics(label, diagnostics) {
+  const items = Array.isArray(diagnostics) ? diagnostics : [];
+  if (items.length === 0) {
+    return [`${label}: none`];
+  }
+
+  return [
+    `${label}:`,
+    ...items.map((item) => `- ${item.code ?? 'diagnostic'}: ${item.message ?? JSON.stringify(item)}`)
+  ];
+}
+
+function extractClearRequirements(contents) {
+  const requirements = [];
+  const seen = new Set();
+
+  for (const content of contents) {
+    if (!hasText(content)) {
+      continue;
+    }
+
+    for (const line of content.split(/\r?\n/)) {
+      const cleaned = line.replace(/^\s*[-*]\s+/, '').trim();
+      if (!/\b(?:MUST|SHALL)\b/.test(cleaned)) {
+        continue;
+      }
+
+      const text = cleaned.replace(/\s+$/, '').replace(/[.;]?$/, '.');
+      const key = text.toLowerCase();
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      requirements.push({
+        name: requirementNameFromText(text),
+        text
+      });
+    }
+  }
+
+  return requirements;
+}
+
+function requirementNameFromText(text) {
+  const withoutPrefix = text
+    .replace(/^The system MUST\s+/i, '')
+    .replace(/^The system SHALL\s+/i, '')
+    .replace(/\.$/, '');
+  return titleFromWords(withoutPrefix.split(/\s+/).slice(0, 8).join(' '));
+}
+
+function scenarioThenText(text) {
+  return text
+    .replace(/^The system MUST\s+/i, 'the system must ')
+    .replace(/^The system SHALL\s+/i, 'the system shall ')
+    .replace(/\.$/, '.');
+}
+
+function extractTitle(content) {
+  if (!hasText(content)) {
+    return null;
+  }
+
+  const match = content.match(/^#\s+(.+?)\s*$/m);
+  return match ? match[1].trim() : null;
+}
+
+function extractSection(content, headings) {
+  if (!hasText(content)) {
+    return null;
+  }
+
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(#{2,6})\s+(.+?)\s*$/);
+    if (!match || !headings.some((heading) => heading.toLowerCase() === match[2].trim().toLowerCase())) {
+      continue;
+    }
+
+    const level = match[1].length;
+    const body = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const next = lines[cursor].match(/^(#{2,6})\s+/);
+      if (next && next[1].length <= level) {
+        break;
+      }
+      body.push(lines[cursor]);
+    }
+
+    const text = body.join('\n').trim();
+    return text.length > 0 ? text : null;
+  }
+
+  return null;
+}
+
+function firstMeaningfulParagraph(content) {
+  if (!hasText(content)) {
+    return null;
+  }
+
+  return content
+    .split(/\r?\n\r?\n/)
+    .map((block) => block.trim())
+    .find((block) => block.length > 0 && !block.startsWith('#')) ?? null;
+}
+
+function isDesignLike(content) {
+  return hasText(content) && /\b(design|architecture|implementation|approach|adapter|middleware|callback|state)\b/i.test(content);
+}
+
+async function writeArtifact(rootDir, artifact) {
+  const targetPath = resolveFromRoot(rootDir, artifact.target);
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, artifact.content, 'utf8');
+}
+
+function assertSafeArtifactTarget(rootDir, changeId, artifact) {
+  const targetPath = resolveFromRoot(rootDir, artifact.target);
+  assertWithinRoot(rootDir, targetPath);
+  assertNotLegacyPlanPath(rootDir, targetPath);
+  assertNotBaseSpecPath(rootDir, targetPath);
+
+  if (artifact.bucket === 'canonical') {
+    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(DEFAULT_CHANGES_DIR, changeId)), 'Canonical migration target must stay inside the OpenSpec change folder.');
+    return;
+  }
+
+  if (artifact.bucket === 'state') {
+    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(DEFAULT_STATE_DIR, changeId)), 'Runtime state migration target must stay inside the change state folder.');
+    return;
+  }
+
+  if (artifact.bucket === 'qa') {
+    assertWithinDirectory(targetPath, resolveFromRoot(rootDir, path.join(DEFAULT_QA_DIR, changeId)), 'QA migration target must stay inside the change QA folder.');
+    return;
+  }
+
+  throw new Error(`Unknown migration artifact bucket: ${artifact.bucket}.`);
+}
+
+function assertWithinRoot(rootDir, targetPath) {
+  assertWithinDirectory(targetPath, path.resolve(rootDir), 'Migration target escapes repository root.');
+}
+
+function assertNotLegacyPlanPath(rootDir, targetPath) {
+  const legacyPlansPath = resolveFromRoot(rootDir, DEFAULT_PLANS_DIR);
+  if (isWithinDirectory(targetPath, legacyPlansPath)) {
+    throw new Error('Migration target must not write under legacy plan folders.');
+  }
+}
+
+function assertNotBaseSpecPath(rootDir, targetPath) {
+  const baseSpecsPath = resolveFromRoot(rootDir, path.join('openspec', 'specs'));
+  if (isWithinDirectory(targetPath, baseSpecsPath)) {
+    throw new Error('Migration target must not write under openspec/specs.');
+  }
+}
+
+function assertWithinDirectory(targetPath, directoryPath, message) {
+  if (!isWithinDirectory(targetPath, directoryPath)) {
+    throw new Error(message);
+  }
+}
+
+function isWithinDirectory(targetPath, directoryPath) {
+  const relative = path.relative(path.resolve(directoryPath), path.resolve(targetPath));
+  return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function shouldExcludePlanEntry(name) {
+  const lower = name.toLowerCase();
+  return name.startsWith('.')
+    || EXCLUDED_PLAN_NAMES.has(lower)
+    || lower.endsWith('.bak')
+    || lower.endsWith('.backup')
+    || lower.includes('~');
+}
+
+function createSkippedUnsafeWarning(name) {
+  return {
+    code: 'skipped-unsafe-plan-entry',
+    message: `Skipped unsafe legacy plan entry: ${name}.`
+  };
+}
+
+function hasText(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function titleFromId(id) {
+  return titleFromWords(String(id).replace(/[-_]+/g, ' '));
+}
+
+function titleFromWords(value) {
+  return String(value)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(' ');
+}
+
+function resolveRootDir(options = {}) {
+  return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function resolveFromRoot(rootDir, value) {
+  return path.resolve(rootDir, value);
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(targetPath) {
+  try {
+    const item = await stat(targetPath);
+    return item.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function isFile(targetPath) {
+  try {
+    const item = await stat(targetPath);
+    return item.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  const result = [];
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.code ?? ''}:${diagnostic.message ?? ''}:${diagnostic.path ?? ''}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(diagnostic);
+    }
+  }
+
+  return result;
+}

--- a/scripts/legacy-plan-migration.test.mjs
+++ b/scripts/legacy-plan-migration.test.mjs
@@ -1,0 +1,553 @@
+// legacy-plan-migration.test.mjs - tests for legacy AI Factory plan migration to OpenSpec
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, cp, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import {
+  detectMigrationNeed,
+  discoverLegacyPlans,
+  mapLegacyPlanToOpenSpecArtifacts,
+  migrateAllLegacyPlans,
+  migrateLegacyPlan,
+  normalizeLegacyPlanId,
+  writeMigrationReport
+} from './legacy-plan-migration.mjs';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CLI_PATH = path.join(REPO_ROOT, 'scripts', 'migrate-legacy-plans.mjs');
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-legacy-migration-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function readFixture(rootDir, relativePath) {
+  return readFile(path.join(rootDir, ...relativePath.split('/')), 'utf8');
+}
+
+async function pathExists(rootDir, relativePath) {
+  try {
+    await access(path.join(rootDir, ...relativePath.split('/')));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function copyLegacyFixture(rootDir) {
+  const fixtureRoot = path.join(REPO_ROOT, 'test', 'fixtures', 'legacy-plan-basic');
+  await cp(fixtureRoot, rootDir, { recursive: true });
+}
+
+async function listFiles(rootDir, relativePath) {
+  const base = path.join(rootDir, ...relativePath.split('/'));
+  const output = [];
+
+  async function walk(dir) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(child);
+      } else {
+        output.push(path.relative(rootDir, child).replaceAll('\\', '/'));
+      }
+    }
+  }
+
+  if (await pathExists(rootDir, relativePath)) {
+    await walk(base);
+  }
+
+  return output.sort();
+}
+
+function missingCliDetection() {
+  return {
+    available: false,
+    canValidate: false,
+    canArchive: false,
+    version: null,
+    command: 'openspec',
+    reason: 'missing-cli',
+    errors: [
+      {
+        code: 'missing-cli',
+        message: 'OpenSpec CLI is not available on PATH.'
+      }
+    ]
+  };
+}
+
+function availableCliDetection() {
+  return {
+    available: true,
+    canValidate: true,
+    canArchive: true,
+    version: '1.3.1',
+    command: 'openspec',
+    reason: null,
+    errors: []
+  };
+}
+
+function validationResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? true,
+    command: 'openspec',
+    args: ['validate', overrides.changeId ?? 'add-oauth', '--type', 'change', '--strict', '--json', '--no-interactive', '--no-color'],
+    exitCode: overrides.exitCode ?? 0,
+    stdout: overrides.stdout ?? '{"valid":true}',
+    stderr: overrides.stderr ?? '',
+    json: Object.hasOwn(overrides, 'json') ? overrides.json : { valid: true },
+    jsonParseError: null,
+    error: overrides.error ?? null
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('legacy plan migration API', () => {
+  it('exports required public functions', () => {
+    for (const fn of [
+      discoverLegacyPlans,
+      migrateLegacyPlan,
+      migrateAllLegacyPlans,
+      mapLegacyPlanToOpenSpecArtifacts,
+      writeMigrationReport,
+      detectMigrationNeed,
+      normalizeLegacyPlanId
+    ]) {
+      assert.equal(typeof fn, 'function');
+    }
+  });
+
+  it('normalizes safe legacy ids and rejects unsafe ids', () => {
+    assert.deepEqual(normalizeLegacyPlanId(' add-oauth '), {
+      ok: true,
+      planId: 'add-oauth',
+      error: null
+    });
+
+    for (const input of ['', '../escape', 'nested/change', 'nested\\change', '.hidden', 'archive', 'bad name']) {
+      const result = normalizeLegacyPlanId(input);
+      assert.equal(result.ok, false, `${input} should be rejected`);
+      assert.equal(result.planId, null);
+      assert.equal(result.error.code, 'invalid-legacy-plan-id');
+    }
+  });
+});
+
+describe('discoverLegacyPlans', () => {
+  it('returns an empty successful result when the legacy plans directory is missing', async () => {
+    const rootDir = await createTempRoot();
+
+    const result = await discoverLegacyPlans({ rootDir });
+
+    assert.deepEqual(result, {
+      ok: true,
+      plans: [],
+      warnings: [],
+      errors: []
+    });
+  });
+
+  it('discovers a legacy plan with both parent markdown and companion directory', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+
+    const result = await discoverLegacyPlans({ rootDir });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.plans.map((plan) => plan.id), ['add-oauth']);
+    assert.equal(result.plans[0].planFile, '.ai-factory/plans/add-oauth.md');
+    assert.equal(result.plans[0].planDir, '.ai-factory/plans/add-oauth');
+    assert.deepEqual(result.plans[0].files, {
+      task: '.ai-factory/plans/add-oauth/task.md',
+      context: '.ai-factory/plans/add-oauth/context.md',
+      rules: '.ai-factory/plans/add-oauth/rules.md',
+      verify: '.ai-factory/plans/add-oauth/verify.md',
+      status: '.ai-factory/plans/add-oauth/status.yaml',
+      explore: '.ai-factory/plans/add-oauth/explore.md'
+    });
+    assert.equal(result.plans[0].hasCanonicalTarget, false);
+    assert.equal(result.plans[0].targetChangePath, 'openspec/changes/add-oauth');
+  });
+
+  it('discovers parent-only and folder-only forms and returns stable relative paths', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/plans/parent-only.md', '# Parent only\n');
+    await writeFixture(rootDir, '.ai-factory/plans/folder-only/task.md', '# Task only\n');
+    await writeFixture(rootDir, '.ai-factory/plans/.hidden.md', '# Hidden\n');
+    await writeFixture(rootDir, '.ai-factory/plans/archive/old/task.md', '# Archived\n');
+    await writeFixture(rootDir, '.ai-factory/plans/backup/old/task.md', '# Backup\n');
+    await writeFixture(rootDir, '.ai-factory/plans/unrelated.txt', 'ignore\n');
+
+    const result = await discoverLegacyPlans({ rootDir });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.plans.map((plan) => plan.id), ['folder-only', 'parent-only']);
+    assert.equal(result.plans[0].planFile, null);
+    assert.equal(result.plans[0].planDir, '.ai-factory/plans/folder-only');
+    assert.deepEqual(result.plans[0].files, {
+      task: '.ai-factory/plans/folder-only/task.md'
+    });
+    assert.equal(result.plans[1].planFile, '.ai-factory/plans/parent-only.md');
+    assert.equal(result.plans[1].planDir, null);
+    assert.deepEqual(result.plans[1].files, {});
+  });
+});
+
+describe('mapLegacyPlanToOpenSpecArtifacts', () => {
+  it('maps legacy artifacts to canonical, runtime, and QA targets without losing intended meaning', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    const [legacyPlan] = (await discoverLegacyPlans({ rootDir, includeContent: true })).plans;
+
+    const mapped = mapLegacyPlanToOpenSpecArtifacts(legacyPlan);
+
+    assert.equal(mapped.ok, true);
+    assert.ok(mapped.canonicalArtifacts.some((artifact) => artifact.target === 'openspec/changes/add-oauth/proposal.md'));
+    assert.ok(mapped.canonicalArtifacts.some((artifact) => artifact.target === 'openspec/changes/add-oauth/tasks.md'));
+    assert.ok(mapped.canonicalArtifacts.some((artifact) => artifact.target === 'openspec/changes/add-oauth/design.md'));
+    assert.ok(mapped.canonicalArtifacts.some((artifact) => artifact.target === 'openspec/changes/add-oauth/specs/migrated/spec.md'));
+    assert.ok(mapped.runtimeArtifacts.some((artifact) => artifact.target === '.ai-factory/state/add-oauth/legacy-context.md'));
+    assert.ok(mapped.runtimeArtifacts.some((artifact) => artifact.target === '.ai-factory/state/add-oauth/legacy-rules.md'));
+    assert.ok(mapped.runtimeArtifacts.some((artifact) => artifact.target === '.ai-factory/state/add-oauth/legacy-status.yaml'));
+    assert.ok(mapped.runtimeArtifacts.some((artifact) => artifact.target === '.ai-factory/state/add-oauth/legacy-explore.md'));
+    assert.ok(mapped.qaArtifacts.some((artifact) => artifact.target === '.ai-factory/qa/add-oauth/legacy-verify.md'));
+
+    const proposal = mapped.canonicalArtifacts.find((artifact) => artifact.target.endsWith('/proposal.md')).content;
+    assert.match(proposal, /# Proposal: Add OAuth Authentication/);
+    assert.match(proposal, /GitHub OAuth callback/);
+    assert.match(proposal, /\.ai-factory\/plans\/add-oauth\.md/);
+
+    const tasks = mapped.canonicalArtifacts.find((artifact) => artifact.target.endsWith('/tasks.md')).content;
+    assert.match(tasks, /- \[ \] Add GitHub OAuth callback route\./);
+
+    const spec = mapped.canonicalArtifacts.find((artifact) => artifact.target.endsWith('/spec.md')).content;
+    assert.match(spec, /The system MUST allow a user with a valid GitHub OAuth callback to sign in\./);
+  });
+
+  it('preserves non-checklist task content under migrated legacy tasks', () => {
+    const mapped = mapLegacyPlanToOpenSpecArtifacts({
+      id: 'plain-task',
+      planFile: '.ai-factory/plans/plain-task.md',
+      planDir: '.ai-factory/plans/plain-task',
+      files: {
+        task: '.ai-factory/plans/plain-task/task.md'
+      },
+      contents: {
+        plan: '# Plain Task\n\nMigrate the plain task plan.',
+        task: 'Implement the migration in one careful pass.'
+      },
+      hasCanonicalTarget: false,
+      targetChangePath: 'openspec/changes/plain-task'
+    });
+
+    assert.equal(mapped.ok, true);
+    const tasks = mapped.canonicalArtifacts.find((artifact) => artifact.target.endsWith('/tasks.md')).content;
+    assert.match(tasks, /## Migrated legacy tasks/);
+    assert.match(tasks, /Implement the migration in one careful pass\./);
+  });
+});
+
+describe('migrateLegacyPlan', () => {
+  it('rejects unsafe plan ids before writing files', async () => {
+    const rootDir = await createTempRoot();
+
+    const result = await migrateLegacyPlan('../escape', { rootDir });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errors[0].code, 'invalid-legacy-plan-id');
+    assert.equal(await pathExists(rootDir, 'openspec'), false);
+  });
+
+  it('migrates parent-only plans with safe fallback tasks and no runtime-only artifacts', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/plans/parent-only.md', '# Parent Only\n\nA small migrated plan.\n');
+
+    const result = await migrateLegacyPlan('parent-only', {
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(await readFixture(rootDir, 'openspec/changes/parent-only/proposal.md'), /Parent Only/);
+    assert.match(await readFixture(rootDir, 'openspec/changes/parent-only/tasks.md'), /Review migrated legacy artifacts/);
+    assert.equal(await pathExists(rootDir, '.ai-factory/qa/parent-only/legacy-verify.md'), false);
+    assert.equal(await pathExists(rootDir, '.ai-factory/state/parent-only/legacy-status.yaml'), false);
+  });
+
+  it('dry-run returns operations and writes nothing', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    let ensureRuntimeLayoutCalls = 0;
+
+    const result = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      dryRun: true,
+      ensureRuntimeLayout: async () => {
+        ensureRuntimeLayoutCalls += 1;
+        throw new Error('dry-run must not create runtime layout');
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.dryRun, true);
+    assert.equal(ensureRuntimeLayoutCalls, 0);
+    assert.ok(result.operations.some((operation) => operation.target === 'openspec/changes/add-oauth/proposal.md'));
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/proposal.md'), false);
+    assert.equal(await pathExists(rootDir, '.ai-factory/state/add-oauth/migration-report.md'), false);
+  });
+
+  it('migrates canonical artifacts and preserves runtime-only artifacts outside OpenSpec change folders', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+
+    const result = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.validation.status, 'SKIPPED');
+    assert.match(await readFixture(rootDir, 'openspec/changes/add-oauth/proposal.md'), /GitHub OAuth/);
+    assert.match(await readFixture(rootDir, 'openspec/changes/add-oauth/tasks.md'), /Add GitHub OAuth callback route/);
+    assert.match(await readFixture(rootDir, 'openspec/changes/add-oauth/design.md'), /authentication middleware/);
+    assert.match(await readFixture(rootDir, 'openspec/changes/add-oauth/specs/migrated/spec.md'), /valid GitHub OAuth callback/);
+    assert.match(await readFixture(rootDir, '.ai-factory/state/add-oauth/legacy-context.md'), /provider state/);
+    assert.match(await readFixture(rootDir, '.ai-factory/state/add-oauth/legacy-rules.md'), /access tokens/);
+    assert.match(await readFixture(rootDir, '.ai-factory/state/add-oauth/legacy-status.yaml'), /status: planned/);
+    assert.match(await readFixture(rootDir, '.ai-factory/state/add-oauth/legacy-explore.md'), /GitHub OAuth/);
+    assert.match(await readFixture(rootDir, '.ai-factory/qa/add-oauth/legacy-verify.md'), /authentication tests/);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/verify.md'), false);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/status.yaml'), false);
+    assert.deepEqual(await listFiles(rootDir, 'openspec/specs'), []);
+    assert.equal(await pathExists(rootDir, '.ai-factory/plans/add-oauth.md'), true);
+    assert.equal(await pathExists(rootDir, '.ai-factory/plans/add-oauth/task.md'), true);
+
+    const report = await readFixture(rootDir, '.ai-factory/state/add-oauth/migration-report.md');
+    assert.match(report, /OpenSpec validation: SKIPPED/);
+    assert.match(report, /\.ai-factory\/plans\/add-oauth\/verify\.md/);
+    assert.match(report, /\.ai-factory\/qa\/add-oauth\/legacy-verify\.md/);
+  });
+
+  it('fails by default on target collision and supports suffix and merge-safe modes', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Existing\n');
+    await writeFixture(rootDir, '.ai-factory/state/add-oauth/migration-report.md', '# Existing Report\n');
+
+    const failed = await migrateLegacyPlan('add-oauth', { rootDir });
+    assert.equal(failed.ok, false);
+    assert.equal(failed.errors[0].code, 'target-exists');
+
+    const suffixed = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      onCollision: 'suffix',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+    assert.equal(suffixed.ok, true);
+    assert.equal(suffixed.changeId, 'add-oauth-migrated');
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth-migrated/proposal.md'), true);
+    assert.equal((await readFixture(rootDir, 'openspec/changes/add-oauth/proposal.md')).trim(), '# Existing');
+
+    const merged = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      onCollision: 'merge-safe',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+    assert.equal(merged.ok, true);
+    assert.ok(merged.operations.some((operation) => operation.action === 'skip' && operation.target === 'openspec/changes/add-oauth/proposal.md'));
+    assert.equal((await readFixture(rootDir, 'openspec/changes/add-oauth/proposal.md')).trim(), '# Existing');
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/tasks.md'), true);
+    assert.equal((await readFixture(rootDir, '.ai-factory/state/add-oauth/migration-report.md')).trim(), '# Existing Report');
+    assert.equal(merged.reportPath, '.ai-factory/state/add-oauth/migration-report-migrated.md');
+    assert.equal(await pathExists(rootDir, '.ai-factory/state/add-oauth/migration-report-migrated.md'), true);
+  });
+
+  it('calls validation when CLI is available and records validation failures', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    const calls = [];
+
+    const result = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async (changeId) => {
+        calls.push(changeId);
+        return validationResult({ ok: false, exitCode: 1, stdout: '{"valid":false}', json: null });
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(calls, ['add-oauth']);
+    assert.equal(result.validation.status, 'FAIL');
+    assert.match(await readFixture(rootDir, '.ai-factory/state/add-oauth/migration-report.md'), /OpenSpec validation: FAIL/);
+  });
+
+  it('overwrites existing generated targets only when explicitly requested', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Existing\n');
+
+    const result = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      onCollision: 'overwrite',
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, true);
+    assert.match(await readFixture(rootDir, 'openspec/changes/add-oauth/proposal.md'), /GitHub OAuth/);
+  });
+});
+
+describe('migrateAllLegacyPlans and detectMigrationNeed', () => {
+  it('dry-runs all legacy plans without writing targets', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/plans/alpha.md', '# Alpha\n');
+    await writeFixture(rootDir, '.ai-factory/plans/beta.md', '# Beta\n');
+
+    const result = await migrateAllLegacyPlans({ rootDir, dryRun: true });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.migrated, ['alpha', 'beta']);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/alpha/proposal.md'), false);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/beta/proposal.md'), false);
+  });
+
+  it('migrates all legacy plans in sorted order and reports partial failures', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/plans/alpha.md', '# Alpha\n');
+    await writeFixture(rootDir, '.ai-factory/plans/beta.md', '# Beta\n');
+    await writeFixture(rootDir, 'openspec/changes/beta/proposal.md', '# Existing\n');
+
+    const result = await migrateAllLegacyPlans({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection()
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.partial, true);
+    assert.deepEqual(result.migrated, ['alpha']);
+    assert.deepEqual(result.failed, ['beta']);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/alpha/proposal.md'), true);
+  });
+
+  it('detects matching legacy plans and returns exact suggestion commands', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+
+    const needed = await detectMigrationNeed({ rootDir, changeId: 'add-oauth' });
+    assert.equal(needed.ok, true);
+    assert.equal(needed.migrationSuggested, true);
+    assert.equal(needed.changeExists, false);
+    assert.equal(needed.legacyPlan.id, 'add-oauth');
+    assert.deepEqual(needed.commands, [
+      'node scripts/migrate-legacy-plans.mjs add-oauth --dry-run',
+      'node scripts/migrate-legacy-plans.mjs add-oauth'
+    ]);
+
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Existing\n');
+    const existing = await detectMigrationNeed({ rootDir, changeId: 'add-oauth' });
+    assert.equal(existing.migrationSuggested, false);
+    assert.equal(existing.changeExists, true);
+  });
+});
+
+describe('writeMigrationReport', () => {
+  it('supports dry-run and real report writes', async () => {
+    const rootDir = await createTempRoot();
+
+    const dryRun = await writeMigrationReport('add-oauth', {
+      changeId: 'add-oauth',
+      validation: { status: 'SKIPPED' },
+      sourceArtifacts: ['.ai-factory/plans/add-oauth.md'],
+      generatedOpenSpecArtifacts: ['openspec/changes/add-oauth/proposal.md'],
+      runtimeArtifacts: ['.ai-factory/state/add-oauth/legacy-context.md']
+    }, {
+      rootDir,
+      dryRun: true
+    });
+
+    assert.equal(dryRun.ok, true);
+    assert.equal(dryRun.dryRun, true);
+    assert.equal(await pathExists(rootDir, '.ai-factory/state/add-oauth/migration-report.md'), false);
+
+    const written = await writeMigrationReport('add-oauth', {
+      changeId: 'add-oauth',
+      validation: { status: 'PASS' },
+      sourceArtifacts: ['.ai-factory/plans/add-oauth.md'],
+      generatedOpenSpecArtifacts: ['openspec/changes/add-oauth/proposal.md'],
+      runtimeArtifacts: ['.ai-factory/state/add-oauth/legacy-context.md']
+    }, {
+      rootDir
+    });
+
+    assert.equal(written.path, '.ai-factory/state/add-oauth/migration-report.md');
+    assert.match(await readFixture(rootDir, '.ai-factory/state/add-oauth/migration-report.md'), /OpenSpec validation: PASS/);
+  });
+});
+
+describe('migrate-legacy-plans CLI', () => {
+  it('lists and dry-runs legacy plans with JSON output', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+
+    const list = await execFileAsync(process.execPath, [CLI_PATH, '--list'], {
+      cwd: rootDir,
+      windowsHide: true
+    });
+    assert.match(list.stdout, /add-oauth/);
+
+    const dryRun = await execFileAsync(process.execPath, [CLI_PATH, 'add-oauth', '--dry-run', '--json'], {
+      cwd: rootDir,
+      windowsHide: true
+    });
+    const parsed = JSON.parse(dryRun.stdout);
+    assert.equal(parsed.dryRun, true);
+    assert.equal(parsed.changeId, 'add-oauth');
+    assert.ok(parsed.operations.some((operation) => operation.target === 'openspec/changes/add-oauth/proposal.md'));
+    assert.equal(JSON.stringify(parsed).includes('Add OAuth Authentication'), false);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/proposal.md'), false);
+  });
+
+  it('returns exit code 2 for invalid arguments', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+
+    await assert.rejects(
+      () => execFileAsync(process.execPath, [CLI_PATH, 'add-oauth', '--on-collision', 'unsafe'], {
+        cwd: rootDir,
+        windowsHide: true
+      }),
+      (err) => {
+        assert.equal(err.code, 2);
+        assert.match(err.stderr, /Invalid --on-collision value/);
+        return true;
+      }
+    );
+  });
+});

--- a/scripts/legacy-plan-migration.test.mjs
+++ b/scripts/legacy-plan-migration.test.mjs
@@ -271,6 +271,23 @@ describe('mapLegacyPlanToOpenSpecArtifacts', () => {
     assert.match(tasks, /## Migrated legacy tasks/);
     assert.match(tasks, /Implement the migration in one careful pass\./);
   });
+
+  it('honors custom canonical, state, and QA directories during mapping', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    const [legacyPlan] = (await discoverLegacyPlans({ rootDir, includeContent: true })).plans;
+
+    const mapped = mapLegacyPlanToOpenSpecArtifacts(legacyPlan, {
+      changesDir: 'custom/changes',
+      stateDir: 'custom/state',
+      qaDir: 'custom/qa'
+    });
+
+    assert.equal(mapped.ok, true);
+    assert.ok(mapped.canonicalArtifacts.every((artifact) => artifact.target.startsWith('custom/changes/add-oauth/')));
+    assert.ok(mapped.runtimeArtifacts.every((artifact) => artifact.target.startsWith('custom/state/add-oauth/')));
+    assert.ok(mapped.qaArtifacts.every((artifact) => artifact.target.startsWith('custom/qa/add-oauth/')));
+  });
 });
 
 describe('migrateLegacyPlan', () => {
@@ -352,6 +369,45 @@ describe('migrateLegacyPlan', () => {
     assert.match(report, /OpenSpec validation: SKIPPED/);
     assert.match(report, /\.ai-factory\/plans\/add-oauth\/verify\.md/);
     assert.match(report, /\.ai-factory\/qa\/add-oauth\/legacy-verify\.md/);
+  });
+
+  it('honors custom changesDir, stateDir, and qaDir when writing migration artifacts', async () => {
+    const rootDir = await createTempRoot();
+    await copyLegacyFixture(rootDir);
+    let layoutCall = null;
+
+    const result = await migrateLegacyPlan('add-oauth', {
+      rootDir,
+      changesDir: 'custom/changes',
+      stateDir: 'custom/state',
+      qaDir: 'custom/qa',
+      detectOpenSpec: async () => missingCliDetection(),
+      ensureRuntimeLayout: async (changeId, layoutOptions) => {
+        layoutCall = {
+          changeId,
+          stateDir: layoutOptions.stateDir,
+          qaDir: layoutOptions.qaDir
+        };
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.targetChangePath, 'custom/changes/add-oauth');
+    assert.equal(result.reportPath, 'custom/state/add-oauth/migration-report.md');
+    assert.deepEqual(layoutCall, {
+      changeId: 'add-oauth',
+      stateDir: 'custom/state',
+      qaDir: 'custom/qa'
+    });
+    assert.equal(await pathExists(rootDir, 'custom/changes/add-oauth/proposal.md'), true);
+    assert.equal(await pathExists(rootDir, 'custom/changes/add-oauth/tasks.md'), true);
+    assert.equal(await pathExists(rootDir, 'custom/changes/add-oauth/specs/migrated/spec.md'), true);
+    assert.equal(await pathExists(rootDir, 'custom/state/add-oauth/legacy-status.yaml'), true);
+    assert.equal(await pathExists(rootDir, 'custom/state/add-oauth/migration-report.md'), true);
+    assert.equal(await pathExists(rootDir, 'custom/qa/add-oauth/legacy-verify.md'), true);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/proposal.md'), false);
+    assert.equal(await pathExists(rootDir, '.ai-factory/state/add-oauth/migration-report.md'), false);
+    assert.equal(await pathExists(rootDir, '.ai-factory/qa/add-oauth/legacy-verify.md'), false);
   });
 
   it('fails by default on target collision and supports suffix and merge-safe modes', async () => {

--- a/scripts/migrate-legacy-plans.mjs
+++ b/scripts/migrate-legacy-plans.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// migrate-legacy-plans.mjs - dependency-free CLI for legacy plan migration
+import {
+  discoverLegacyPlans,
+  migrateAllLegacyPlans,
+  migrateLegacyPlan
+} from './legacy-plan-migration.mjs';
+
+const COLLISION_MODES = new Set(['fail', 'merge-safe', 'suffix', 'overwrite']);
+
+async function main(argv) {
+  const parsed = parseArgs(argv);
+
+  if (!parsed.ok) {
+    writeError(parsed.error);
+    return 2;
+  }
+
+  const options = {
+    dryRun: parsed.dryRun,
+    onCollision: parsed.onCollision
+  };
+
+  if (parsed.list) {
+    const result = await discoverLegacyPlans();
+    output(parsed.json, result, renderList(result));
+    return result.ok ? 0 : 1;
+  }
+
+  if (parsed.all) {
+    const result = await migrateAllLegacyPlans(options);
+    output(parsed.json, publicResult(result), renderAll(result));
+    return result.ok ? 0 : 1;
+  }
+
+  const result = await migrateLegacyPlan(parsed.planId, options);
+  output(parsed.json, publicResult(result), renderMigration(result));
+  return result.ok ? 0 : 1;
+}
+
+function parseArgs(argv) {
+  const result = {
+    ok: true,
+    list: false,
+    all: false,
+    dryRun: false,
+    json: false,
+    onCollision: 'fail',
+    planId: null,
+    error: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--list') {
+      result.list = true;
+      continue;
+    }
+
+    if (arg === '--all') {
+      result.all = true;
+      continue;
+    }
+
+    if (arg === '--dry-run') {
+      result.dryRun = true;
+      continue;
+    }
+
+    if (arg === '--json') {
+      result.json = true;
+      continue;
+    }
+
+    if (arg === '--on-collision') {
+      const value = argv[index + 1];
+      if (value === undefined || !COLLISION_MODES.has(value)) {
+        return invalid(`Invalid --on-collision value: ${value ?? '<missing>'}. Expected fail, merge-safe, suffix, or overwrite.`);
+      }
+
+      result.onCollision = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      return invalid(`Unknown option: ${arg}.`);
+    }
+
+    if (result.planId !== null) {
+      return invalid(`Unexpected extra argument: ${arg}.`);
+    }
+
+    result.planId = arg;
+  }
+
+  if (result.list && (result.all || result.planId !== null)) {
+    return invalid('--list cannot be combined with --all or a plan id.');
+  }
+
+  if (!result.list && !result.all && result.planId === null) {
+    return invalid('Provide a plan id, --all, or --list.');
+  }
+
+  if (result.all && result.planId !== null) {
+    return invalid('--all cannot be combined with a plan id.');
+  }
+
+  return result;
+}
+
+function invalid(message) {
+  return {
+    ok: false,
+    error: message
+  };
+}
+
+function output(json, value, humanText) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${humanText}\n`);
+}
+
+function writeError(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+function renderList(result) {
+  if (!result.ok) {
+    return renderDiagnostics('Errors', result.errors);
+  }
+
+  if (result.plans.length === 0) {
+    return 'No legacy plans found.';
+  }
+
+  return [
+    'Legacy plans:',
+    ...result.plans.map((plan) => `- ${plan.id} -> ${plan.targetChangePath}`)
+  ].join('\n');
+}
+
+function renderMigration(result) {
+  const lines = [
+    `${result.dryRun ? 'Dry run' : 'Migration'}: ${result.planId ?? '<unknown>'}`,
+    `Status: ${result.ok ? 'OK' : 'FAILED'}`,
+    `Change: ${result.changeId ?? '<none>'}`,
+    `Target: ${result.targetChangePath ?? '<none>'}`,
+    `Validation: ${result.validation?.status ?? 'SKIPPED'}`
+  ];
+
+  if (result.reportPath) {
+    lines.push(`Report: ${result.reportPath}`);
+  }
+
+  if (result.operations?.length > 0) {
+    lines.push('', 'Operations:');
+    for (const operation of result.operations) {
+      lines.push(`- ${operation.action}: ${operation.target}`);
+    }
+  }
+
+  return [
+    ...lines,
+    '',
+    ...renderDiagnostics('Warnings', result.warnings),
+    '',
+    ...renderDiagnostics('Errors', result.errors)
+  ].join('\n');
+}
+
+function renderAll(result) {
+  return [
+    `${result.dryRun ? 'Dry run' : 'Migration'}: all legacy plans`,
+    `Status: ${result.ok ? 'OK' : result.partial ? 'PARTIAL' : 'FAILED'}`,
+    `Migrated: ${result.migrated.join(', ') || 'none'}`,
+    `Failed: ${result.failed.join(', ') || 'none'}`,
+    '',
+    ...renderDiagnostics('Warnings', result.warnings),
+    '',
+    ...renderDiagnostics('Errors', result.errors)
+  ].join('\n');
+}
+
+function renderDiagnostics(label, diagnostics) {
+  const items = Array.isArray(diagnostics) ? diagnostics : [];
+  if (items.length === 0) {
+    return [`${label}: none`];
+  }
+
+  return [
+    `${label}:`,
+    ...items.map((item) => `- ${item.code ?? 'diagnostic'}: ${item.message ?? JSON.stringify(item)}`)
+  ];
+}
+
+function publicResult(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => publicResult(item));
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const clone = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'content' || key === 'contents') {
+      continue;
+    }
+
+    clone[key] = publicResult(child);
+  }
+  return clone;
+}
+
+process.exitCode = await main(process.argv.slice(2));

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -319,6 +319,28 @@ describe('OpenSpec-native prompt asset contract', () => {
     }
   });
 
+  it('suggests explicit legacy migration without auto-migrating in improve, implement, and verify prompts', async () => {
+    for (const relativePath of [
+      'injections/core/aif-improve-plan-folder.md',
+      'injections/core/aif-implement-plan-folder.md',
+      'injections/core/aif-verify-plan-folder.md'
+    ]) {
+      const asset = await readRepoFile(relativePath);
+      const openspec = extractMarkdownSection(asset, 'OpenSpec-native mode');
+
+      for (const expected of [
+        'detectMigrationNeed(options)',
+        'scripts/legacy-plan-migration.mjs',
+        'do not auto-migrate',
+        'Found legacy AI Factory plan artifacts for `<change-id>` but no OpenSpec change at `openspec/changes/<change-id>`.',
+        'node scripts/migrate-legacy-plans.mjs <change-id> --dry-run',
+        'node scripts/migrate-legacy-plans.mjs <change-id>'
+      ]) {
+        assertIncludes(openspec, expected, `${relativePath} OpenSpec-native mode`);
+      }
+    }
+  });
+
   it('requires done prompts to archive verified OpenSpec changes through the done finalizer', async () => {
     for (const relativePath of DONE_PROMPT_ASSETS) {
       const asset = stripFencedBlocks(await readRepoFile(relativePath));

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth.md
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth.md
@@ -1,0 +1,20 @@
+# Add OAuth Authentication
+
+## Summary
+
+Add OAuth sign-in for GitHub accounts so users can authenticate without a password.
+
+## Scope
+
+- Add a GitHub OAuth callback flow.
+- Store the linked provider account on the existing user record.
+- Keep password sign-in unchanged.
+
+## Approach
+
+Use the existing authentication middleware and add a provider callback handler.
+
+## Requirements
+
+- The system MUST allow a user with a valid GitHub OAuth callback to sign in.
+- The system MUST reject an OAuth callback when the provider state does not match the session.

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/context.md
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/context.md
@@ -1,0 +1,10 @@
+# Context
+
+## Design
+
+The OAuth callback should reuse the existing authentication middleware and session storage.
+The callback should validate the provider state before exchanging the code.
+
+## Implementation notes
+
+Keep provider-specific code isolated behind a small adapter so another provider can be added later.

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/explore.md
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/explore.md
@@ -1,0 +1,3 @@
+# Exploration
+
+GitHub OAuth was selected because it is the first provider requested by users.

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/rules.md
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/rules.md
@@ -1,0 +1,4 @@
+# Rules
+
+- Do not store OAuth access tokens in plaintext.
+- Keep password sign-in behavior unchanged.

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/status.yaml
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/status.yaml
@@ -1,0 +1,3 @@
+status: planned
+current_task: 1
+updated_at: 2026-04-29T00:00:00.000Z

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/task.md
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/task.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [ ] Add GitHub OAuth callback route.
+- [ ] Link GitHub account to the existing user record.
+- [ ] Reject callbacks with invalid state.
+- [ ] Document OAuth configuration.

--- a/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/verify.md
+++ b/test/fixtures/legacy-plan-basic/.ai-factory/plans/add-oauth/verify.md
@@ -1,0 +1,4 @@
+# Verification
+
+- Run authentication tests.
+- Manually verify invalid OAuth state is rejected.


### PR DESCRIPTION
## Summary
- Add an explicit migration flow from legacy `.ai-factory/plans` artifacts to OpenSpec-native change folders.
- Preserve runtime-only legacy files under `.ai-factory/state/<id>/` and `.ai-factory/qa/<id>/`, with collision handling, dry-run support, and migration reports.
- Update improve/implement/verify guidance and add docs, fixtures, and tests for the new migration path.

## Testing
- Added focused unit tests for discovery, mapping, dry-run behavior, collision modes, migration reporting, CLI behavior, and migration-suggestion detection.
- Added fixture-backed coverage to verify legacy plan meaning is preserved after migration.
- Ran repository validation and the full test suite successfully; OpenSpec CLI validation was skipped in degraded mode because the CLI was not available on PATH.