### PR TITLE
Tighten OpenSpec gate contracts and verification boundaries

### DIFF
--- a/agent-files/claude/aifhub-plan-polisher.md
+++ b/agent-files/claude/aifhub-plan-polisher.md
@@ -19,6 +19,7 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present.
 - Allowed write scope: canonical artifacts inside the selected OpenSpec change and runtime state under `.ai-factory/state/<change-id>/`.
+- After touching `proposal.md`, `design.md`, `tasks.md`, or `specs/**/spec.md`, validate through `scripts/openspec-runner.mjs` using `validateOpenSpecChange(changeId)` when available. If the OpenSpec CLI is unavailable, report degraded validation rather than treating it as a planning failure.
 - Do not write QA evidence except to name `.ai-factory/qa/<change-id>/` in the final report.
 - Do not create legacy plan artifacts in OpenSpec-native mode.
 - Return concise output with: active OpenSpec change, canonical artifacts inspected or touched, generated rules state, runtime state path, QA evidence path, critique status, remaining issues, and whether more refinement is recommended.

--- a/agent-files/claude/aifhub-review-sidecar.md
+++ b/agent-files/claude/aifhub-review-sidecar.md
@@ -34,3 +34,24 @@ Use this mode when OpenSpec-native mode is not enabled.
 Rules:
 - Surface only material correctness, regression, performance, or maintainability findings.
 - If there are no material issues, say so explicitly.
+
+Output:
+- Start with `Verdict: PASS`, `Verdict: WARN`, or `Verdict: FAIL`.
+- Return findings first.
+- Include `Evidence:` with changed files, canonical artifacts, generated rules state, runtime state path, and QA evidence path when applicable.
+- End with exactly one final fenced `aif-gate-result` JSON block.
+- Use `"gate": "review"` and lowercase JSON `status` values: `pass`, `warn`, or `fail`.
+- Set `blocking` to `true` only for `Verdict: FAIL`.
+- Use `suggested_next.command` `/aif-fix` only when blocking review findings need fixes.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "review",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/agent-files/claude/aifhub-security-sidecar.md
+++ b/agent-files/claude/aifhub-security-sidecar.md
@@ -33,3 +33,24 @@ Use this mode when OpenSpec-native mode is not enabled.
 Rules:
 - Focus on changed paths, exposed interfaces, secrets, validation, unsafe shell or filesystem patterns, and injection risks.
 - Return only actionable security findings. If none are present, say so explicitly.
+
+Output:
+- Start with `Verdict: PASS`, `Verdict: WARN`, or `Verdict: FAIL`.
+- Return actionable security findings first.
+- Include `Evidence:` with changed files, canonical artifacts, generated rules state, runtime state path, and QA evidence path when applicable.
+- End with exactly one final fenced `aif-gate-result` JSON block.
+- Use `"gate": "security"` and lowercase JSON `status` values: `pass`, `warn`, or `fail`.
+- Set `blocking` to `true` only for `Verdict: FAIL`.
+- Use `suggested_next.command` `/aif-fix` only when blocking security findings need fixes.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "security",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/agent-files/codex/aifhub-plan-polisher.toml
+++ b/agent-files/codex/aifhub-plan-polisher.toml
@@ -16,6 +16,7 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present.
 - Allowed write scope: canonical artifacts inside the selected OpenSpec change and runtime state under .ai-factory/state/<change-id>/.
+- After touching proposal.md, design.md, tasks.md, or specs/**/spec.md, validate through scripts/openspec-runner.mjs using validateOpenSpecChange(changeId) when available. If the OpenSpec CLI is unavailable, report degraded validation rather than treating it as a planning failure.
 - Do not write QA evidence except to name .ai-factory/qa/<change-id>/ in the final report.
 - Do not create legacy plan artifacts in OpenSpec-native mode.
 - Return concise output with: active OpenSpec change, canonical artifacts inspected or touched, generated rules state, runtime state path, QA evidence path, critique status, remaining issues, and whether more refinement is recommended.

