### PR TITLE
Update docs for OpenSpec-native artifact workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,159 +1,187 @@
 # AIFHub Extension
 
-Extension for [ai-factory 2.x](https://github.com/lee-to/ai-factory) CLI that keeps a structured plan-folder workflow while returning the public workflow to upstream commands.
+AIFHub Extension adds an OpenSpec-native artifact protocol to the AI Factory CLI user experience.
 
-## Сводка совместимости
+The v1 workflow keeps AI Factory commands as the user-facing path and uses OpenSpec artifacts as the canonical source of truth for specs and changes:
 
-| Поле | Значение |
-|-------|----------|
-| Проверенный upstream | `ai-factory 2.10.0` |
-| Поддерживаемый `compat.ai-factory` | `>=2.10.0 <3.0.0` |
-| Исторический `baselineVersion` | `2.0.0` |
+```text
+AI Factory UX + OpenSpec artifact protocol
+```
 
-`baselineVersion` фиксирует историческую upstream-базу этой модели extension. Актуальные ожидания по поддержке и установке всегда определяются `compat.ai-factory`.
+## What This Extension Does
 
-### OpenSpec compatibility
-
-OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol.
-
-| Capability | Requirement |
-|---|---|
-| AI Factory-only extension install/use | `ai-factory >=2.10.0 <3.0.0` |
-| OpenSpec-native validation/archive | OpenSpec CLI `>=1.3.1 <2.0.0` |
-| OpenSpec CLI runtime | Node `>=20.19.0` |
-| OpenSpec skills/commands | Not installed by this extension |
-
-When the OpenSpec CLI is unavailable, the extension remains usable. OpenSpec validation/archive capabilities are disabled until a compatible `openspec` CLI is available, but OpenSpec-native planning can still generate structurally correct artifacts with degraded validation. `/aif-done` fails archive-required OpenSpec-native finalization when the CLI is missing.
-
-AI Factory-only mode follows the Node/runtime support of AI Factory and upstream. OpenSpec-native validation/archive requires Node `>=20.19.0` because that is the OpenSpec CLI runtime requirement.
-
-OpenSpec can be initialized without tool integrations using `openspec init --tools none`, but this extension does not require running that during install.
-
-`/aif-analyze` supports an explicit OpenSpec-native bootstrap mode. Use it only when a project requests OpenSpec-native artifacts or already has `aifhub.artifactProtocol: openspec`; otherwise the legacy AI Factory-only config remains the default. In OpenSpec-native mode, canonical plan/change artifacts map to `openspec/changes`, specs map to `openspec/specs`, and runtime AI Factory output stays under `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`.
-
-`/aif-plan full` remains the public planning entrypoint. In OpenSpec-native mode it creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs under `specs/**/spec.md`; legacy `.ai-factory/plans` output is AI Factory-only mode.
-
-`/aif-explore` remains research-oriented in OpenSpec-native mode. It may read OpenSpec specs and changes, but writes research/runtime notes only to `.ai-factory/RESEARCH.md` or `.ai-factory/state/<change-id>/` and does not create non-OpenSpec files inside `openspec/changes/<change-id>/`.
-
-`/aif-improve` refines existing OpenSpec-native artifacts in place: `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`. It preserves user edits with patch-style changes, returns changed/preserved summary sections, warns or refuses archived changes, and keeps legacy plan-folder refinement as AI Factory-only behavior.
-
-Prompt assets for `/aif-implement`, `/aif-fix`, `/aif-verify`, `/aif-done`, `/aif-rules-check`, and bundled runtime agents are mode-gated. In OpenSpec-native mode they read canonical OpenSpec artifacts and write runtime/QA/finalizer state outside `openspec/changes`; in legacy AI Factory-only mode they keep using `.ai-factory/plans` plan-folder artifacts. `/aif-done` is the OpenSpec-native finalizer: it requires passing `/aif-verify` evidence, archives through `openspec archive <change-id> --yes` via the shared OpenSpec runner, supports `--skip-specs`, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`.
-
-See [OpenSpec Compatibility](docs/openspec-compatibility.md) for install/upgrade notes and the capability flags planned for runtime detection.
+- Keeps `/aif-analyze`, `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-fix`, and `/aif-done` as the public command vocabulary.
+- In OpenSpec-native mode, writes canonical change artifacts under `openspec/changes/<change-id>/` and accepted specs under `openspec/specs/`.
+- Keeps AI Factory runtime state, verification evidence, finalization evidence, and generated rules outside canonical OpenSpec changes.
+- Preserves legacy AI Factory-only plan folders as compatibility and migration input only.
+- Publishes namespaced Codex and Claude agent files through the extension manifest for explicit user or orchestrator invocation.
+- Does not install OpenSpec skills or slash commands.
 
 ## Quick Start
+
+Install the extension:
 
 ```bash
 ai-factory extension add https://github.com/ichinya/aifhub-extension.git
 ```
 
-Run:
+Bootstrap project context:
 
-```bash
+```text
 /aif-analyze
 ```
 
-Then use:
+Confirm or request OpenSpec-native mode when bootstrapping a v1 OpenSpec workflow. The expected config marker is:
 
-```bash
-/aif-explore "your feature"   # optional
-/aif-plan full "your feature"
-/aif-improve
-/aif-implement
-/aif-verify
+```yaml
+aifhub:
+  artifactProtocol: openspec
 ```
 
-If verification finds issues:
-
-```bash
-/aif-fix
-/aif-verify
-```
-
-Optional explicit AIFHub finalizer after passing verification:
-
-```bash
-/aif-done                     # OpenSpec CLI archive, commit/PR drafts, evidence-driven follow-ups
-```
-
-`/aif-analyze` здесь выступает отдельным bootstrap/setup step. Canonical public workflow начинается после него.
-
-## What This Extension Adds
-
-- `aif-analyze` remains extension-owned and bootstraps `.ai-factory/config.yaml` plus `rules/base.md`; it can also prepare explicit OpenSpec-native config without installing OpenSpec skills.
-- `aif-done` is an explicit extension-owned AIFHub/Handoff finalizer that archives verified OpenSpec-native changes through OpenSpec CLI or archives verified legacy plans in AI Factory-only mode, drafts commit/PR summaries, and drives evidence-backed governance and evolution follow-ups.
-- `aif-plan`, `aif-explore`, `aif-improve`, `aif-implement`, `aif-verify`, `aif-fix`, `aif-roadmap`, and `aif-evolve` remain upstream skills with extension injections.
-- Full-mode planning is mode-gated:
-  - OpenSpec-native mode creates `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and behavior delta specs.
-  - AI Factory-only legacy mode creates `.ai-factory/plans/<plan-id>.md` plus `.ai-factory/plans/<plan-id>/`.
-- OpenSpec-native prompt assets are mode-gated: explore writes only research/runtime notes outside change folders, improve edits only canonical OpenSpec change artifacts, and implement/fix/verify/done/rules-check/runtime agents keep OpenSpec changes canonical while writing runtime output under `.ai-factory/state`, `.ai-factory/qa`, or finalizer state.
-- Legacy folder-only plans are soft-migrated by generating the missing companion plan file on first improve, implement, or verify entry.
-- На `ai-factory 2.10.0+` extension публикует namespaced runtime-aware `agentFiles` для Codex и Claude; подробности и ограничения собраны в [Codex Agents](docs/codex-agents.md) и [Claude Agents](docs/claude-agents.md).
-
-## Слои Prompt Assets
-
-- `injections/core/` содержит active `core plan-folder overlay`, который единственный подключается через `extension.json` и обслуживает обычный CLI workflow.
-- `injections/handoff/` содержит four-file dormant handoff profile: future stub prompt assets для review/security/rules/done semantics. Пока отдельный runtime binding не реализован, verifier/fixer остаются частью `core` workflow и используют inline `developer_instructions` из `agent-files/codex/*.toml`. Каждый stub включает machine-consumable `<!-- gate-summary -->` блок для будущего Handoff parser.
-- `injections/references/` остаётся shared root-level bucket для reference assets, которыми могут пользоваться оба слоя без дублирования.
-
-## Канонический Public Workflow
+Create and refine a change:
 
 ```text
-aif-explore -> aif-plan -> aif-improve -> aif-implement -> aif-verify
-                                                            \-> aif-fix -> aif-verify
+/aif-plan full "add OAuth login"
+/aif-improve add-oauth-login
 ```
 
-`/aif-analyze` подготавливает bootstrap context, но не входит в canonical public command path.
+Implement, verify, fix if needed, and finalize:
 
-- Для новой работы используйте `/aif-plan full`. `/aif-new` — только historical alias; stage name `New` в handoff vocabulary не является slash command и не заменяет canonical entrypoint.
-- `Explore / New / Apply / Done` могут использоваться как handoff stage names, но это naming layer, а не public CLI command list.
-- `aif-apply` как delegated wrapper отложен до закрытия ownership/status contract из [issue #20](https://github.com/ichinya/aifhub-extension/issues/20). Issue #20 остаётся открытым для реальной subagent orchestration, а current public execution entrypoint — `/aif-implement`.
-- `/aif-done` — explicit AIFHub/Handoff finalizer после `/aif-verify`, а не восстановленный legacy alias и не часть canonical public CLI workflow.
+```text
+/aif-implement add-oauth-login
+/aif-verify add-oauth-login
+/aif-fix add-oauth-login
+/aif-verify add-oauth-login
+/aif-done add-oauth-login
+```
+
+`/aif-done` is an explicit finalizer after passing verification. It archives through the OpenSpec CLI when archive is required, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`.
+
+## Artifact Layout
+
+OpenSpec-native v1 uses this ownership model:
+
+```text
+openspec/
+  specs/
+    <capability>/spec.md
+  changes/
+    <change-id>/
+      proposal.md
+      design.md
+      tasks.md
+      specs/
+        <capability>/spec.md
+
+.ai-factory/
+  state/
+    <change-id>/
+      implementation/
+      fixes/
+      final-summary.md
+      migration-report.md
+  qa/
+    <change-id>/
+      verify.md
+      openspec-validation.json
+      openspec-status.json
+      openspec-archive.json
+      done.md
+      raw/
+  rules/
+    generated/
+      openspec-base.md
+      openspec-change-<change-id>.md
+      openspec-merged-<change-id>.md
+```
+
+| Path | Ownership |
+|---|---|
+| `openspec/specs` | Canonical current behavior |
+| `openspec/changes` | Canonical proposed changes |
+| `.ai-factory/state` | Runtime execution traces and summaries |
+| `.ai-factory/qa` | Verification and finalization evidence |
+| `.ai-factory/rules/generated` | Derived rules, safe to regenerate |
+| `.ai-factory/plans` | Legacy compatibility and migration input only |
+
+## OpenSpec Compatibility
+
+OpenSpec is optional for extension install and AI Factory-only workflows.
+
+| Capability | Requirement |
+|---|---|
+| AI Factory extension install/use | `ai-factory >=2.10.0 <3.0.0` |
+| OpenSpec-native validation/archive | OpenSpec CLI `>=1.3.1 <2.0.0` |
+| OpenSpec CLI runtime | Node `>=20.19.0` |
+| OpenSpec skills/commands | Not installed by this extension |
+
+When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
+
+OpenSpec can be initialized without tool integrations:
+
+```bash
+openspec init --tools none
+```
+
+That command is optional and is not run by the extension installer.
+
+See [OpenSpec Compatibility](docs/openspec-compatibility.md) for supported versions, capability flags, and degraded-mode behavior.
+
+## Legacy Migration
+
+Existing `.ai-factory/plans` artifacts are legacy AI Factory-only records. Migrate them explicitly before using the OpenSpec-native flow for that work:
+
+```bash
+node scripts/migrate-legacy-plans.mjs --list
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id>
+```
+
+The migration writes canonical artifacts under `openspec/changes/<change-id>/`, preserves runtime material under `.ai-factory/state/<change-id>/`, preserves QA material under `.ai-factory/qa/<change-id>/`, and never silently deletes legacy source files.
+
+See [Legacy Plan Migration](docs/legacy-plan-migration.md) for collision modes, validation behavior, and the full artifact map.
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| OpenSpec CLI missing | Continue in degraded mode for planning or install a compatible `openspec` CLI before validation/archive-required finalization. |
+| Node too old | Use Node `>=20.19.0` for OpenSpec validation/archive. |
+| Invalid delta spec | Fix `openspec/changes/<change-id>/specs/**/spec.md`, then rerun `/aif-verify <change-id>`. |
+| Ambiguous active change | Pass an explicit `<change-id>` or update `.ai-factory/state/current.yaml`. |
+| Missing or stale generated rules | Regenerate derived rules from OpenSpec specs before relying on rules guidance. |
+| Dirty working tree before `/aif-done` | Commit, stash, or explicitly allow the dirty state only when the finalizer supports that path. |
 
 ## Documentation
 
 | Guide | Description |
-|-------|-------------|
-| [Documentation Index](docs/README.md) | Overview and recommended reading order |
-| [Usage](docs/usage.md) | Current command flow, examples, and smoke checks |
-| [Codex Agents](docs/codex-agents.md) | Namespaced Codex subagents, sandbox contract, and explicit invocation examples |
-| [Claude Agents](docs/claude-agents.md) | Namespaced Claude subagents, `.claude/agents/` install target, and handoff limitations |
-| [Handoff Naming](docs/handoff.md) | Терминология `Explore / New / Apply / Done` без возврата legacy commands в public path |
-| [Context Loading Policy](docs/context-loading-policy.md) | Runtime context contract and ownership rules |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, OpenSpec-native planning, degraded mode, and capability flags |
+|---|---|
+| [Documentation Index](docs/README.md) | Reading order and docs map |
+| [Usage](docs/usage.md) | Full command flow, read/write boundaries, examples, and troubleshooting |
+| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, ownership, and legacy boundaries |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy and capability flags |
+| [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |
+| [Active Change Resolver](docs/active-change-resolver.md) | Active change selection and runtime paths |
+| [ADR 0001](docs/adr/0001-openspec-native-artifact-protocol.md) | v1 artifact ownership decision |
+| [Codex Agents](docs/codex-agents.md) | Namespaced Codex agent files |
+| [Claude Agents](docs/claude-agents.md) | Namespaced Claude agent files |
 
 ## Validation
 
-CI автоматически проверяет manifest paths, Codex/Claude agent schema и doc links на каждом PR.
-
-Локальный запуск:
+Run the local checks:
 
 ```bash
-npm run validate   # все валидаторы
-npm test           # все тесты
+npm run validate
+npm test
 ```
 
-## Requirements
-
-- `ai-factory CLI >=2.10.0 <3.0.0`
-- Optional OpenSpec-native validation/archive: `openspec CLI >=1.3.1 <2.0.0` on Node `>=20.19.0`
-- OpenSpec skills/commands are not installed by this extension.
-- Missing OpenSpec CLI is degraded AI Factory-only mode, not an extension install failure.
-
-Отслеживание совместимости ведётся в `extension.json`:
-
-- `compat.ai-factory`: поддерживаемый диапазон `ai-factory`
-- `sources.ai-factory.version`: последняя проверенная upstream-версия
-- `sources.ai-factory.baselineVersion`: исторический baseline исходной модели extension
-- `sources.ai-factory.notes`: причина текущей минимально поддерживаемой версии
-- `sources.openspec`: optional OpenSpec CLI adapter baseline, supported range, Node requirement, and degraded-mode policy
+`npm run validate` checks manifest paths, Codex/Claude agent schemas, and markdown links under `docs/`, `injections/`, and `skills/`. Root `README.md` links should be checked manually when edited.
 
 ## Update Behavior
 
 - `ai-factory update` refreshes built-in skills and reapplies extension injections.
-- На поддерживаемых релизах `ai-factory` объявленные в manifest `agentFiles` продолжают управляться через extension contract.
 - `ai-factory extension update` refreshes the installed extension copy from its Git source.
-- Passing `/aif-verify` now leaves the plan in a verified state; optional archival, summaries, and final follow-up orchestration live in `/aif-done`.
+- `ai-factory extension remove aifhub-extension` returns the workflow to upstream AI Factory behavior.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,66 +1,77 @@
-[Back to README](../README.md) · [Next Page →](usage.md)
+[Back to README](../README.md) | [Next Page](usage.md)
 
 # Documentation
 
-Detailed documentation for the AIFHub extension.
+This documentation explains the AIFHub Extension v1 workflow:
 
-## Сводка совместимости
+```text
+AI Factory UX + OpenSpec artifact protocol
+```
 
-| Поле | Значение |
-|-------|----------|
-| Проверенный upstream | `ai-factory 2.10.0` |
-| Поддерживаемый диапазон | `>=2.10.0 <3.0.0` |
-| Исторический `baselineVersion` | `2.0.0` |
+OpenSpec-native artifacts under `openspec/` are canonical. AI Factory artifacts under `.ai-factory/` hold runtime state, QA evidence, generated rules, and legacy migration input.
 
-Для решений о поддержке ориентируйтесь на `compat.ai-factory`. `baselineVersion` нужен только как исторический контекст.
+## Reading Order
 
-OpenSpec compatibility is tracked as optional adapter metadata, not as a hard extension requirement. See [OpenSpec Compatibility](openspec-compatibility.md) for the supported CLI range, Node policy, degraded mode, and future capability flags.
+1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
+2. [Usage](usage.md) for the full command flow, command read/write boundaries, OAuth example, troubleshooting, and smoke checks.
+3. [Context Loading Policy](context-loading-policy.md) for consumer context, ownership boundaries, generated rules, and legacy path rules.
+4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, Node requirements, capability flags, and degraded mode.
+5. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
+6. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
+7. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+
+The remaining runtime-specific guides are supporting references:
+
+- [Codex Agents](codex-agents.md)
+- [Claude Agents](claude-agents.md)
+- [Codex Plan Mode](codex-plan-mode.md)
+- [Handoff Naming](handoff.md)
 
 ## Guides
 
-| Guide | Description |
-|-------|-------------|
-| [Usage](usage.md) | Canonical workflow, command behavior, and smoke checks |
-| [Codex Agents](codex-agents.md) | Namespaced Codex subagents, sandbox contract, and explicit invocation examples |
-| [Claude Agents](claude-agents.md) | Namespaced Claude subagents, `.claude/agents/` install target, and handoff limitations |
-| [Handoff Naming](handoff.md) | Stage vocabulary versus current public commands and future mapping constraints |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context contract, ownership boundaries, and artifact rules |
-| [OpenSpec Compatibility](openspec-compatibility.md) | Optional OpenSpec CLI adapter policy, degraded mode, and future capability flags |
-| [Active Change Resolver](active-change-resolver.md) | Shared active OpenSpec change selection, runtime paths, pointer behavior, and ambiguity diagnostics |
-| [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration from legacy `.ai-factory/plans` artifacts to OpenSpec-native changes |
-| [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) | v1 source-of-truth contract for OpenSpec canonical artifacts and AI Factory runtime state |
-
-## Recommended Reading Order
-
-1. Read [Usage](usage.md) for the command path, runtime notes, and smoke checks.
-2. Read [Codex Agents](codex-agents.md) or [Claude Agents](claude-agents.md) for the runtime-specific subagent contract you need.
-3. Read [Handoff Naming](handoff.md) for current manual stages versus future mapping.
-4. Read [Context Loading Policy](context-loading-policy.md) for ownership and runtime path rules.
-5. Read [OpenSpec Compatibility](openspec-compatibility.md) for optional OpenSpec CLI adapter policy and degraded-mode behavior.
-6. Read [Active Change Resolver](active-change-resolver.md) for shared change selection and runtime state paths.
-7. Read [Legacy Plan Migration](legacy-plan-migration.md) if you still have `.ai-factory/plans` artifacts to migrate.
-8. Read [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership contract.
+| Guide | Purpose |
+|---|---|
+| [Usage](usage.md) | Full OpenSpec-native command flow and examples |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, ownership, and legacy boundaries |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, version support, and degraded mode |
+| [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
+| [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |
+| [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec and AI Factory runtime state contract |
+| [Codex Agents](codex-agents.md) | Namespaced Codex subagents and invocation contract |
+| [Claude Agents](claude-agents.md) | Namespaced Claude subagents and install target |
+| [Codex Plan Mode](codex-plan-mode.md) | Codex mode and question-format guidance |
+| [Handoff Naming](handoff.md) | Stage vocabulary versus public CLI commands |
 
 ## Scope
 
 This docs set covers:
 
-- public workflow for the extension
-- companion plan-file plus plan-folder model
-- runtime-контекст, границы владения и проверенный контракт совместимости
-- optional OpenSpec CLI adapter baseline and degraded-mode policy
+- OpenSpec-native v1 workflow
+- command reads, writes, and forbidden writes
+- canonical OpenSpec artifact ownership
+- AI Factory runtime state, QA evidence, and generated rules
+- legacy AI Factory-only compatibility and migration
+- runtime-managed Codex and Claude agent files
 
-Project-level AI Factory planning and archived specs remain under `.ai-factory/` and are not duplicated here.
+It does not document `.ai-factory/plans` as the normal v1 artifact model. Those paths are legacy compatibility and migration input only.
+
+## Local Checks
+
+Run:
+
+```bash
+npm run validate
+npm test
+```
+
+`npm run validate` checks markdown links under `docs/`, `injections/`, and `skills/`. Root `README.md` links need a manual check when edited.
 
 ## See Also
 
-- [Usage](usage.md) - workflow, examples, and smoke-check steps
-- [Codex Agents](codex-agents.md) - runtime-managed Codex agent files and invocation contract
-- [Claude Agents](claude-agents.md) - runtime-managed Claude agent files and `.claude/agents/` behavior
-- [Handoff Naming](handoff.md) - current manual stages and future stage-agent mapping constraints
-- [Context Loading Policy](context-loading-policy.md) - context-loading and ownership rules
-- [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter policy and future capability flags
-- [Active Change Resolver](active-change-resolver.md) - active change selection and runtime state layout
-- [Legacy Plan Migration](legacy-plan-migration.md) - explicit migration commands and artifact mapping
-- [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md) - canonical OpenSpec artifacts and runtime AI Factory state
-- [Project README](../README.md) - landing page and quick start
+- [Project README](../README.md)
+- [Usage](usage.md)
+- [Context Loading Policy](context-loading-policy.md)
+- [OpenSpec Compatibility](openspec-compatibility.md)
+- [Legacy Plan Migration](legacy-plan-migration.md)
+- [Active Change Resolver](active-change-resolver.md)
+- [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/active-change-resolver.md
+++ b/docs/active-change-resolver.md
@@ -1,4 +1,4 @@
-[Back to Documentation](README.md)
+[Previous Page](legacy-plan-migration.md) | [Back to Documentation](README.md) | [Next Page](adr/0001-openspec-native-artifact-protocol.md)
 
 # Active Change Resolver
 
@@ -118,7 +118,28 @@ paths:
 
 `paths.plans` maps to the OpenSpec changes directory only when it points at `openspec/changes`. Legacy `.ai-factory/plans` values are ignored for active OpenSpec change resolution.
 
+## Troubleshooting
+
+When resolution returns `ambiguous-active-change`, pass an explicit `<change-id>` to the command:
+
+```text
+/aif-improve <change-id>
+/aif-implement <change-id>
+/aif-verify <change-id>
+```
+
+When resolution returns `current-pointer-not-found`, update or remove `.ai-factory/state/current.yaml`. A stale pointer blocks fallback so broken runtime state is visible.
+
+When a legacy plan exists but no OpenSpec change exists, run explicit migration instead of expecting automatic fallback:
+
+```bash
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id>
+```
+
 ## See Also
 
+- [Usage](usage.md)
+- [Legacy Plan Migration](legacy-plan-migration.md)
 - [ADR 0001: OpenSpec-native artifact protocol](adr/0001-openspec-native-artifact-protocol.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)

--- a/docs/adr/0001-openspec-native-artifact-protocol.md
+++ b/docs/adr/0001-openspec-native-artifact-protocol.md
@@ -1,4 +1,4 @@
-[Back to Documentation](../README.md)
+[Previous Page](../active-change-resolver.md) | [Back to Documentation](../README.md)
 
 # ADR 0001: OpenSpec-native artifact protocol
 
@@ -12,7 +12,7 @@ AIFHub Extension v1 keeps the AI Factory user experience and command vocabulary 
 
 Issue #25 and PR #40 established that OpenSpec is an optional CLI adapter, not a required extension dependency. The supported OpenSpec range is `>=1.3.1 <2.0.0`; OpenSpec validation and archive require Node `>=20.19.0`; AIFHub Extension does not install OpenSpec skills or commands; and a missing OpenSpec CLI means degraded AI Factory-only mode, not install failure.
 
-Before runtime code is added, the project needs a stable ownership contract that separates canonical requirements and change intent from runtime execution state.
+The project needs a stable ownership contract that separates canonical requirements and change intent from runtime execution state.
 
 ## Decision
 
@@ -122,24 +122,19 @@ For `/aif-done`, OpenSpec-native archive is the finalizer step after passing `/a
 
 ## Legacy artifact policy
 
-Legacy `.ai-factory/plans` artifacts are pre-migration planning and execution records. Before migration is implemented, commands may read them as compatibility inputs and migration sources.
+Legacy `.ai-factory/plans` artifacts are pre-migration planning and execution records. Commands may read them as compatibility inputs and migration sources.
 
 Legacy plan artifacts are not the v1 canonical source of truth once OpenSpec-native artifacts exist for the same change. Any future migration must preserve user edits and avoid silently overwriting canonical OpenSpec artifacts.
 
-This ADR defines policy only; it does not implement migration.
+The implemented migration path preserves source artifacts, writes migrated canonical artifacts under `openspec/changes/<change-id>/`, and preserves runtime/QA material under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`.
 
 ## Out of scope
 
-- OpenSpec CLI runner implementation
-- OpenSpec-native `/aif-plan`
-- migration implementation
-- full runtime implementation for #31 implement/fix/verify state alignment
 - TOON/context/KB
 - AIFHub registry/evals
-- OpenSpec capability detection
-- bootstrap changes
-- active-change resolver
-- migration behavior outside verify validate/status runtime behavior
+- custom OpenSpec schema work
+- OpenSpec skill or slash-command installation
+- future AIFHub registry/runtime artifacts under `.aifhub/`
 
 ## Consequences
 

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -1,186 +1,131 @@
-[← Previous Page](usage.md) · [Back to README](../README.md)
+[Previous Page](usage.md) | [Back to Documentation](README.md) | [Next Page](openspec-compatibility.md)
 
 # Context Loading Policy
 
-## Goal
+This policy defines which artifacts AIFHub Extension commands load and which artifacts they may write.
 
-Define one explicit context-loading contract across bootstrap, planning, execution, and verification skills.
+OpenSpec-native v1 has one core rule: canonical requirements and change intent live under `openspec/`; runtime state, QA evidence, and generated rules live under `.ai-factory/`.
 
-Эта политика фиксирует контракт extension, проверенный против `ai-factory 2.10.0`.
+## Modes
 
-## Roles
+### OpenSpec-Native Mode
 
-### Bootstrap skill
+OpenSpec-native mode is selected when `.ai-factory/config.yaml` contains:
 
-- `aif-analyze`
+```yaml
+aifhub:
+  artifactProtocol: openspec
+```
 
-Responsibilities:
-- create or update `.ai-factory/config.yaml`
-- create or update `.ai-factory/rules/base.md`
-- support migration and bootstrap compatibility
-- support explicit OpenSpec-native bootstrap when requested or when config already has `aifhub.artifactProtocol: openspec`
+In this mode, plan-aware commands resolve active work from `openspec/changes/<change-id>/`, not from `.ai-factory/plans/`.
 
-In OpenSpec-native bootstrap mode, `aif-analyze` may set `paths.plans` to `openspec/changes`, `paths.specs` to `openspec/specs`, and runtime/generated paths to `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`. This changes where consumers resolve canonical plan/change and spec artifacts, but it does not install OpenSpec skills.
+### Legacy AI Factory-Only Mode
 
-Bootstrap lookup order follows `aif-analyze`: `.ai-factory/config.yaml`, then `AGENTS.md`, then `CLAUDE.md`, then `.ai-factory/RULES.md`. Legacy bridge files (`AGENTS.md`, `CLAUDE.md`) могут читаться только как migration inputs, если уже существуют, но extension не создаёт новые bridge files. Каноническими bootstrap-результатами остаются `.ai-factory/config.yaml` и `.ai-factory/rules/base.md`.
+Legacy AI Factory-only mode uses the older companion plan model:
 
-### Consumer skills
+```text
+.ai-factory/plans/<plan-id>.md
+.ai-factory/plans/<plan-id>/
+```
 
-- `aif-explore`
-- `aif-plan`
-- `aif-improve`
-- `aif-implement`
-- `aif-verify`
-- `aif-fix`
-- `aif-roadmap`
-- `aif-evolve`
+These paths remain supported only for legacy compatibility and explicit migration input.
 
-### Gate skills (read-only)
+## Base Context
 
-- `aif-rules-check` — extension-owned temporary gate for rule compliance checks
-
-These skills must not depend on bridge files.
-
-`aif-rules-check` must use:
-
-- `.ai-factory/config.yaml`
-- in OpenSpec-native mode, generated rules in priority order:
-  - `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
-  - `.ai-factory/rules/generated/openspec-change-<change-id>.md`
-  - `.ai-factory/rules/generated/openspec-base.md`
-- `.ai-factory/RULES.md` if present
-- `.ai-factory/rules/base.md`
-- active plan-local `rules.md` only in legacy AI Factory-only mode
-- current changed scope from `git diff` / changed files
-
-OpenSpec-native `aif-rules-check` does not require plan-local `rules.md`. If generated rules are missing or stale, the gate reports `WARN` and asks the caller to regenerate rules; it does not edit or regenerate files. In legacy AI Factory-only mode, plan-local `rules.md` overrides project-level and base rules for the scoped gate result.
-
-## Required Consumer Context Set
-
-Consumer skills must use:
+Consumer commands load these project context files when present:
 
 - `.ai-factory/config.yaml`
 - `.ai-factory/DESCRIPTION.md`
 - `.ai-factory/ARCHITECTURE.md`
-- `.ai-factory/RULES.md` if present
+- `.ai-factory/RULES.md`
 - `.ai-factory/rules/base.md`
+- configured area rules from `.ai-factory/config.yaml`
 
-Optional area rules are loaded via `config.rules.*` when present.
+Consumer commands must not use bridge files such as `AGENTS.md`, `CLAUDE.md`, `QWEN.md`, or `AIFACTORY.md` as substitutes for configured context paths.
 
-Plan-aware consumer skills additionally use:
+## OpenSpec-Native Context Set
 
-In OpenSpec-native mode:
+Plan-aware consumer commands load these canonical artifacts:
 
 - `openspec/changes/<change-id>/proposal.md`
 - `openspec/changes/<change-id>/design.md`
 - `openspec/changes/<change-id>/tasks.md`
 - `openspec/changes/<change-id>/specs/**/spec.md`
+- `openspec/specs/**/spec.md`
+
+They may also load derived/runtime artifacts:
+
 - `.ai-factory/rules/generated/openspec-base.md`
 - `.ai-factory/rules/generated/openspec-change-<change-id>.md`
 - `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
-- `.ai-factory/state/<change-id>/` for runtime state
-- `.ai-factory/qa/<change-id>/` for QA output
+- `.ai-factory/state/<change-id>/**`
+- `.ai-factory/qa/<change-id>/**`
 
-In legacy AI Factory-only mode:
+Generated rules are derived guidance only. If generated rules conflict with canonical OpenSpec artifacts, canonical OpenSpec artifacts win.
 
-- `config.paths.plans/<plan-id>.md`
-- `config.paths.plans/<plan-id>/task.md`
-- `config.paths.plans/<plan-id>/context.md`
-- `config.paths.plans/<plan-id>/rules.md`
-- `config.paths.plans/<plan-id>/verify.md`
-- `config.paths.plans/<plan-id>/status.yaml`
-- `config.paths.plans/<plan-id>/explore.md` if present
+## Command Ownership
 
-Special ownership case:
+| Command | May write canonical OpenSpec artifacts | May write runtime or QA artifacts |
+|---|---|---|
+| `/aif-analyze` | Optional `openspec/` skeleton only when configured | capability/config setup |
+| `/aif-plan full` | `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md` | optional `.ai-factory/state/<change-id>/` |
+| `/aif-explore` | no | `.ai-factory/RESEARCH.md`, `.ai-factory/state/<change-id>/` |
+| `/aif-improve` | `proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md` | optional `.ai-factory/state/<change-id>/` |
+| `/aif-implement` | no, unless explicitly requested for selected scope | `.ai-factory/state/<change-id>/implementation/` |
+| `/aif-fix` | no, unless explicitly requested for selected finding scope | `.ai-factory/state/<change-id>/fixes/` |
+| `/aif-verify` | no | `.ai-factory/qa/<change-id>/` |
+| `/aif-rules-check` | no | no |
+| `/aif-done` | `openspec/specs/**` only through OpenSpec CLI archive | `.ai-factory/qa/<change-id>/`, `.ai-factory/state/<change-id>/final-summary.md` |
 
-- `aif-explore` may read `config.paths.research` and is the only consumer skill allowed to write it
-- `aif-plan` may read the same research artifact and normalize it into plan-local `explore.md` in legacy AI Factory-only mode
-- In OpenSpec-native mode, `aif-explore` may write research and runtime notes outside canonical change folders only: `.ai-factory/RESEARCH.md`, `.ai-factory/state/<change-id>/explore.md`, and `.ai-factory/state/<change-id>/research-notes.md`
-- In OpenSpec-native mode, `aif-improve` edits only valid OpenSpec change artifacts: `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
-- OpenSpec-native planning must keep runtime-only notes under `.ai-factory/state/<change-id>/`, not under `openspec/changes/<change-id>/`
-- In OpenSpec-native mode, `aif-implement` consumes canonical OpenSpec artifacts and generated rules through `scripts/openspec-execution-context.mjs` when available. It writes implementation traces only under `.ai-factory/state/<change-id>/implementation/` and does not require legacy `.ai-factory/plans/<id>/task.md`
-- In OpenSpec-native mode, `aif-fix` consumes the same canonical OpenSpec artifacts plus QA evidence under `.ai-factory/qa/<change-id>/`. It writes fix traces only under `.ai-factory/state/<change-id>/fixes/` and does not require legacy `.ai-factory/plans/<id>/task.md`
-- In OpenSpec-native mode, `aif-implement` and `aif-fix` may change implementation source files within the selected task/finding scope; they do not rewrite canonical OpenSpec artifacts unless explicitly requested
-- In OpenSpec-native mode, `aif-verify` reads canonical OpenSpec artifacts, validates the active change before code checks when validation is enabled, writes OpenSpec validation/status evidence plus QA findings under `.ai-factory/qa/<change-id>/`, treats missing CLI as degraded mode unless strict config requires CLI, hard-fails invalid OpenSpec before lint/tests/review, and must not archive
-- In OpenSpec-native mode, `aif-done` requires passing `/aif-verify` evidence, archives through `openspec archive <change-id> --yes` via the OpenSpec CLI runner, supports `--skip-specs`, writes final evidence under `.ai-factory/qa/<change-id>/`, writes final summaries under `.ai-factory/state/<change-id>/`, and does not use custom archive logic or legacy `.ai-factory/specs` finalization
-- Legacy plan migration is explicit and is not part of normal improve, implement, or verify execution. The migration reads legacy `.ai-factory/plans` artifacts, writes canonical migrated planning artifacts only under `openspec/changes/<change-id>/`, preserves runtime notes under `.ai-factory/state/<change-id>/`, preserves legacy verification evidence under `.ai-factory/qa/<change-id>/`, and never deletes the legacy source artifacts.
-- Legacy `task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, and `explore.md` apply only to legacy AI Factory-only plan folders, not OpenSpec-native changes
-- no consumer skill may use bridge files as a substitute for these runtime paths
+## Legacy Artifact Boundaries
 
-## Artifact Metadata Contract
+These files are legacy AI Factory-only artifacts or migration input only:
 
-Extension-owned markdown workflow artifacts use YAML frontmatter as a metadata layer.
+- `.ai-factory/plans/<id>.md`
+- `.ai-factory/plans/<id>/task.md`
+- `.ai-factory/plans/<id>/context.md`
+- `.ai-factory/plans/<id>/rules.md`
+- `.ai-factory/plans/<id>/verify.md`
+- `.ai-factory/plans/<id>/status.yaml`
+- `.ai-factory/plans/<id>/explore.md`
+- `.ai-factory/plans/<id>/fixes/*.md`
 
-Required frontmatter fields:
+OpenSpec-native commands must not require those files and must not create them as part of normal OpenSpec-native execution.
 
-- `artifact_type`
-- `plan_id`
-- `title`
-- `artifact_status`
-- `owner`
-- `created_at`
-- `updated_at`
+## Migration Context
 
-This contract applies to markdown artifacts such as:
+Legacy migration is explicit. It reads `.ai-factory/plans` artifacts and writes:
 
-- `task.md`
-- `context.md`
-- `rules.md`
-- `verify.md`
-- `explore.md`
-- `plans/<id>/fixes/*.md`
-- `spec.md`
+- canonical migrated artifacts under `openspec/changes/<change-id>/`
+- preserved runtime notes under `.ai-factory/state/<change-id>/`
+- preserved legacy verification evidence under `.ai-factory/qa/<change-id>/`
 
-This contract does not apply to YAML-native artifacts such as `status.yaml` and `specs/index.yaml`.
-The companion plan file `.ai-factory/plans/<plan-id>.md` remains an upstream-style summary artifact and does not require frontmatter.
+Migration never silently deletes legacy source artifacts and never writes migrated artifacts under `openspec/specs/`.
 
-## Artifact Loading Order
+See [Legacy Plan Migration](legacy-plan-migration.md).
 
-For markdown workflow artifacts:
+## Generated Rules
 
-1. Read YAML frontmatter first.
-2. Use frontmatter for routing, freshness, and identity checks.
-3. Read the markdown body only when the current step needs body sections.
+`.ai-factory/rules/generated/` is owned by the OpenSpec generated-rules compiler. Files in that directory are safe to delete and regenerate from:
 
-If a markdown artifact has no frontmatter:
+```text
+openspec/specs/**/spec.md
+openspec/changes/<change-id>/specs/**/spec.md
+```
 
-- treat it as a legacy artifact
-- fall back to the existing full-body read path
-- do not require a migration before the workflow can continue
-
-Special case: when `aif-plan` imports `.ai-factory/RESEARCH.md` into plan-local `explore.md`, it must preserve the imported body and add metadata only to the plan-local copy. The source `RESEARCH.md` stays unchanged.
+Read-only gates report missing or stale generated rules as warnings and do not regenerate them automatically.
 
 ## Fallback Behavior
 
-If `config.yaml` is missing or incomplete for the requested operation:
+If `.ai-factory/config.yaml` is missing or incomplete:
 
-- do not fall back to bridge files in consumer skills
-- ask for missing values only when the operation cannot proceed safely
-- suggest running `/aif-analyze` to initialize or repair config
-
-## Ownership Notes
-
-- `DESCRIPTION.md` owner: core `/aif`
-- `ARCHITECTURE.md` owner: core `/aif-architecture`
-- `ROADMAP.md` owner: core `/aif-roadmap`
-- `RULES.md` owner: `/aif-rules`
-- `rules/base.md` owner: extension `aif-analyze`
-- `aif-rules-check` owner: extension; reads rules but never writes
-- `.ai-factory/rules/generated/*.md` owner: OpenSpec generated rules compiler; derived from `openspec/specs/**/spec.md` and `openspec/changes/<change-id>/specs/**/spec.md`, safe to delete and regenerate
-- `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md` owner in OpenSpec-native mode: built-in `/aif-plan` with extension injection rules
-- OpenSpec-native refinement owner: built-in `/aif-improve` with extension injection rules; it preserves user edits and updates only canonical OpenSpec artifacts
-- `.ai-factory/state/<change-id>/implementation/*` owner in OpenSpec-native mode: `/aif-implement` execution traces
-- `.ai-factory/state/<change-id>/fixes/*` owner in OpenSpec-native mode: `/aif-fix` fix traces
-- `.ai-factory/state/<change-id>/*` owner in OpenSpec-native mode: runtime state for execution progress, fix notes, and git strategy; `/aif-explore` may own research-only state files
-- `.ai-factory/qa/<change-id>/*` owner in OpenSpec-native mode: `/aif-verify`
-- OpenSpec-native finalizer state owner: `/aif-done`; it owns `.ai-factory/qa/<change-id>/done.md`, `.ai-factory/qa/<change-id>/openspec-archive.json`, raw archive output, and `.ai-factory/state/<change-id>/final-summary.md`; canonical archive mutation must flow through OpenSpec CLI, not custom file movement
-- `.ai-factory/plans/<plan-id>.md` owner in legacy AI Factory-only mode: built-in `/aif-plan` with extension injection rules
-- `.ai-factory/plans/<plan-id>/status.yaml` owner in legacy AI Factory-only mode: `/aif-implement`, `/aif-verify`, `/aif-fix`
-- `rules/*.md` owner: `/aif-plan` when the active plan explicitly adds area-specific rules
+- consumer commands stop when they cannot resolve required paths safely
+- they should suggest `/aif-analyze` to initialize or repair config
+- they must not fabricate canonical artifacts from chat context alone
 
 ## See Also
 
-- [Documentation Index](README.md) - docs overview and reading order
-- [Usage](usage.md) - command flow and current workflow behavior
-- [Legacy Plan Migration](legacy-plan-migration.md) - explicit migration commands and artifact mapping
-- [Project README](../README.md) - landing page and install path
+- [Usage](usage.md)
+- [OpenSpec Compatibility](openspec-compatibility.md)
+- [Legacy Plan Migration](legacy-plan-migration.md)
+- [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/legacy-plan-migration.md
+++ b/docs/legacy-plan-migration.md
@@ -1,87 +1,109 @@
-[← Previous Page](active-change-resolver.md) · [Back to README](README.md)
+[Previous Page](openspec-compatibility.md) | [Back to Documentation](README.md) | [Next Page](active-change-resolver.md)
 
 # Legacy Plan Migration
 
-Use this migration when a project has legacy AI Factory plan artifacts but the active workflow expects OpenSpec-native changes.
+Use legacy migration when a project has `.ai-factory/plans` artifacts and the active workflow expects OpenSpec-native changes.
 
-Legacy sources are read from `.ai-factory/plans/<id>.md` and `.ai-factory/plans/<id>/`. The migration creates canonical OpenSpec change artifacts under `openspec/changes/<change-id>/` and preserves runtime-only material under `.ai-factory/state/<change-id>/` or `.ai-factory/qa/<change-id>/`.
+Migration is explicit. It does not run automatically from `/aif-improve`, `/aif-implement`, or `/aif-verify`.
 
 ## Commands
 
-List legacy plans:
+List discovered legacy plans:
 
 ```bash
 node scripts/migrate-legacy-plans.mjs --list
 ```
 
-Preview one migration without writing files:
+Dry-run one migration:
 
 ```bash
-node scripts/migrate-legacy-plans.mjs add-oauth --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
 ```
 
 Migrate one plan:
 
 ```bash
-node scripts/migrate-legacy-plans.mjs add-oauth
+node scripts/migrate-legacy-plans.mjs <change-id>
 ```
 
-Preview or migrate all discovered plans:
+Dry-run all discovered plans:
 
 ```bash
 node scripts/migrate-legacy-plans.mjs --all --dry-run
+```
+
+Migrate all discovered plans:
+
+```bash
 node scripts/migrate-legacy-plans.mjs --all
 ```
 
-The package script is an optional convenience:
+Use the package wrapper when preferred:
 
 ```bash
-npm run migrate:legacy-plans -- add-oauth --dry-run
+npm run migrate:legacy-plans -- <change-id> --dry-run
 ```
 
-Use `--json` when automation needs structured output.
+Use JSON output for automation:
+
+```bash
+node scripts/migrate-legacy-plans.mjs <change-id> --json
+```
 
 ## Collision Behavior
 
-Default collision behavior is `fail`: if `openspec/changes/<id>` already exists, migration stops without overwriting it.
+The default collision mode is `fail`: if `openspec/changes/<change-id>/` already exists, migration stops without overwriting it.
 
-Supported modes:
-
-| Mode | Behavior |
-|------|----------|
-| `fail` | Stop when the target OpenSpec change exists |
-| `suffix` | Create a distinct target such as `<id>-migrated` |
-| `merge-safe` | Create only missing files and report skipped existing files |
-| `overwrite` | Overwrite generated targets only when explicitly requested |
-
-Example:
+Supported collision modes:
 
 ```bash
-node scripts/migrate-legacy-plans.mjs add-oauth --on-collision suffix
+node scripts/migrate-legacy-plans.mjs <change-id> --on-collision fail
+node scripts/migrate-legacy-plans.mjs <change-id> --on-collision merge-safe
+node scripts/migrate-legacy-plans.mjs <change-id> --on-collision suffix
+node scripts/migrate-legacy-plans.mjs <change-id> --on-collision overwrite
 ```
+
+| Mode | Behavior |
+|---|---|
+| `fail` | Stop when the target OpenSpec change exists. |
+| `merge-safe` | Write only missing files and report skipped existing files. |
+| `suffix` | Create a distinct target such as `<change-id>-migrated`. |
+| `overwrite` | Overwrite generated migration targets only when explicitly requested. |
 
 ## Artifact Mapping
 
-Canonical OpenSpec artifacts:
+Canonical and preservation mapping:
 
-| Legacy source | OpenSpec target |
-|---------------|-----------------|
+| Legacy source | Target |
+|---|---|
 | `.ai-factory/plans/<id>.md` | `openspec/changes/<id>/proposal.md` |
 | `.ai-factory/plans/<id>/task.md` | `openspec/changes/<id>/tasks.md` |
-| Design-like `context.md` | `openspec/changes/<id>/design.md` |
-| Clear behavioral requirements | `openspec/changes/<id>/specs/migrated/spec.md` |
+| `.ai-factory/plans/<id>/context.md` | `openspec/changes/<id>/design.md` and/or `.ai-factory/state/<id>/legacy-context.md` |
+| `.ai-factory/plans/<id>/rules.md` | `.ai-factory/state/<id>/legacy-rules.md` |
+| `.ai-factory/plans/<id>/verify.md` | `.ai-factory/qa/<id>/legacy-verify.md` |
+| `.ai-factory/plans/<id>/status.yaml` | `.ai-factory/state/<id>/legacy-status.yaml` |
+| `.ai-factory/plans/<id>/explore.md` | `.ai-factory/state/<id>/legacy-explore.md` |
 
-Runtime and QA preservation:
+When clear behavioral requirements are extractable, migration may create:
 
-| Legacy source | Runtime target |
-|---------------|----------------|
-| `context.md` | `.ai-factory/state/<id>/legacy-context.md` |
-| `rules.md` | `.ai-factory/state/<id>/legacy-rules.md` |
-| `status.yaml` | `.ai-factory/state/<id>/legacy-status.yaml` |
-| `explore.md` | `.ai-factory/state/<id>/legacy-explore.md` |
-| `verify.md` | `.ai-factory/qa/<id>/legacy-verify.md` |
+```text
+openspec/changes/<id>/specs/migrated/spec.md
+```
 
-`verify.md` and `status.yaml` are never copied into `openspec/changes/<id>/`. The migration never mutates `openspec/specs/**`.
+Review migrated delta specs before treating them as product requirements.
+
+## Safety Behavior
+
+Migration never silently deletes legacy source files.
+
+Migration must not write migrated output under:
+
+- `.ai-factory/plans/`
+- `openspec/specs/`
+- another change's `.ai-factory/state/<change-id>/`
+- another change's `.ai-factory/qa/<change-id>/`
+
+If a safety check fails, the script stops and reports diagnostics.
 
 ## Validation and Reports
 
@@ -91,18 +113,32 @@ After a non-dry-run migration, the script writes:
 .ai-factory/state/<id>/migration-report.md
 ```
 
-The report lists source artifacts, generated OpenSpec artifacts, runtime artifacts, validation status, diagnostics, and manual follow-ups.
+The report records source artifacts, generated OpenSpec artifacts, runtime artifacts, validation status, diagnostics, and manual follow-ups.
 
-When a compatible OpenSpec CLI is available, migration runs change validation through the shared runner. Missing or unsupported OpenSpec CLI records `SKIPPED` and does not block migration.
+When a compatible OpenSpec CLI is available, migration validates the migrated change through the shared runner.
 
-If validation fails, generated files remain in place and the report records `FAIL`; the script does not rollback by deleting migrated or legacy artifacts.
+When the CLI is missing or unsupported, validation is recorded as `SKIPPED`; this is degraded behavior, not silent success.
+
+When validation fails, generated files remain in place and the report records `FAIL`. The script does not roll back by deleting migrated or legacy artifacts.
 
 ## After Migration
 
-Legacy artifacts are not deleted. Review the generated OpenSpec change and refine it before implementation:
+Refine the migrated OpenSpec-native change before implementation:
 
-```bash
+```text
 /aif-improve <change-id>
 ```
 
-Generated delta specs are conservative. Review them before relying on them as product requirements.
+Then run the normal v1 flow:
+
+```text
+/aif-implement <change-id>
+/aif-verify <change-id>
+/aif-done <change-id>
+```
+
+## See Also
+
+- [Usage](usage.md)
+- [Context Loading Policy](context-loading-policy.md)
+- [Active Change Resolver](active-change-resolver.md)

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -1,38 +1,37 @@
-[Back to Documentation](README.md)
+[Previous Page](context-loading-policy.md) | [Back to Documentation](README.md) | [Next Page](legacy-plan-migration.md)
 
 # OpenSpec Compatibility
 
-OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol. This page records the supported baseline, bootstrap/config behavior, mode-gated prompt assets, `/aif-plan full` OpenSpec-native planning behavior, runtime detection surface, and expected degraded behavior.
+OpenSpec is an optional CLI adapter for the v1 OpenSpec-native artifact protocol.
+
+AIFHub Extension can create and consume OpenSpec-native filesystem artifacts without a local OpenSpec CLI. Validation and archive operations require a compatible CLI.
 
 ## Supported Versions
 
 | Capability | Requirement |
 |---|---|
-| AI Factory-only extension install/use | `ai-factory >=2.10.0 <3.0.0` |
+| AI Factory extension install/use | `ai-factory >=2.10.0 <3.0.0` |
 | OpenSpec-native validation/archive | OpenSpec CLI `>=1.3.1 <2.0.0` |
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-AI Factory-only mode follows the Node/runtime support of AI Factory and upstream. OpenSpec-native validation and archive require Node `>=20.19.0`, matching the OpenSpec CLI runtime requirement.
+AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-OpenSpec can be initialized without tool integrations using:
+## Optional Initialization
+
+Projects may initialize OpenSpec without tool integrations:
 
 ```bash
 openspec init --tools none
 ```
 
-The AIFHub extension does not require this command during install.
+This is optional. The extension installer does not run it.
 
-## OpenSpec-Native Bootstrap Mode
+OpenSpec skills and slash commands are not installed by this extension.
 
-`/aif-analyze` supports an explicit OpenSpec-native bootstrap/config mode. The mode is selected only when the user asks for `openspec-native` or when existing config already has:
+## OpenSpec-Native Config
 
-```yaml
-aifhub:
-  artifactProtocol: openspec
-```
-
-In that mode, `.ai-factory/config.yaml` can include:
+OpenSpec-native mode is selected through `.ai-factory/config.yaml`:
 
 ```yaml
 aifhub:
@@ -52,13 +51,11 @@ paths:
   generated_rules: .ai-factory/rules/generated
 ```
 
-OpenSpec-native bootstrap verifies or creates `openspec/config.yaml`, `openspec/specs/`, `openspec/changes/`, `.ai-factory/state/`, `.ai-factory/qa/`, and `.ai-factory/rules/generated/`. If a compatible OpenSpec CLI is present, the skill may use or recommend `openspec init --tools none`; if the CLI is missing or unsupported, bootstrap continues with manual skeleton behavior and degraded capability flags.
-
-OpenSpec skills and slash commands are not installed by this extension.
+`installSkills: false` is intentional. AIFHub Extension uses OpenSpec artifacts and the optional CLI adapter, not OpenSpec-installed skills.
 
 ## OpenSpec-Native Planning
 
-`/aif-plan full` remains the public planning entrypoint. When `.ai-factory/config.yaml` has `aifhub.artifactProtocol: openspec`, planning creates canonical OpenSpec change artifacts instead of legacy AI Factory plan folders:
+`/aif-plan full` remains the public planning entrypoint. In OpenSpec-native mode it creates:
 
 ```text
 openspec/changes/<change-id>/
@@ -68,29 +65,11 @@ openspec/changes/<change-id>/
   specs/<capability>/spec.md
 ```
 
-Behavior-changing plans should include at least one delta spec under `specs/**/spec.md`. Docs/tooling-only plans may omit a delta spec only when they explicitly explain why no product or workflow behavior changes.
+It does not create `.ai-factory/plans/<id>.md` or `.ai-factory/plans/<id>/task.md` in OpenSpec-native mode. Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
 
-Planning validates through `scripts/openspec-runner.mjs` with `validateOpenSpecChange(changeId)` when a compatible OpenSpec CLI is available. Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
+## Capability Shape
 
-Legacy `.ai-factory/plans/<plan-id>.md` plus `.ai-factory/plans/<plan-id>/` output remains available only in AI Factory-only mode.
-
-## Install And Upgrade Notes
-
-This change only updates extension policy, metadata, and documentation. OpenSpec remains an optional external CLI adapter and is not added to `dependencies` or `devDependencies`.
-
-When a compatible OpenSpec CLI is missing:
-
-- extension install remains valid
-- AI Factory bootstrap/config workflows may still run in AI Factory-only mode
-- OpenSpec-native validation is unavailable and `/aif-verify` continues in degraded mode unless `aifhub.openspec.requireCliForVerify: true`
-- OpenSpec-native archive-required `/aif-done` fails with an explicit CLI requirement
-- OpenSpec-aware commands should report capability flags instead of failing extension install
-
-OpenSpec skills and slash commands are not installed by this extension in v1.
-
-## Runtime Capability Flags
-
-Issue #38 adds the shared runner in `scripts/openspec-runner.mjs` for OpenSpec CLI detection and normalized command execution. OpenSpec-aware commands consume capability metadata equivalent to:
+`scripts/openspec-runner.mjs` exposes capability detection with this stable minimum:
 
 ```yaml
 openspec:
@@ -100,12 +79,67 @@ openspec:
   version: string | null
   supportedRange: ">=1.3.1 <2.0.0"
   requiresNode: ">=20.19.0"
-  nodeSupported: boolean
-  versionSupported: boolean
 ```
 
-`/aif-verify` uses `scripts/openspec-verification-context.mjs` with `scripts/openspec-runner.mjs` to validate the active OpenSpec change before normal code checks. Invalid OpenSpec artifacts hard-fail before lint, tests, or review. Validation/status evidence is written under `.ai-factory/qa/<change-id>/`; `/aif-verify` does not archive.
+The current runner also reports operational detail fields:
 
-`/aif-done` is the OpenSpec-native finalizer. It refuses archive unless `/aif-verify` passed for the same change, guards dirty working tree state, archives through `openspec archive <change-id> --yes` via `scripts/openspec-runner.mjs`, supports `--skip-specs` for docs/tooling-only changes, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`. It does not use custom archive logic or legacy `.ai-factory/specs` archives in OpenSpec-native mode.
+```yaml
+openspec:
+  nodeVersion: string
+  nodeSupported: boolean
+  versionSupported: boolean
+  command: string
+  reason: string | null
+  errors:
+    - code: string
+      message: string
+```
 
-The runner reports missing or incompatible OpenSpec environments as structured degraded-mode data. OpenSpec-native bootstrap, planning, generated-rules guidance, and prompt assets for implement, fix, verify, done, rules-check, and runtime agents consume this capability shape. Runtime integrations remain scoped: #31 covers implementation/fix runtime state alignment, #32 covers verify validate/status runtime behavior, and done finalization covers archive/finalizer integration.
+Commands should treat the stable minimum as the contract and the operational detail fields as diagnostics.
+
+## Degraded Mode
+
+When the OpenSpec CLI is missing or unsupported:
+
+- extension install remains valid
+- OpenSpec-native planning can still write `openspec/changes/<change-id>/`
+- generated-rules and execution context may continue from filesystem artifacts
+- `/aif-verify` records degraded validation unless strict config requires CLI availability
+- `/aif-done` fails archive-required finalization because archive requires a compatible CLI
+
+When Node is below `>=20.19.0`, the CLI is treated as unavailable for validate/archive capabilities even if an `openspec` command exists.
+
+## Prompt Assets and Runtime Integration
+
+OpenSpec-native prompt assets are mode-gated. They keep canonical changes under `openspec/changes/<change-id>/`, read generated rules as derived guidance, and write runtime state or QA evidence under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`.
+
+Scoped runtime integrations are already documented in the active prompt assets: #31 covers implementation/fix runtime state alignment, #32 covers verify validate/status runtime behavior, and done finalization covers archive/finalizer integration.
+
+## Validation and Archive
+
+Validation uses:
+
+```bash
+openspec validate <change-id> --type change --strict --json --no-interactive --no-color
+```
+
+Status evidence uses:
+
+```bash
+openspec status --change <change-id> --json --no-color
+```
+
+Archive-required finalization uses:
+
+```bash
+openspec archive <change-id> --yes --no-color
+```
+
+`/aif-done --skip-specs` may add `--skip-specs` for docs/tooling-only changes.
+
+## See Also
+
+- [Usage](usage.md)
+- [Context Loading Policy](context-loading-policy.md)
+- [Active Change Resolver](active-change-resolver.md)
+- [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,418 +1,388 @@
-[← Previous Page](README.md) · [Back to README](../README.md) · [Next Page →](context-loading-policy.md)
+[Back to Documentation](README.md) | [Back to README](../README.md) | [Next Page](context-loading-policy.md)
 
 # Usage
 
-## Skills
-
-| Skill | Type | Purpose |
-|-------|------|---------|
-| `/aif-analyze` | Extension skill | Bootstrap `.ai-factory/config.yaml` and `rules/base.md`; explicit OpenSpec-native config is supported |
-| `/aif-rules-check` | Extension skill (temporary gate) | Read-only rule compliance check against rules hierarchy |
-| `/aif-explore` | Built-in + injection | Explore ideas; in OpenSpec-native mode, keep research/runtime notes outside canonical change folders |
-| `/aif-plan` | Built-in + injection | Create mode-gated full plans: OpenSpec changes in OpenSpec-native mode, companion plan folders in legacy AI Factory mode |
-| `/aif-improve` | Built-in + injection | Refine OpenSpec-native artifacts with preservation, or both legacy plan layers together before execution |
-| `/aif-implement` | Built-in + injection | Execute tasks with mode-gated OpenSpec runtime state or legacy plan-folder metadata |
-| `/aif-verify` | Built-in + injection | Verify changed scope with mode-gated QA output; optional archival/finalizer work lives in `/aif-done` |
-| `/aif-fix` | Built-in + injection | Apply fixes for verification findings without rewriting canonical artifacts unless requested |
-| `/aif-roadmap` | Built-in + injection | Evidence-based maturity audit roadmap |
-| `/aif-evolve` | Built-in + injection | Plan-evidence-driven evolution workflow |
-| `/aif-done` | Extension skill | Finalize verified work with OpenSpec-native archive policy or legacy plan archive, commit/PR drafts, and evidence-backed follow-ups |
-
-## Канонический Public Workflow
+This guide documents the v1 OpenSpec-native workflow for AIFHub Extension.
 
 ```text
-aif-explore -> aif-plan -> aif-improve -> aif-implement -> aif-verify
-                                                            \-> aif-fix -> aif-verify
-```
-
-`/aif-analyze` — это bootstrap/setup step перед этим flow. Он подготавливает `.ai-factory/config.yaml` и `rules/base.md`, но не является первым узлом canonical public command sequence.
-
-- Для новой работы используйте `/aif-plan full`. `/aif-new` — только historical alias; `New` в handoff vocabulary — stage name, а не slash command.
-- `Explore / New / Apply / Done` — это handoff stage names. Это naming layer, не public CLI command list. Подробности собраны в [Handoff Naming](handoff.md).
-- `aif-apply` как delegated wrapper пока отложен по ownership/status contract из [issue #20](https://github.com/ichinya/aifhub-extension/issues/20); issue остаётся открытым для реальной subagent orchestration, а current public path использует `/aif-implement`.
-- `/aif-done` — explicit AIFHub/Handoff finalizer после passing verification. Он не дублирует `/aif-verify`, не является legacy alias и не входит в canonical public CLI path.
-
-## Recommended Codex App Flow
-
-Codex не имеет автоматического переключения режимов из extension prompts. Пользователь управляет режимом вручную, а prompts могут только рекомендовать нужный режим для текущей стадии.
-
-### Recommended Flow
-
-```text
-# 1. Switch to Plan mode (user action)
-/plan-mode
-
-# 2. Explore and plan (Plan mode — request_user_input available)
-/aif-explore "task description"
-/aif-plan full "task description"
-/aif-improve
-
-# 3. Exit Plan mode (user action)
-exit plan mode
-
-# 4. Implement and verify (Default mode — plain-text questions only)
-/aif-implement
-/aif-verify
-
-# 5. Optional explicit finalizer
-/aif-done
-```
-
-Этот flow документирует безопасный runtime contract для Codex. Он не обещает client automation и не подразумевает auto-switch Plan mode из skill/injection prompts.
-
-### Runtime Notes
-
-- **Plan mode**: `request_user_input` доступен только после ручного входа в Plan mode и только для 1-3 коротких вопросов. Используйте его в planning/refinement стадиях.
-- **Default mode**: формы недоступны. Задавайте вопросы как plain text в assistant message. Не используйте `question(...)`, `questionnaire(...)` или `request_user_input`.
-- **Subagent mode**: не задавайте интерактивные вопросы. Фиксируйте assumptions и возвращайте blockers/open questions родителю.
-- Подробности по форматам вопросов: [Codex Plan Mode](codex-plan-mode.md).
-- Справочник по форматам вопросов для всех runtime: `skills/shared/QUESTION-TOOL.md`.
-
-## Совместимость
-
-- Это руководство рассчитано на `ai-factory >=2.10.0 <3.0.0`.
-- Extension хранит `sources.ai-factory.baselineVersion = 2.0.0` только как исторический контекст.
-- Runtime-aware Codex и Claude `agentFiles` входят в поддерживаемый контракт, начиная с проверенного upstream `2.10.0`.
-
-## Слои Prompt-Инъекций
-
-- `injections/core/` — active mode-gated workflow prompt assets; только этот слой подключается через `extension.json` и поддерживает canonical public workflow. OpenSpec-native sections keep canonical artifacts under `openspec/`, while legacy AI Factory-only sections keep the plan-folder overlay.
-- `injections/handoff/` — future stub prompt assets; здесь лежат только `aif-review-handoff-gate.md`, `aif-security-checklist-handoff-gate.md`, `aif-rules-check-handoff-gate.md` и `aif-done-handoff-finalizer.md` как dormant profile для отдельного runtime binding, но не как уже подключённый profile. `aif-verify` и `aif-fix` остаются частью `core` workflow, а соответствующие runtime consumers по-прежнему используют inline `developer_instructions`. Каждый stub содержит machine-consumable `<!-- gate-summary -->` блок для будущего Handoff parser.
-- `injections/references/` — shared root-level references для verify/roadmap и будущих handoff consumers без копирования файлов по слоям.
-
-Пока отдельный handoff runtime binding не реализован, ordinary CLI workflow зависит только от `core` overlays, а `injections/handoff/*` остаются future stubs и не должны трактоваться как текущий runtime contract.
-
-## Bundled Runtime Agents
-
-- Extension публикует namespaced runtime-managed agents через top-level поле `agentFiles` в `extension.json` для Codex и Claude.
-- Codex и Claude не начинают использовать эти subagents автоматически только из-за факта установки extension; для запуска нужен явный пользовательский запрос или future orchestrator mapping.
-- Для Codex подробности по именам `aifhub-*`, `sandbox_mode` и примерам вызова собраны в [Codex Agents](codex-agents.md).
-- Для Claude подробности по `.claude/agents/`, `permissionMode`, `background: true` sidecars и ручному использованию собраны в [Claude Agents](claude-agents.md).
-
-## Validation
-
-Extension включает четыре валидатора, которые проверяют целостность manifest, Codex/Claude agent schema и документации.
-
-### Валидаторы
-
-| Скрипт | Что проверяет |
-|--------|---------------|
-| `scripts/validate-extension.mjs` | `extension.json`: paths из `skills`, `agentFiles.source`, `injections.file` существуют; `agentFiles.target` соответствуют runtime (`.toml` для Codex, `.md` для Claude); `version` — semver; `compat.ai-factory` присутствует |
-| `scripts/validate-codex-agents.mjs` | Codex TOML файлы в `agent-files/codex/`: обязательные поля `name`, `description`, `developer_instructions`, `sandbox_mode`; отсутствие legacy полей `prompt` и `reasoning_effort` |
-| `scripts/validate-claude-agents.mjs` | Claude markdown-файлы в `agent-files/claude/`: YAML frontmatter, обязательные поля `name` и `description`, namespaced `aifhub-*` naming contract |
-| `scripts/validate-doc-links.mjs` | Markdown ссылки в `docs/`, `injections/`, `skills/`: целевые файлы существуют; нет пустых plan placeholders с пропущенным `<plan-id>`; внешние ссылки и anchor-only игнорируются |
-
-### Запуск
-
-```bash
-# Запустить все валидаторы
-npm run validate
-
-# Запустить все тесты
-npm test
-```
-
-CI автоматически запускает валидаторы на каждом PR (`.github/workflows/validate.yml`).
-
-## Legacy Plan Migration
-
-If OpenSpec-native commands cannot resolve `openspec/changes/<change-id>` but matching legacy AI Factory plan artifacts still exist, run an explicit migration. Migration never runs automatically from improve, implement, or verify.
-
-Preview:
-
-```bash
-node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
-```
-
-Migrate:
-
-```bash
-node scripts/migrate-legacy-plans.mjs <change-id>
-```
-
-Migrate all discovered legacy plans:
-
-```bash
-node scripts/migrate-legacy-plans.mjs --all --dry-run
-node scripts/migrate-legacy-plans.mjs --all
-```
-
-The migration maps `proposal.md`, `tasks.md`, `design.md`, and optional delta specs into `openspec/changes/<change-id>/`. Runtime-only legacy files are preserved under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`; legacy sources are not deleted. Review generated specs and run `/aif-improve <change-id>` after migration.
-
-See [Legacy Plan Migration](legacy-plan-migration.md) for collision modes and the full artifact map.
-
-## Installation
-
-```bash
-ai-factory extension add https://github.com/ichinya/aifhub-extension.git
-```
-
-Notes:
-- `ai-factory extension list` prints `name/version/source` from `.ai-factory.json`
-- update through `ai-factory extension update` against the Git source configured in `.ai-factory.json`
-
-## Typical Flow
-
-### 1. Analyze project
-
-```bash
 /aif-analyze
+  -> /aif-plan full "<request>"
+  -> optional /aif-explore "<topic>"
+  -> optional /aif-improve <change-id>
+  -> /aif-implement <change-id>
+  -> /aif-verify <change-id>
+      fail -> /aif-fix <change-id> -> /aif-verify <change-id>
+  -> /aif-done <change-id>
 ```
 
-Creates or updates:
+OpenSpec-native mode uses OpenSpec artifacts as canonical planning/spec artifacts and AI Factory paths for runtime state, QA evidence, and generated rules.
+
+## Artifact Ownership
+
+| Path | Role |
+|---|---|
+| `openspec/specs/**/spec.md` | Canonical current behavior |
+| `openspec/changes/<change-id>/proposal.md` | Canonical change intent |
+| `openspec/changes/<change-id>/design.md` | Canonical design notes |
+| `openspec/changes/<change-id>/tasks.md` | Canonical implementation checklist |
+| `openspec/changes/<change-id>/specs/**/spec.md` | Canonical proposed behavior deltas |
+| `.ai-factory/state/<change-id>/` | Runtime execution state and summaries |
+| `.ai-factory/qa/<change-id>/` | Verification and finalization evidence |
+| `.ai-factory/rules/generated/` | Derived rules, safe to regenerate |
+| `.ai-factory/plans/` | Legacy AI Factory-only compatibility and migration input |
+
+## Command Boundaries
+
+### `/aif-analyze`
+
+Reads:
+
+- project files and repository metadata
+- existing `.ai-factory/config.yaml` when present
+- existing rules/context artifacts when present
+
+Writes:
+
 - `.ai-factory/config.yaml`
 - `.ai-factory/rules/base.md`
+- optional OpenSpec-native skeleton paths such as `openspec/specs/`, `openspec/changes/`, `.ai-factory/state/`, `.ai-factory/qa/`, and `.ai-factory/rules/generated/`
 
-For OpenSpec-native bootstrap, explicitly request `openspec-native` or start from a config that already contains `aifhub.artifactProtocol: openspec`. The skill then completes the OpenSpec-native config shape, maps canonical changes to `openspec/changes`, maps specs to `openspec/specs`, prepares `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated`, and reports OpenSpec CLI capabilities through `scripts/openspec-runner.mjs` when available. Missing OpenSpec CLI remains degraded mode, not bootstrap failure.
+Does not write:
 
-Compatible OpenSpec CLI environments may use or receive this recommendation:
+- OpenSpec skills or slash commands
+- canonical change artifacts for a feature request
+- `.ai-factory/plans` in OpenSpec-native mode
 
-```bash
-openspec init --tools none
+Select OpenSpec-native mode explicitly by asking for it or by starting from config with:
+
+```yaml
+aifhub:
+  artifactProtocol: openspec
 ```
 
-The extension does not install OpenSpec skills or slash commands.
+### `/aif-plan full`
 
-`/aif-analyze` завершает bootstrap. После него canonical public workflow начинается с `/aif-explore` или сразу с `/aif-plan full`.
+Reads:
 
-### 2. Explore (optional)
+- `.ai-factory/config.yaml`
+- project context and rules
+- `openspec/specs/**/spec.md`
+- optional `.ai-factory/RESEARCH.md`
 
-```bash
-/aif-explore "add OAuth authentication"
-/aif-explore <change-id>
-/aif-explore <plan-id>
-/aif-explore @.ai-factory/plans/<plan-id>.md
-```
-
-Explore behavior:
-- reads `.ai-factory/config.yaml` first
-- in OpenSpec-native mode, stays research-oriented and may read `openspec/specs/**` plus `openspec/changes/<change-id>/**`
-- in OpenSpec-native mode, writes research/runtime output only to `.ai-factory/RESEARCH.md` or `.ai-factory/state/<change-id>/`
-- does not create non-OpenSpec files inside `openspec/changes/<change-id>/`
-- in legacy AI Factory-only mode, resolves either the companion plan file or the plan folder to one active pair and writes only `.ai-factory/RESEARCH.md`
-- routes new work to `/aif-plan full`; route existing OpenSpec-native changes to `/aif-improve <change-id>`
-
-### 3. Create a full plan
-
-```bash
-/aif-plan full "add OAuth authentication"
-```
-
-Full-mode planning is mode-gated.
-
-In OpenSpec-native mode (`aifhub.artifactProtocol: openspec`), `/aif-plan full` creates canonical OpenSpec change artifacts:
+Writes in OpenSpec-native mode:
 
 - `openspec/changes/<change-id>/proposal.md`
 - `openspec/changes/<change-id>/design.md`
 - `openspec/changes/<change-id>/tasks.md`
 - `openspec/changes/<change-id>/specs/**/spec.md` when behavior changes
+- optional runtime notes under `.ai-factory/state/<change-id>/`
 
-OpenSpec validation runs through `scripts/openspec-runner.mjs` when a compatible CLI is available. Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
+Does not write in OpenSpec-native mode:
 
-In legacy AI Factory-only mode, full-mode planning creates both:
+- `.ai-factory/plans/<id>.md`
+- `.ai-factory/plans/<id>/task.md`
+- non-OpenSpec helper files under `openspec/changes/<change-id>/`
 
-- `.ai-factory/plans/<plan-id>.md`
-- `.ai-factory/plans/<plan-id>/`
+Docs/tooling-only changes may omit delta specs only when the proposal explains why no product or workflow behavior changes.
 
-If active research exists, `/aif-plan` normalizes it into plan-local `explore.md` only in legacy AI Factory mode. OpenSpec-native runtime notes belong under `.ai-factory/state/<change-id>/`, not inside `openspec/changes/<change-id>/`.
+### `/aif-explore`
 
-Для открытия новой full plan pair используйте `/aif-plan full`. Historical `/aif-new` больше не является current public command.
+Reads:
 
-### 4. Improve the plan
+- `.ai-factory/config.yaml`
+- project context and rules
+- `openspec/specs/**/spec.md`
+- `openspec/changes/<change-id>/**` when exploring an existing change
 
-```bash
-/aif-improve
-/aif-improve <change-id>
-/aif-improve @openspec/changes/<change-id>/
-/aif-improve @.ai-factory/plans/<plan-id>/
-/aif-improve @.ai-factory/plans/<plan-id>.md
-```
+Writes:
 
-Improve behavior:
-- in OpenSpec-native mode, resolves the active change with `scripts/active-change-resolver.mjs`
-- refines only `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
-- preserves user edits, prefers patch-style changes, and returns `Changed:` / `Preserved:` summary sections
-- warns or refuses archived targets under `openspec/changes/archive/**` because archived changes are immutable by default
-- validates through `scripts/openspec-runner.mjs` when a compatible CLI is available; missing or unsupported CLI is degraded validation
-- in legacy AI Factory-only mode, resolves the plan file, the plan folder, or any plan-local artifact path
-- updates the legacy plan summary plus plan-folder artifacts together and auto-generates a missing companion plan file for legacy folder-only plans
+- `.ai-factory/RESEARCH.md`
+- `.ai-factory/state/<change-id>/explore.md` or equivalent runtime notes
 
-### 5. Implement
+Does not write:
 
-```bash
-/aif-implement
-/aif-implement <change-id>
-/aif-implement @openspec/changes/<change-id>/
-/aif-implement @.ai-factory/plans/<plan-id>/status.yaml
-```
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+- legacy `.ai-factory/plans` artifacts in OpenSpec-native mode
 
-Implement behavior:
-- in OpenSpec-native mode, reads `proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md`, accepted specs, and generated rules
-- in OpenSpec-native mode, uses `scripts/openspec-execution-context.mjs` when available to prepare implementation context and optional OpenSpec `instructions apply` guidance
-- in OpenSpec-native mode, writes implementation traces only under `.ai-factory/state/<change-id>/implementation/`; it does not write canonical OpenSpec artifacts unless the user explicitly expands scope
-- in OpenSpec-native mode, does not require legacy `.ai-factory/plans/<id>/task.md`
-- generated rules are derived guidance; missing or stale generated rules warn without replacing canonical OpenSpec artifacts
-- in legacy AI Factory-only mode, owns `status.yaml` execution metadata and git-strategy persistence
-- supports `--from <n>` resume and optional Claude worker mode
-- routes completion to `/aif-verify`
+Exploration is research-only until promoted into canonical OpenSpec artifacts by planning or refinement.
 
-`Apply` в handoff wording может ссылаться на этот этап, но current public command здесь — `/aif-implement`, не `/aif-apply`.
+### `/aif-improve`
 
-### 6. Verify
+Reads:
 
-```bash
-/aif-verify
-/aif-verify --check-only
-/aif-verify --strict
-```
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+- `openspec/specs/**/spec.md`
+- project context and generated rules when relevant
 
-Verify behavior:
-- in OpenSpec-native mode, reads canonical OpenSpec artifacts, generated rules, runtime state, and changed files
-- in OpenSpec-native mode, validates the active OpenSpec change before lint/tests/review checks when validation is enabled
-- in OpenSpec-native mode, records OpenSpec validation/status evidence, QA evidence, and findings under `.ai-factory/qa/<change-id>/` and does not archive
-- in OpenSpec-native mode, treats missing OpenSpec CLI as degraded mode unless strict config requires CLI
-- in OpenSpec-native mode, hard-fails invalid OpenSpec artifacts before code checks
-- in legacy AI Factory-only mode, reads the plan pair and plan-folder artifacts and records findings in `verify.md` and `status.yaml`
-- returns the pass/fail state that gates `/aif-fix` or the optional `/aif-done` finalizer
+Writes:
 
-### 7. Done (explicit AIFHub/Handoff finalizer)
+- patch-style edits to `proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
+- optional runtime evidence under `.ai-factory/state/<change-id>/`
 
-```bash
-/aif-done
-```
+Does not write:
 
-`/aif-done` owns post-verify finalization, commit/PR drafting, and evidence-backed governance/evolution follow-ups. In OpenSpec-native mode it requires passing `/aif-verify` evidence, guards dirty working tree state, archives through `openspec archive <change-id> --yes` via the shared OpenSpec runner, supports `--skip-specs` for docs/tooling-only changes, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`. Missing OpenSpec CLI fails archive-required finalization. In legacy AI Factory-only mode it archives the verified plan pair to `.ai-factory/specs/<plan-id>/`. `/aif-verify` remains verification-only, including `--check-only` runs.
+- `task.md`, `context.md`, `rules.md`, `verify.md`, or `status.yaml` under OpenSpec changes
+- legacy `.ai-factory/plans` artifacts in OpenSpec-native mode
+- archived changes under `openspec/changes/archive/**` unless the user explicitly chooses a supported recovery path
 
-### Review Gates (optional)
+### `/aif-implement`
 
-Three independent read-only gates can be run after implementation and before final verification:
+Reads:
+
+- `openspec/changes/<change-id>/proposal.md`
+- `openspec/changes/<change-id>/design.md`
+- `openspec/changes/<change-id>/tasks.md`
+- `openspec/changes/<change-id>/specs/**/spec.md`
+- `openspec/specs/**/spec.md`
+- `.ai-factory/rules/generated/*.md` when present
+- optional OpenSpec `instructions apply` output when a compatible CLI is available
+
+Writes:
+
+- implementation source files in the selected task scope
+- `.ai-factory/state/<change-id>/implementation/`
+- task progress in `openspec/changes/<change-id>/tasks.md`
+
+Does not write:
+
+- runtime traces under `openspec/changes/<change-id>/`
+- legacy `.ai-factory/plans/<id>/task.md`
+- canonical OpenSpec artifacts outside the selected implementation scope unless the user explicitly expands scope
+
+### `/aif-verify`
+
+Reads:
+
+- canonical OpenSpec specs and change artifacts
+- generated rules when present
+- runtime state under `.ai-factory/state/<change-id>/`
+- changed files and verification commands for the repository
+
+Writes:
+
+- `.ai-factory/qa/<change-id>/verify.md`
+- `.ai-factory/qa/<change-id>/openspec-validation.json`
+- `.ai-factory/qa/<change-id>/openspec-status.json`
+- `.ai-factory/qa/<change-id>/raw/`
+
+Does not write:
+
+- `openspec/specs/**`
+- `openspec/changes/archive/**`
+- final archive output
+- legacy `.ai-factory/specs` archives in OpenSpec-native mode
+
+Invalid OpenSpec validation is a hard stop before code checks. Missing or unsupported CLI is degraded mode unless config requires strict CLI availability.
+
+### `/aif-fix`
+
+Reads:
+
+- the same canonical OpenSpec artifacts as `/aif-implement`
+- QA evidence under `.ai-factory/qa/<change-id>/`
+- generated rules when present
+
+Writes:
+
+- implementation fixes in the selected finding scope
+- `.ai-factory/state/<change-id>/fixes/`
+
+Does not write:
+
+- runtime traces under `openspec/changes/<change-id>/`
+- legacy `.ai-factory/plans/<id>/task.md`
+- canonical specs unless the user explicitly asks to fix the spec itself
+
+After fixes, rerun:
 
 ```text
-/aif-review             — code review gate
-/aif-security-checklist — security gate
-/aif-rules-check        — rules compliance gate (extension-owned, temporary)
+/aif-verify <change-id>
 ```
 
-All three gates are independent and can run in any order. If any gate returns `FAIL`, return to the implementing stage. `/aif-rules-check` is an extension-owned temporary gate — when upstream `ai-factory` adds a native version, this skill should be deprecated.
+### `/aif-done`
 
-`/aif-done` — extension-owned explicit finalizer, работающий **после** passing verification:
+Reads:
 
-- Проверяет, что active work прошёл verify (verdict `pass` или `pass-with-notes`).
-- В OpenSpec-native mode archives through OpenSpec CLI with `openspec archive <change-id> --yes`, supports `--skip-specs`, writes final QA evidence to `.ai-factory/qa/<change-id>/`, writes final summaries to `.ai-factory/state/<change-id>/`, and does not use custom archive logic.
-- В legacy AI Factory-only mode архивирует plan folder и companion plan file в `.ai-factory/specs/<plan-id>/`.
-- Готовит commit message draft.
-- Если есть feature branch и `gh` доступен — готовит PR summary draft. Без `gh` — выводит manual PR instructions.
-- Применяет evidence-driven follow-ups для roadmap/architecture/rules через owning path или возвращает exact handoff, если текущий runtime не может безопасно завершить update.
-- Если workspace dirty не только из текущего плана — останавливается и просит подтверждения.
+- `openspec/changes/<change-id>/**`
+- passing verification evidence from `.ai-factory/qa/<change-id>/`
+- git working tree state
 
-`/aif-done` не дублирует `/aif-verify` — это отдельный AIFHub/Handoff finalizer для archive/summary/follow-up задачи, а не legacy alias старого public workflow.
+Writes:
 
-Governance note: roadmap/architecture/rules follow-ups must be backed by verified plan evidence. If the owning update cannot run safely in the current runtime, `/aif-done` should return an exact handoff instead of silently skipping it.
+- `.ai-factory/qa/<change-id>/done.md`
+- `.ai-factory/qa/<change-id>/openspec-archive.json`
+- `.ai-factory/qa/<change-id>/raw/`
+- `.ai-factory/state/<change-id>/final-summary.md`
+- `openspec/specs/**` only through `openspec archive <change-id> --yes`
 
-### 8. Fix findings
+Does not write:
+
+- custom manual mutations to `openspec/specs/**`
+- manual file moves from `openspec/changes` to archives
+- legacy `.ai-factory/specs` archives in OpenSpec-native mode
+
+Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected.
+
+## OAuth Example
+
+Create the change:
+
+```text
+/aif-plan full "add OAuth login"
+```
+
+Expected canonical artifacts:
+
+```text
+openspec/changes/add-oauth-login/
+  proposal.md
+  design.md
+  tasks.md
+  specs/
+    auth/
+      spec.md
+```
+
+Refine, implement, verify, and finalize:
+
+```text
+/aif-improve add-oauth-login
+/aif-implement add-oauth-login
+/aif-verify add-oauth-login
+/aif-done add-oauth-login
+```
+
+Expected runtime and QA output:
+
+```text
+.ai-factory/state/add-oauth-login/
+.ai-factory/qa/add-oauth-login/
+```
+
+Implementation and verification traces stay out of `openspec/changes/add-oauth-login/`.
+
+## Legacy AI Factory-Only Mode
+
+Legacy AI Factory-only mode is still supported for compatibility. It is not the normal OpenSpec-native v1 creation path.
+
+Legacy planning writes:
+
+```text
+.ai-factory/plans/<plan-id>.md
+.ai-factory/plans/<plan-id>/
+  task.md
+  context.md
+  rules.md
+  verify.md
+  status.yaml
+  explore.md
+```
+
+Use the explicit migration command when existing legacy artifacts need to enter the OpenSpec-native workflow:
 
 ```bash
-/aif-fix
-/aif-fix B001 I001
-/aif-fix --all
+node scripts/migrate-legacy-plans.mjs <change-id> --dry-run
+node scripts/migrate-legacy-plans.mjs <change-id>
 ```
 
-Fix behavior:
-- in OpenSpec-native mode, reads the same canonical OpenSpec artifacts as `/aif-implement`
-- in OpenSpec-native mode, reads QA evidence from `.ai-factory/qa/<change-id>/`
-- in OpenSpec-native mode, uses `scripts/openspec-execution-context.mjs` when available to prepare fix context and optional OpenSpec `instructions apply` guidance
-- in OpenSpec-native mode, writes fix traces only under `.ai-factory/state/<change-id>/fixes/`
-- in OpenSpec-native mode, does not write runtime traces into `openspec/changes/<change-id>/`
-- in OpenSpec-native mode, does not require legacy `.ai-factory/plans/<id>/task.md`
-- generated rules are derived guidance; missing or stale generated rules warn without replacing canonical OpenSpec artifacts
+After migration, run:
 
-After fixes, run:
-
-```bash
-/aif-verify
+```text
+/aif-improve <change-id>
 ```
+
+See [Legacy Plan Migration](legacy-plan-migration.md).
+
+## Recommended Codex App Flow
+
+Codex cannot switch modes from extension prompts. The user controls the mode manually.
+
+```text
+# Plan mode, user action
+/aif-explore "task description"
+/aif-plan full "task description"
+/aif-improve <change-id>
+
+# Default mode, user action
+/aif-implement <change-id>
+/aif-verify <change-id>
+/aif-done <change-id>
+```
+
+In Codex Default mode, prompts must ask plain-text questions rather than using `request_user_input`.
+
+See [Codex Plan Mode](codex-plan-mode.md) for question-format guidance.
+
+## Troubleshooting
+
+| Problem | Meaning | Action |
+|---|---|---|
+| OpenSpec CLI missing | `openspec` is not available on `PATH`. | Continue degraded planning or install a compatible CLI before validation/archive-required finalization. |
+| Node too old | OpenSpec validate/archive requires Node `>=20.19.0`. | Use Node `>=20.19.0` for OpenSpec commands. |
+| Invalid delta spec | OpenSpec validation failed for `specs/**/spec.md`. | Fix the delta spec and rerun `/aif-verify <change-id>`. |
+| Ambiguous active change | More than one active change can be selected. | Pass `<change-id>` explicitly or update `.ai-factory/state/current.yaml`. |
+| Missing generated rules | Derived rules are absent. | Regenerate `.ai-factory/rules/generated/*.md` from OpenSpec specs before relying on rules guidance. |
+| Stale generated rules | Generated rules do not match canonical OpenSpec artifacts. | Regenerate them; do not edit generated rules as source of truth. |
+| Dirty working tree before `/aif-done` | Finalization cannot prove archive/summary scope safely. | Commit, stash, or use an explicit supported dirty-state override when available. |
 
 ## Release Smoke Checks
 
-Use this checklist when validating an install or update of the extension:
-
-1. Проверить версию CLI:
+1. Check the AI Factory version:
 
 ```bash
 ai-factory --version
 ```
 
-Ожидается версия внутри `>=2.10.0 <3.0.0`.
+Expected range:
 
-2. Установка:
+```text
+>=2.10.0 <3.0.0
+```
+
+2. Install the extension:
 
 ```bash
 ai-factory extension add https://github.com/ichinya/aifhub-extension.git
 ```
 
-Ожидается, что `extension.json` будет публиковать только `skills/aif-analyze`, injected built-in workflow и namespaced runtime-managed `agentFiles` для Codex и Claude.
-
-3. Обновление:
-
-```bash
-ai-factory update
-ai-factory extension update
-```
-
-Ожидается, что built-in skills останутся canonical, injections переустановятся чисто, а поддерживаемые runtime-managed assets останутся синхронизированы с manifest.
-
-4. Удаление:
-
-```bash
-ai-factory extension remove aifhub-extension
-```
-
-Ожидается, что canonical upstream commands останутся доступными без extension-owned override для `aif-plan`.
-
-5. Сквозной workflow:
-
-```bash
-/aif-analyze
-/aif-plan full "smoke-check feature"
-/aif-improve
-/aif-implement
-/aif-verify --check-only
-```
-
-Ожидаются companion artifacts в `.ai-factory/plans/`, синхронизированный `status.yaml` и документация, которая указывает только на текущий workflow. For an explicit OpenSpec-native smoke, expect `openspec/changes/<change-id>/` plus runtime/QA output under `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`.
-
-## Project Layout
+3. Run an OpenSpec-native smoke:
 
 ```text
-aifhub-extension/
-|- extension.json
-|- agent-files/
-|  |- claude/
-|  `- codex/
-|- injections/
-|  |- core/
-|  |- handoff/
-|  `- references/
-|- docs/
-|  |- README.md
-|  |- claude-agents.md
-|  |- codex-agents.md
-|  |- usage.md
-|  |- handoff.md
-|  `- context-loading-policy.md
-`- skills/
-   |- aif-analyze/
-   |- aif-done/
-   |- aif-rules-check/
-   `- shared/
+/aif-analyze
+/aif-plan full "smoke check feature"
+/aif-improve <change-id>
+/aif-implement <change-id>
+/aif-verify <change-id>
+```
+
+Expected OpenSpec-native artifacts:
+
+```text
+openspec/changes/<change-id>/
+.ai-factory/state/<change-id>/
+.ai-factory/qa/<change-id>/
+```
+
+Legacy `.ai-factory/plans/` artifacts are expected only when the project is intentionally in legacy AI Factory-only mode.
+
+4. Run local repository checks:
+
+```bash
+npm run validate
+npm test
 ```
 
 ## See Also
 
-- [Documentation Index](README.md) - docs overview and reading order
-- [Handoff Naming](handoff.md) - терминология стадий versus current public commands
-- [Claude Agents](claude-agents.md) - bundled `aifhub-*` Claude agents, `.claude/agents/` install behavior, and manual invocation contract
-- [Codex Agents](codex-agents.md) - bundled `aifhub-*` agents, explicit invocation, and sandbox contract
-- [Context Loading Policy](context-loading-policy.md) - runtime context and ownership contract
-- [Codex Plan Mode](codex-plan-mode.md) - Codex app/CLI recommended flow and question format guidance
-- [Project README](../README.md) - quick start and high-level workflow summary
+- [Documentation Index](README.md)
+- [Context Loading Policy](context-loading-policy.md)
+- [OpenSpec Compatibility](openspec-compatibility.md)
+- [Legacy Plan Migration](legacy-plan-migration.md)
+- [Active Change Resolver](active-change-resolver.md)
+- [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/openspec/changes/rewrite-v1-openspec-native-docs/design.md
+++ b/openspec/changes/rewrite-v1-openspec-native-docs/design.md
@@ -1,0 +1,115 @@
+# Design: Rewrite v1 OpenSpec-native workflow docs
+
+## Technical Approach
+
+Rewrite the public documentation around one mental model:
+
+```text
+AI Factory UX + OpenSpec artifact protocol.
+```
+
+The README should be the short landing page. `docs/usage.md` should be the detailed operational guide. `docs/context-loading-policy.md`, `docs/openspec-compatibility.md`, and `docs/legacy-plan-migration.md` should each own one policy area and link to each other instead of repeating conflicting workflow descriptions.
+
+Use exact vocabulary consistently:
+
+- OpenSpec-native mode
+- canonical OpenSpec artifacts
+- runtime state
+- QA evidence
+- generated rules
+- legacy AI Factory-only mode
+- migration input
+
+## Data / Artifact Model
+
+The docs must use this conceptual layout exactly when explaining v1 ownership:
+
+```text
+openspec/
+  specs/
+    <capability>/spec.md
+  changes/
+    <change-id>/
+      proposal.md
+      design.md
+      tasks.md
+      specs/
+        <capability>/spec.md
+
+.ai-factory/
+  state/
+    <change-id>/
+      implementation/
+      fixes/
+      final-summary.md
+      migration-report.md
+  qa/
+    <change-id>/
+      verify.md
+      openspec-validation.json
+      openspec-status.json
+      openspec-archive.json
+      done.md
+      raw/
+  rules/
+    generated/
+      openspec-base.md
+      openspec-change-<change-id>.md
+      openspec-merged-<change-id>.md
+```
+
+Ownership wording:
+
+```text
+openspec/specs                  canonical current behavior
+openspec/changes                canonical proposed changes
+.ai-factory/state               runtime execution traces
+.ai-factory/qa                  verification/finalization evidence
+.ai-factory/rules/generated     derived rules, safe to regenerate
+.ai-factory/plans               legacy compatibility only
+```
+
+`docs/legacy-plan-migration.md` must document this exact mapping:
+
+```text
+.ai-factory/plans/<id>.md                    -> openspec/changes/<id>/proposal.md
+.ai-factory/plans/<id>/task.md               -> openspec/changes/<id>/tasks.md
+.ai-factory/plans/<id>/context.md            -> design.md and/or .ai-factory/state/<id>/legacy-context.md
+.ai-factory/plans/<id>/rules.md              -> .ai-factory/state/<id>/legacy-rules.md
+.ai-factory/plans/<id>/verify.md             -> .ai-factory/qa/<id>/legacy-verify.md
+.ai-factory/plans/<id>/status.yaml           -> .ai-factory/state/<id>/legacy-status.yaml
+.ai-factory/plans/<id>/explore.md            -> .ai-factory/state/<id>/legacy-explore.md
+```
+
+## Integration Points
+
+Primary files:
+
+- `README.md`: public landing page, quick start, artifact layout, compatibility, migration, troubleshooting links.
+- `docs/usage.md`: complete v1 flow with command read/write/never-write sections and an OAuth example.
+- `docs/context-loading-policy.md`: context-loading contract for OpenSpec-native consumers and legacy/migration-only paths.
+- `docs/openspec-compatibility.md`: optional OpenSpec CLI adapter policy, version and Node requirements, capability flags, no installed OpenSpec skills.
+- `docs/legacy-plan-migration.md`: exact migration commands and behavior.
+
+Secondary files:
+
+- `docs/active-change-resolver.md`: link and wording updates only if active-change troubleshooting needs a clearer cross-reference.
+- `docs/adr/0001-openspec-native-artifact-protocol.md`: small consistency correction only; do not rewrite into a user guide.
+- `docs/README.md`: docs index and reading order.
+
+Validation:
+
+- `npm run validate` runs manifest, agent schema, and doc-link validation.
+- `npm test` runs prompt/script tests. If prompt tests object to legacy path mentions, make the legacy/migration boundaries more explicit in docs.
+
+## Alternatives Considered
+
+- Patch only the requested paragraphs: rejected because the issue is the final v1 docs pass and needs one consistent story across the public docs.
+- Remove all legacy plan references: rejected because migration and AI Factory-only compatibility remain supported and must be documented.
+- Update ADR 0001 heavily: rejected because the ADR should remain a decision record. User-facing explanations belong in README and usage docs.
+
+## Risks
+
+- Legacy examples can accidentally look like the default workflow. Keep every legacy path under clearly labeled compatibility or migration sections.
+- The README can become too long if it duplicates the usage guide. Keep README short and link to deeper docs.
+- The troubleshooting section can drift if repeated in many files. Prefer a concise README pointer plus the fuller `docs/usage.md` troubleshooting section.

--- a/openspec/changes/rewrite-v1-openspec-native-docs/proposal.md
+++ b/openspec/changes/rewrite-v1-openspec-native-docs/proposal.md
@@ -1,0 +1,54 @@
+# Proposal: Rewrite v1 OpenSpec-native workflow docs
+
+## Intent
+
+Issue #37 is the final v1 public documentation pass. The docs need to present one canonical artifact protocol: AI Factory remains the user-facing workflow, while OpenSpec owns canonical specs and changes in OpenSpec-native mode.
+
+The current docs already mention OpenSpec-native behavior, but the landing page and usage guide still mix older plan-folder language into the normal workflow. That makes it too easy for users to treat `.ai-factory/plans` as the current canonical artifact model.
+
+## Scope
+
+In scope:
+
+- Rewrite `README.md` around the v1 OpenSpec-native user story.
+- Rewrite `docs/usage.md` to document the complete command flow and each command's reads, writes, and forbidden writes.
+- Rewrite `docs/context-loading-policy.md` so OpenSpec-native context is canonical and legacy plan files are explicitly legacy-only or migration input.
+- Tighten `docs/openspec-compatibility.md` around optional CLI behavior, supported versions, Node requirement, capability flags, and the no-OpenSpec-skills policy.
+- Expand `docs/legacy-plan-migration.md` with the real migration commands, artifact mapping, dry-run behavior, collision behavior, validation behavior, and post-migration `/aif-improve <change-id>` guidance.
+- Update `docs/active-change-resolver.md`, `docs/adr/0001-openspec-native-artifact-protocol.md`, and `docs/README.md` only for small consistency or cross-link fixes.
+- Add troubleshooting coverage for missing CLI, old Node, invalid delta specs, ambiguous active changes, stale generated rules, and dirty working tree before `/aif-done`.
+- Keep all public examples aligned with the current generated OpenSpec layout and runtime/QA paths.
+
+Out of scope:
+
+- New runtime behavior.
+- New OpenSpec runner behavior.
+- Installing OpenSpec skills or slash commands.
+- Custom OpenSpec schema work.
+- TOON, context, KB, or AIFHub registry work.
+- Git commit or PR creation.
+- Generated-rules behavior changes.
+- Migration behavior changes except tiny docs/test fixes required by validation.
+
+## Approach
+
+Treat the docs as a single product surface instead of patching isolated sections. Start from `README.md`, then make `docs/usage.md` the detailed workflow guide. Use the same canonical artifact layout and ownership wording everywhere.
+
+Keep legacy `.ai-factory/plans` documentation, but move it behind "Legacy AI Factory-only mode" and migration language. Do not describe legacy plan-folder artifacts as the normal v1 path.
+
+Use the actual repository commands for migration:
+
+- `node scripts/migrate-legacy-plans.mjs --list`
+- `node scripts/migrate-legacy-plans.mjs <change-id> --dry-run`
+- `node scripts/migrate-legacy-plans.mjs <change-id>`
+- `node scripts/migrate-legacy-plans.mjs --all --dry-run`
+- `node scripts/migrate-legacy-plans.mjs --all`
+- optional package wrapper `npm run migrate:legacy-plans -- <args>`
+
+Run `npm run validate` and `npm test` after the docs rewrite. If validation fails because legitimate migration sections mention legacy paths, tighten the surrounding wording instead of deleting migration documentation.
+
+## Risks / Open Questions
+
+- The repository still has older `.ai-factory` project context files that describe the pre-OpenSpec plan-folder model. Do not use those as the source of truth for this docs pass; the issue text and current OpenSpec/runtime scripts are authoritative.
+- Doc-link validation scans `docs/`, `injections/`, and `skills/`, but not the root README. Still check root README links manually while editing.
+- Prompt contract tests may assert exact OpenSpec and legacy wording in injections. This issue is docs-only, so avoid prompt asset changes unless a test proves a tiny link or wording fix is required.

--- a/openspec/changes/rewrite-v1-openspec-native-docs/specs/v1-documentation/spec.md
+++ b/openspec/changes/rewrite-v1-openspec-native-docs/specs/v1-documentation/spec.md
@@ -1,0 +1,108 @@
+# Delta for v1 Documentation
+
+## ADDED Requirements
+
+### Requirement: OpenSpec-native workflow is the primary public documentation story
+
+The documentation MUST present AI Factory UX with the OpenSpec artifact protocol as the primary v1 workflow.
+
+#### Scenario: README quick start uses OpenSpec-native flow
+
+- GIVEN a user opens `README.md`
+- WHEN they read the quick start
+- THEN the documented flow starts with `/aif-analyze`
+- AND includes `/aif-plan full "<request>"`
+- AND uses explicit `<change-id>` arguments for improve, implement, verify, fix, and done where applicable
+- AND does not present `.ai-factory/plans` as the normal OpenSpec-native workflow.
+
+#### Scenario: Legacy mode is compatibility-only
+
+- GIVEN a user reads any public workflow documentation
+- WHEN legacy `.ai-factory/plans` artifacts are mentioned
+- THEN the section labels them as legacy AI Factory-only mode or migration input
+- AND points users to the migration guide for converting existing legacy plans.
+
+### Requirement: Documentation distinguishes canonical, runtime, QA, generated, and legacy artifacts
+
+The documentation MUST clearly distinguish canonical OpenSpec artifacts from AI Factory runtime state, QA evidence, generated rules, and legacy compatibility artifacts.
+
+#### Scenario: Canonical artifact layout is documented consistently
+
+- GIVEN a user reads the README or usage documentation
+- WHEN they inspect the artifact layout
+- THEN `openspec/specs` is described as canonical current behavior
+- AND `openspec/changes` is described as canonical proposed changes
+- AND `.ai-factory/state` is described as runtime execution traces
+- AND `.ai-factory/qa` is described as verification and finalization evidence
+- AND `.ai-factory/rules/generated` is described as derived and safe to regenerate
+- AND `.ai-factory/plans` is described as legacy compatibility only.
+
+### Requirement: Usage guide documents command read and write boundaries
+
+The usage guide MUST document what each v1 workflow command reads, writes, and does not write.
+
+#### Scenario: Plan command boundaries are explicit
+
+- GIVEN a user reads the `/aif-plan full` section in `docs/usage.md`
+- WHEN they compare reads, writes, and does-not-write lists
+- THEN reads include project context and `openspec/specs/**`
+- AND writes include `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`
+- AND forbidden writes include `.ai-factory/plans/<id>.md` and `.ai-factory/plans/<id>/task.md` in OpenSpec-native mode.
+
+#### Scenario: Runtime commands keep state outside canonical changes
+
+- GIVEN a user reads implement, fix, verify, and done sections
+- WHEN they inspect write locations
+- THEN implementation traces are under `.ai-factory/state/<change-id>/implementation/`
+- AND fix traces are under `.ai-factory/state/<change-id>/fixes/`
+- AND verification and finalization evidence are under `.ai-factory/qa/<change-id>/`
+- AND runtime traces are not documented as writes under `openspec/changes/<change-id>/`.
+
+### Requirement: OpenSpec compatibility policy is explicit
+
+The documentation MUST state the optional OpenSpec CLI adapter policy, supported range, Node requirement, degraded behavior, and no-skills-installation rule.
+
+#### Scenario: Compatibility page includes capability metadata
+
+- GIVEN a user reads `docs/openspec-compatibility.md`
+- WHEN they inspect runtime capability behavior
+- THEN the documented shape includes `available`, `canValidate`, `canArchive`, `version`, `supportedRange: ">=1.3.1 <2.0.0"`, and `requiresNode: ">=20.19.0"`
+- AND the page states AIFHub Extension does not install OpenSpec skills or commands.
+
+### Requirement: Legacy migration guide documents safe migration behavior
+
+The migration guide MUST explain how existing `.ai-factory/plans` artifacts migrate into OpenSpec-native changes and runtime or QA preservation paths.
+
+#### Scenario: Migration commands match the real CLI
+
+- GIVEN a user reads `docs/legacy-plan-migration.md`
+- WHEN they copy commands from the guide
+- THEN the guide includes `node scripts/migrate-legacy-plans.mjs --list`
+- AND includes single-plan dry-run and migration commands
+- AND includes all-plan dry-run and migration commands
+- AND documents `--on-collision fail|merge-safe|suffix|overwrite`
+- AND does not invent script names.
+
+#### Scenario: Migration preserves legacy files
+
+- GIVEN a user reads the migration guide
+- WHEN they inspect safety behavior
+- THEN the guide says legacy files are not silently deleted
+- AND validation runs after migration when the compatible OpenSpec CLI is available
+- AND missing CLI records degraded validation behavior
+- AND users should run `/aif-improve <change-id>` after migration.
+
+### Requirement: Troubleshooting covers expected v1 failure modes
+
+The documentation MUST provide troubleshooting guidance for common OpenSpec-native workflow failures.
+
+#### Scenario: Troubleshooting includes required failure modes
+
+- GIVEN a user reads troubleshooting documentation
+- WHEN they scan the listed issues
+- THEN it covers OpenSpec CLI missing
+- AND Node too old for OpenSpec
+- AND invalid delta spec
+- AND ambiguous active change
+- AND missing or stale generated rules
+- AND dirty working tree before `/aif-done`.

--- a/openspec/changes/rewrite-v1-openspec-native-docs/tasks.md
+++ b/openspec/changes/rewrite-v1-openspec-native-docs/tasks.md
@@ -1,0 +1,58 @@
+# Tasks
+
+## 1. README rewrite
+
+- [x] 1.1 Rewrite `README.md` so the opening user story is `AI Factory UX + OpenSpec artifact protocol`.
+- [x] 1.2 Add `## What this extension does` with OpenSpec-native mode as the v1 default story and legacy mode as compatibility only.
+- [x] 1.3 Add `## Quick start` with `/aif-analyze`, OpenSpec-native confirmation, `/aif-plan full "<request>"`, optional `/aif-improve <change-id>`, `/aif-implement <change-id>`, `/aif-verify <change-id>`, `/aif-fix <change-id>` on failure, and `/aif-done <change-id>` after passing verification.
+- [x] 1.4 Add `## Artifact layout` using the exact canonical/runtime/derived layout and ownership table from `design.md`.
+- [x] 1.5 Add concise `## OpenSpec compatibility`, `## Legacy migration`, and `## Troubleshooting` sections that link to the detailed docs.
+- [x] 1.6 Remove or relocate README wording that presents `.ai-factory/plans` as the normal OpenSpec-native workflow.
+- [x] 1.7 Normalize touched README prose to clean English and remove mojibake or stale legacy-default wording from the first-viewport story.
+
+## 2. Usage guide rewrite
+
+- [x] 2.1 Rewrite `docs/usage.md` around the full v1 flow: `/aif-analyze`, `/aif-plan full "<request>"`, optional `/aif-explore "<topic>"`, optional `/aif-improve <change-id>`, `/aif-implement <change-id>`, `/aif-verify <change-id>`, `/aif-fix <change-id>` if verification fails, and `/aif-done <change-id>` after verification passes.
+- [x] 2.2 For `/aif-analyze`, document what it reads, what it writes, and that it never installs OpenSpec skills or commands.
+- [x] 2.3 For `/aif-plan full`, document reads from project context and `openspec/specs/**`, writes to `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`, and does not write `.ai-factory/plans/<id>.md` or `.ai-factory/plans/<id>/task.md` in OpenSpec-native mode.
+- [x] 2.4 For `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-fix`, and `/aif-done`, add the same reads/writes/does-not-write shape with exact paths.
+- [x] 2.5 Add the concrete OAuth example: `/aif-plan full "add OAuth login"` creates `openspec/changes/add-oauth-login/proposal.md`, `design.md`, `tasks.md`, and `specs/auth/spec.md`; implementation/verification/done writes `.ai-factory/state/add-oauth-login/` and `.ai-factory/qa/add-oauth-login/`.
+- [x] 2.6 Add troubleshooting entries for OpenSpec CLI missing, Node too old, invalid delta spec, ambiguous active change, missing or stale generated rules, and dirty working tree before `/aif-done`.
+- [x] 2.7 Keep legacy AI Factory-only mode as a compatibility section, not a normal creation path.
+- [x] 2.8 Rewrite the release smoke check so the default smoke result is `openspec/changes/<change-id>/` plus `.ai-factory/state/<change-id>/` and `.ai-factory/qa/<change-id>/`; legacy `.ai-factory/plans/` expectations must appear only under legacy AI Factory-only mode.
+- [x] 2.9 Normalize touched `docs/usage.md` prose to clean English and remove mojibake from command explanations and validation sections.
+
+## 3. Context-loading and compatibility policy
+
+- [x] 3.1 Rewrite `docs/context-loading-policy.md` so OpenSpec-native consumer skills load `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md`, `openspec/specs/**/spec.md`, `.ai-factory/rules/generated/*.md`, `.ai-factory/state/<change-id>/**`, and `.ai-factory/qa/<change-id>/**`.
+- [x] 3.2 Document `.ai-factory/plans/<id>/task.md`, `context.md`, `rules.md`, `verify.md`, `status.yaml`, and related legacy files as legacy AI Factory-only mode or migration input only.
+- [x] 3.3 Update `docs/openspec-compatibility.md` to clearly state OpenSpec is optional, supported CLI range is `>=1.3.1 <2.0.0`, Node requirement is `>=20.19.0`, missing CLI degrades gracefully, AIFHub does not install OpenSpec skills/commands, and `openspec init --tools none` is optional.
+- [x] 3.4 Include the current `scripts/openspec-runner.mjs` capability shape with `available`, `canValidate`, `canArchive`, `version`, `supportedRange`, `requiresNode`, `nodeVersion`, `nodeSupported`, `versionSupported`, `reason`, and `errors`, while keeping `available`, `canValidate`, `canArchive`, `version`, `supportedRange`, and `requiresNode` as the documented stable minimum.
+
+## 4. Migration guide and cross-links
+
+- [x] 4.1 Update `docs/legacy-plan-migration.md` with real commands from `scripts/migrate-legacy-plans.mjs`: `--list`, single-plan `--dry-run`, single-plan migrate, `--all --dry-run`, `--all`, `--on-collision fail|merge-safe|suffix|overwrite`, and `--json`.
+- [x] 4.2 Document the exact legacy-to-OpenSpec/runtime/QA mapping from `design.md`.
+- [x] 4.3 Document collision behavior, validation after migration when the CLI is available, missing-CLI degraded behavior, no silent deletion of legacy files, and the post-migration `/aif-improve <change-id>` step.
+- [x] 4.4 Update `docs/README.md` reading order, links, and scope text so README, usage, context-loading policy, compatibility, migration, active-change resolver, and ADR 0001 form a clear loop and no longer describe the companion plan-file plus plan-folder model as the normal v1 documentation scope.
+- [x] 4.5 Update `docs/active-change-resolver.md` only if needed for ambiguous active-change troubleshooting or cross-links.
+- [x] 4.6 Update `docs/adr/0001-openspec-native-artifact-protocol.md` only for small consistency corrections; keep it as an ADR.
+
+## 5. Validation
+
+- [x] 5.1 Run `npm run validate`.
+- [x] 5.2 Fix any doc-link failures or empty plan placeholder failures.
+- [x] 5.3 Run `npm test`.
+- [x] 5.4 If tests fail because docs contain legacy paths, ensure those paths are clearly gated under legacy AI Factory-only mode or migration sections rather than deleting legitimate migration documentation.
+- [x] 5.5 Confirm the final diff is docs-only except for tiny doc-link/test fixes if validation requires them.
+- [x] 5.6 Manually check root `README.md` links and anchors because `scripts/validate-doc-links.mjs` scans `docs/`, `injections/`, and `skills/`, but not the repository root README.
+- [x] 5.7 Attempt OpenSpec validation for `rewrite-v1-openspec-native-docs`; if the OpenSpec CLI is missing or unsupported, record degraded validation evidence instead of treating missing CLI as an implementation failure.
+  Evidence: `openspec validate rewrite-v1-openspec-native-docs --type change --strict --json --no-interactive --no-color` returned `CommandNotFoundException`; this is degraded missing-CLI evidence, not an implementation failure.
+
+## Suggested Commit Plan
+
+Not executed as part of this issue because the scope excludes git commit creation.
+
+- Commit 1: `docs: rewrite v1 OpenSpec-native workflow docs`
+- Commit 2: `docs: clarify legacy migration and compatibility policy`
+- Commit 3: `test: align documentation link checks if needed`


### PR DESCRIPTION
## Summary
- Rewrite the main documentation set around the OpenSpec-native artifact protocol and current change flow
- Add updated usage, compatibility, migration, and context-loading guidance
- Include the OpenSpec change proposal, design, spec, and task artifacts for the documentation rewrite

## Testing
- Lint and validation checks passed locally
- Unit tests passed locally