--- a/agent-files/codex/aifhub-review-sidecar.toml
+++ b/agent-files/codex/aifhub-review-sidecar.toml
@@ -30,4 +30,25 @@ Use this mode when OpenSpec-native mode is not enabled.
 Rules:
 - Surface only material correctness, regression, performance, or maintainability findings.
 - If there are no material issues, say so explicitly.
+
+Output:
+- Start with Verdict: PASS, Verdict: WARN, or Verdict: FAIL.
+- Return findings first.
+- Include Evidence: with changed files, canonical artifacts, generated rules state, runtime state path, and QA evidence path when applicable.
+- End with exactly one final fenced aif-gate-result JSON block.
+- Use "gate": "review" and lowercase JSON status values: pass, warn, or fail.
+- Set blocking to true only for Verdict: FAIL.
+- Use suggested_next.command "/aif-fix" only when blocking review findings need fixes.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "review",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```
 """

--- a/agent-files/codex/aifhub-security-sidecar.toml
+++ b/agent-files/codex/aifhub-security-sidecar.toml
@@ -29,4 +29,25 @@ Use this mode when OpenSpec-native mode is not enabled.
 Rules:
 - Focus on changed paths, exposed interfaces, secrets, validation, unsafe shell or filesystem patterns, and injection risks.
 - Return only actionable security findings. If none are present, say so explicitly.
+
+Output:
+- Start with Verdict: PASS, Verdict: WARN, or Verdict: FAIL.
+- Return actionable security findings first.
+- Include Evidence: with changed files, canonical artifacts, generated rules state, runtime state path, and QA evidence path when applicable.
+- End with exactly one final fenced aif-gate-result JSON block.
+- Use "gate": "security" and lowercase JSON status values: pass, warn, or fail.
+- Set blocking to true only for Verdict: FAIL.
+- Use suggested_next.command "/aif-fix" only when blocking security findings need fixes.
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "security",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```
 """

--- a/docs/claude-agents.md
+++ b/docs/claude-agents.md
@@ -21,8 +21,9 @@
 
 ## Ролевые семейства
 
-- `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope и возвращают findings-first output без auto-fix. Запускаются в фоне (`background: true`).
-- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it uses `aif-rules-check`, reads `.ai-factory/rules/generated/*` in OpenSpec-native mode, and ends with a final `aif-gate-result` block with `"gate": "rules"`.
+- `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope, возвращают findings-first output без auto-fix, and end with one final machine-readable `aif-gate-result` block. Запускаются в фоне (`background: true`).
+- `aifhub-review-sidecar`, `aifhub-security-sidecar`, and `aifhub-rules-sidecar` use gate values `"review"`, `"security"`, and `"rules"` respectively, with lowercase `status` values `pass`, `warn`, or `fail`.
+- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it uses `aif-rules-check` and reads `.ai-factory/rules/generated/*` in OpenSpec-native mode.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
 - `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, and prepares summary/archive evidence.

--- a/docs/codex-agents.md
+++ b/docs/codex-agents.md
@@ -21,8 +21,9 @@
 
 ## Ролевые семейства
 
-- `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope и возвращают findings-first output без auto-fix.
-- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it is namespaced for AIFHub, reads `.ai-factory/rules/generated/*` in OpenSpec-native mode, and ends with a final `aif-gate-result` block with `"gate": "rules"`.
+- `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope, возвращают findings-first output без auto-fix, and end with one final machine-readable `aif-gate-result` block.
+- `aifhub-review-sidecar`, `aifhub-security-sidecar`, and `aifhub-rules-sidecar` use gate values `"review"`, `"security"`, and `"rules"` respectively, with lowercase `status` values `pass`, `warn`, or `fail`.
+- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it is namespaced for AIFHub and reads `.ai-factory/rules/generated/*` in OpenSpec-native mode.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
 - `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, prepares summary/archive evidence, and does not bypass owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json",
   "name": "aifhub-extension",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Upstream-first extension for AI Factory 2.11+: bootstrap remains extension-owned; `aif-plan`, `aif-implement`, `aif-verify`, and `aif-fix` connect through injections; upstream `aif-rules-check` is augmented by the AIFHub OpenSpec generated-rules injection; `aif-done` and `aif-mode` remain extension-owned finalizers/orchestrators; Codex and Claude runtime files publish through top-level `agentFiles`.",
   "commands": [
     {

--- a/injections/core/aif-verify-plan-folder.md
+++ b/injections/core/aif-verify-plan-folder.md
@@ -66,7 +66,7 @@ Runtime state and QA evidence boundaries:
 - Write verification findings, verdicts, command results, and review evidence only under `.ai-factory/qa/<change-id>/`.
 - Record OpenSpec validation/status evidence under `.ai-factory/qa/<change-id>/` before code verification.
 - Do not write QA evidence or runtime-only files into `openspec/changes/<change-id>/`.
-- Do not archive. `/aif-verify` does not archive; `/aif-done <change-id>` remains the post-verify finalizer, with full archive integration deferred to issue #33.
+- Do not archive. `/aif-verify` records verification evidence only; `/aif-done <change-id>` owns OpenSpec archive/finalization.
 - Do not create legacy plan-folder verification artifacts in OpenSpec-native mode.
 
 Normal verification responses should report:

--- a/scripts/aif-gate-result.test.mjs
+++ b/scripts/aif-gate-result.test.mjs
@@ -289,3 +289,53 @@ describe('aif-rules-check gate contract', () => {
     }
   });
 });
+
+describe('review and security sidecar gate contracts', () => {
+  async function readSidecarAssets(kind) {
+    return {
+      codex: await readFile(
+        path.join(REPO_ROOT, 'agent-files', 'codex', `aifhub-${kind}-sidecar.toml`),
+        'utf8'
+      ),
+      claude: await readFile(
+        path.join(REPO_ROOT, 'agent-files', 'claude', `aifhub-${kind}-sidecar.md`),
+        'utf8'
+      )
+    };
+  }
+
+  function assertReadOnlySidecarBoundaries(codexAsset, claudeAsset) {
+    assert.match(codexAsset, /sandbox_mode = "read-only"/);
+    assert.match(claudeAsset, /tools: Read, Glob, Grep/);
+    assert.doesNotMatch(claudeAsset, /^tools:.*(?:Write|Edit|Bash)/m);
+
+    for (const asset of [codexAsset, claudeAsset]) {
+      assert.match(asset, /Do not edit files/);
+      assert.doesNotMatch(asset, /\.ai-factory\/qa\/<change-id>\/verify\.md/);
+    }
+  }
+
+  function assertGateContract(asset, gate) {
+    assert.match(asset, /End with exactly one final fenced `?aif-gate-result`? JSON block/);
+    assert.match(asset, new RegExp(`"gate": "${gate}"`));
+    assert.match(asset, /pass`, `warn`, or `fail`|pass, warn, or fail/);
+    assert.match(asset, /blocking.*true.*fail|fail.*blocking.*true/i);
+    assert.match(asset, /suggested_next\.command.*\/aif-fix|suggested_next.*\/aif-fix/i);
+  }
+
+  it('keeps review sidecars read-only and aligned with review gate output', async () => {
+    const { codex, claude } = await readSidecarAssets('review');
+
+    assertReadOnlySidecarBoundaries(codex, claude);
+    assertGateContract(codex, 'review');
+    assertGateContract(claude, 'review');
+  });
+
+  it('keeps security sidecars read-only and aligned with security gate output', async () => {
+    const { codex, claude } = await readSidecarAssets('security');
+
+    assertReadOnlySidecarBoundaries(codex, claude);
+    assertGateContract(codex, 'security');
+    assertGateContract(claude, 'security');
+  });
+});

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -27,6 +27,11 @@ const VERIFY_PROMPT_ASSETS = [
   'agent-files/claude/aifhub-verifier.md'
 ];
 
+const PLAN_POLISHER_PROMPT_ASSETS = [
+  'agent-files/codex/aifhub-plan-polisher.toml',
+  'agent-files/claude/aifhub-plan-polisher.md'
+];
+
 const DONE_PROMPT_ASSETS = [
   'skills/aif-done/SKILL.md',
   'skills/aif-done/references/finalization-contract.md',
@@ -243,6 +248,11 @@ describe('OpenSpec-native prompt asset contract', () => {
       assertNotIncludes(openspec, 'status.yaml as source of truth', `${relativePath} OpenSpec-native mode`);
       assertNotIncludes(openspec, 'active plan pair', `${relativePath} OpenSpec-native mode`);
       assertNotIncludes(openspec, 'plan-local `rules.md`', `${relativePath} OpenSpec-native mode`);
+      assert.doesNotMatch(
+        openspec,
+        /(?:runtime state|QA evidence|verification findings|verdicts|command results|trace(?:s)?)\s+(?:under|inside|to|into)\s+`?openspec\/changes/i,
+        `${relativePath} OpenSpec-native mode should not direct runtime-only writes into openspec/changes`
+      );
       assertIncludes(legacy, '.ai-factory/plans/<plan-id>/', `${relativePath} Legacy AI Factory-only mode`);
     }
   });
@@ -316,6 +326,54 @@ describe('OpenSpec-native prompt asset contract', () => {
         `${relativePath} should forbid archive from /aif-verify`
       );
     }
+  });
+
+  it('requires plan-polisher prompts to validate touched OpenSpec artifacts', async () => {
+    for (const relativePath of PLAN_POLISHER_PROMPT_ASSETS) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      for (const expected of [
+        'proposal.md',
+        'design.md',
+        'tasks.md',
+        'specs/**/spec.md',
+        'scripts/openspec-runner.mjs',
+        'validateOpenSpecChange(changeId)'
+      ]) {
+        assertIncludes(asset, expected, relativePath);
+      }
+
+      assert.match(
+        asset,
+        /After touching .*OpenSpec artifacts|After touching .*proposal\.md.*design\.md.*tasks\.md.*specs/i,
+        `${relativePath} should require validation after artifact edits`
+      );
+      assert.match(
+        asset,
+        /degraded validation|CLI is unavailable|missing CLI/i,
+        `${relativePath} should report degraded validation when the CLI is unavailable`
+      );
+    }
+  });
+
+  it('keeps verify prompt wording aligned with done-owned archive finalization', async () => {
+    const asset = stripFencedBlocks(await readRepoFile('injections/core/aif-verify-plan-folder.md'));
+
+    assert.doesNotMatch(
+      asset,
+      /archive integration (?:is )?deferred to issue #33|deferred archive status/i,
+      'verify injection should not describe OpenSpec archive integration as deferred'
+    );
+    assert.match(
+      asset,
+      /\/aif-verify.*records verification evidence|verification evidence only/i,
+      'verify injection should describe /aif-verify as evidence-only'
+    );
+    assert.match(
+      asset,
+      /\/aif-done.*owns OpenSpec archive\/finalization/i,
+      'verify injection should state that /aif-done owns OpenSpec archive/finalization'
+    );
   });
 
   it('suggests explicit legacy migration without auto-migrating in improve, implement, and verify prompts', async () => {


### PR DESCRIPTION
## Summary
- Tightened Codex and Claude prompt assets for OpenSpec plan-polisher, review, and security sidecars.
- Standardized gate output contracts for review/security sidecars, including final `aif-gate-result` JSON blocks and blocking semantics.
- Clarified `/aif-verify` scope so verification records evidence only and `/aif-done` owns archive/finalization.
- Added contract tests covering the new sidecar requirements, OpenSpec validation wording, and archive boundary updates.
- Bumped the extension version to `1.0.8`.

## Testing
- Added/updated automated contract checks in `scripts/aif-gate-result.test.mjs` and `scripts/openspec-prompt-assets.test.mjs`.
- Not run (not requested).