### PR TITLE
chore: Update OpenSpec workflow documentation and related scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@
 ## [В разработке]
 
 ### Изменено
+- Документация OpenSpec-native workflow теперь описывает полный tail: sync/rules/review/security gates, verify/fix loop, doctor, done, post-archive sync, commit и optional evolve.
+- Prompt assets для done/implement/verifier теперь явно передают финализацию в `/aif-mode sync`, `/aif-commit` и optional `/aif-evolve`, не представляя `/aif-done` заменой commit gate.
 - `extension.json` теперь указывает на upstream JSON Schema `https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json` и больше не содержит private AIFHub поля.
 - AIFHub metadata `compat` и `sources` вынесены в `aifhub-extension.json` с локальной схемой `schemas/aifhub-extension.schema.json`.
 - `npm run validate` теперь проверяет split contract: upstream manifest, AIFHub metadata, bundled agent files и docs links.
 - `compat.ai-factory` now requires `>=2.11.0 <3.0.0`; AI Factory 2.11.0 provides native `aif-rules-check`, so AIFHub keeps only `injections/core/aif-rules-check-openspec-generated-rules.md` for OpenSpec generated-rules augmentation.
 - `scripts/validate-extension.mjs` validates `extension.json` against the local synced copy of the upstream AI Factory extension schema.
+
+### Исправлено
+- `/aif-mode sync` в OpenSpec-native mode теперь обновляет `.ai-factory/rules/generated/openspec-base.md` даже после archive, когда активных changes больше нет, и пропускает change-specific rules/validation без ошибки.
+- `/aif-mode sync --all` больше не падает только из-за активных migrated/docs-only changes без delta specs; такие changes помечаются `no-delta-specs`, а changes с delta specs продолжают проходить sync validation.
 
 ## [0.10.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AI Factory UX + OpenSpec artifact protocol
 
 ## What This Extension Does
 
-- Keeps `/aif-analyze`, `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-fix`, `/aif-done`, and `/aif-mode` as the public command vocabulary.
+- Keeps `/aif-analyze`, `/aif-plan`, `/aif-explore`, `/aif-improve`, `/aif-implement`, `/aif-rules-check`, `/aif-review`, `/aif-security-checklist`, `/aif-verify`, `/aif-fix`, `/aif-done`, `/aif-commit`, `/aif-evolve`, and `/aif-mode` as the public command vocabulary.
 - In OpenSpec-native mode, writes canonical change artifacts under `openspec/changes/<change-id>/` and accepted specs under `openspec/specs/`.
 - Keeps AI Factory runtime state, verification evidence, finalization evidence, and generated rules outside canonical OpenSpec changes.
 - Requests OpenSpec validation, status, instructions, and archive through the AIFHub wrapper and `scripts/openspec-runner.mjs` when a compatible CLI is available.
@@ -25,6 +25,8 @@ Install the extension:
 
 ```bash
 ai-factory extension add https://github.com/ichinya/aifhub-extension.git
+ai-factory update
+ai-factory extension update aifhub-extension
 ```
 
 Bootstrap project context:
@@ -53,19 +55,38 @@ Create and refine a change:
 ```text
 /aif-plan full "add OAuth login"
 /aif-improve add-oauth-login
+/aif-mode sync --change add-oauth-login
 ```
 
-Implement, verify, fix if needed, and finalize:
+Implement, check optional gates, verify, fix if needed, finalize, sync, commit, and optionally evolve:
 
 ```text
 /aif-implement add-oauth-login
+/aif-mode sync --change add-oauth-login
+/aif-rules-check
+/aif-review
+/aif-security-checklist
 /aif-verify add-oauth-login
 /aif-fix add-oauth-login
 /aif-verify add-oauth-login
+/aif-mode doctor --change add-oauth-login
 /aif-done add-oauth-login
+/aif-mode sync
+/aif-commit
+/aif-evolve
 ```
 
-`/aif-done` is an explicit finalizer after passing verification. It archives through the OpenSpec CLI when archive is required, writes final evidence under `.ai-factory/qa/<change-id>/`, and writes final summaries under `.ai-factory/state/<change-id>/`.
+`/aif-done` finalizes the OpenSpec lifecycle. It archives the accepted OpenSpec change through the OpenSpec CLI when archive is required and writes final evidence under `.ai-factory/qa/<change-id>/` plus final summaries under `.ai-factory/state/<change-id>/`.
+
+It does not replace `/aif-commit`. After `/aif-done`, run `/aif-commit` or your normal git workflow to commit implementation changes, OpenSpec archive/spec changes, QA evidence, and final summaries.
+
+Optional gates:
+
+- `/aif-rules-check` - read-only rules compliance.
+- `/aif-review` - read-only code review.
+- `/aif-security-checklist` - read-only security gate.
+- `/aif-mode doctor` - mode/config/artifact readiness.
+- `/aif-mode sync` - derived artifact refresh and OpenSpec validation/status when available.
 
 ## Artifact Layout
 

--- a/agent-files/claude/aifhub-done-finalizer.md
+++ b/agent-files/claude/aifhub-done-finalizer.md
@@ -23,7 +23,8 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Archive only through `archiveOpenSpecChange` from `scripts/openspec-runner.mjs`: normal archive is `openspec archive <change-id> --yes`, and docs/tooling-only finalization uses `--skip-specs`.
 - `/aif-verify` does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
 - Allowed writes are `.ai-factory/qa/<change-id>/` final evidence and `.ai-factory/state/<change-id>/` final summaries; do not write runtime-only files into `openspec/changes/<change-id>/`.
-- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, and any `/aif-evolve` recommendation.
+- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for `/aif-mode sync`, next-step recommendation for `/aif-commit`, and any `/aif-evolve` recommendation.
+- After successful finalization, recommend `/aif-mode sync` to refresh derived artifacts after archive, recommend `/aif-commit` as the next AI Factory command, and optionally recommend `/aif-evolve` when durable learning evidence exists.
 
 ## Legacy AI Factory-only mode
 
@@ -38,5 +39,6 @@ Use this mode when OpenSpec-native mode is not enabled.
 Rules:
 - Follow the finalization contract from `skills/aif-done/references/finalization-contract.md`.
 - Draft a conventional commit message and PR body for user review; do not auto-create PRs.
+- Do not create commits automatically, do not create PRs automatically, and do not present `/aif-done` as replacing `/aif-commit`.
 - Do not invent governance changes that are not supported by verified evidence.
-- Do not reintroduce `/aif-done` as the canonical workflow step; this is a bounded runtime helper only.
+- Do not reintroduce `/aif-done` as the canonical workflow step; this is a bounded runtime helper only and does not replace `/aif-commit`.

--- a/agent-files/claude/aifhub-implement-worker.md
+++ b/agent-files/claude/aifhub-implement-worker.md
@@ -23,6 +23,7 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Treat `.ai-factory/qa/<change-id>/` as QA evidence owned by verification; name it in reports but do not write verifier findings.
 - Do not create legacy plan artifacts in OpenSpec-native mode.
 - Report changed files, active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, blockers, and next recommended command.
+- After implementation, optional read-only gates are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
 
 ## Legacy AI Factory-only mode
 

--- a/agent-files/claude/aifhub-verifier.md
+++ b/agent-files/claude/aifhub-verifier.md
@@ -28,6 +28,7 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Return findings first, then a gate result: `PASS`, `PASS with notes`, or `FAIL`.
 - Include active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, validation status, `shouldRunCodeVerification`, code verification status, counts for blocking/important/optional findings, and next recommended command.
 - Recommend `/aif-fix <change-id>` when validation or verification fails, and `/aif-done <change-id>` only after passing verification.
+- Optional read-only gates before or during verification are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
 - End with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase `status`: `pass`, `warn`, or `fail`. Write the same final block into `.ai-factory/qa/<change-id>/verify.md`.
 
 ## Legacy AI Factory-only mode

--- a/agent-files/codex/aifhub-done-finalizer.toml
+++ b/agent-files/codex/aifhub-done-finalizer.toml
@@ -20,7 +20,8 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Archive only through archiveOpenSpecChange from scripts/openspec-runner.mjs: normal archive is openspec archive <change-id> --yes, and docs/tooling-only finalization uses --skip-specs.
 - /aif-verify does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy .ai-factory/specs archive.
 - Allowed writes are .ai-factory/qa/<change-id>/ final evidence and .ai-factory/state/<change-id>/ final summaries; do not write runtime-only files into openspec/changes/<change-id>/.
-- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, and any /aif-evolve recommendation.
+- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for /aif-mode sync, next-step recommendation for /aif-commit, and any /aif-evolve recommendation.
+- After successful finalization, recommend /aif-mode sync to refresh derived artifacts after archive, recommend /aif-commit as the next AI Factory command, and optionally recommend /aif-evolve when durable learning evidence exists.
 
 ## Legacy AI Factory-only mode
 
@@ -35,6 +36,7 @@ Use this mode when OpenSpec-native mode is not enabled.
 Rules:
 - Follow the finalization contract from skills/aif-done/references/finalization-contract.md.
 - Draft a conventional commit message and PR body for user review; do not auto-create PRs.
+- Do not create commits automatically, do not create PRs automatically, and do not present /aif-done as replacing /aif-commit.
 - Do not invent governance changes that are not supported by verified evidence.
-- Do not reintroduce /aif-done as the canonical workflow step; this is a bounded runtime helper only.
+- Do not reintroduce /aif-done as the canonical workflow step; this is a bounded runtime helper only and does not replace /aif-commit.
 """

--- a/agent-files/codex/aifhub-implement-worker.toml
+++ b/agent-files/codex/aifhub-implement-worker.toml
@@ -20,6 +20,7 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Treat .ai-factory/qa/<change-id>/ as QA evidence owned by verification; name it in reports but do not write verifier findings.
 - Do not create legacy plan artifacts in OpenSpec-native mode.
 - Report changed files, active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, blockers, and next recommended command.
+- After implementation, optional read-only gates are /aif-rules-check, /aif-review, and /aif-security-checklist. The authoritative final verification remains /aif-verify <change-id>.
 
 ## Legacy AI Factory-only mode
 

--- a/agent-files/codex/aifhub-verifier.toml
+++ b/agent-files/codex/aifhub-verifier.toml
@@ -25,6 +25,7 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Return findings first, then a gate result: PASS, PASS with notes, or FAIL.
 - Include active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, validation status, shouldRunCodeVerification, code verification status, counts for blocking/important/optional findings, and next recommended command.
 - Recommend /aif-fix <change-id> when validation or verification fails, and /aif-done <change-id> only after passing verification.
+- Optional read-only gates before or during verification are /aif-rules-check, /aif-review, and /aif-security-checklist. The authoritative final verification remains /aif-verify <change-id>.
 - End with exactly one final fenced aif-gate-result JSON block using "gate": "verify" and lowercase status pass, warn, or fail. Write the same final block into .ai-factory/qa/<change-id>/verify.md.
 
 ## Legacy AI Factory-only mode

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,9 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 ## Reading Order
 
 1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
-2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, command read/write boundaries, OAuth example, troubleshooting, and smoke checks.
-3. [Context Loading Policy](context-loading-policy.md) for consumer context, ownership boundaries, generated rules, and legacy path rules.
-4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, Node requirements, capability flags, and degraded mode.
+2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
+3. [Context Loading Policy](context-loading-policy.md) for consumer context, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
+4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, capability flags, and degraded mode.
 5. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
 6. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
 7. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
@@ -34,9 +34,9 @@ The remaining runtime-specific guides are supporting references:
 
 | Guide | Purpose |
 |---|---|
-| [Usage](usage.md) | Full OpenSpec-native command flow and examples |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, ownership, and legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, version support, and degraded mode |
+| [Usage](usage.md) | Full OpenSpec-native command flow, gates, finalization tail, commit, and examples |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, ownership, gates, commit handoff, and legacy boundaries |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, sync points, rules gate, version support, and degraded mode |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
 | [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec and AI Factory runtime state contract |
@@ -53,6 +53,8 @@ This docs set covers:
 - OpenSpec-native v1 workflow
 - artifact mode switching and sync through `/aif-mode`
 - command reads, writes, and forbidden writes
+- optional rules, review, and security gates
+- verification, fix, done, post-archive sync, commit, and evolve handoff
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence, and generated rules
 - legacy AI Factory-only compatibility and migration

--- a/docs/claude-agents.md
+++ b/docs/claude-agents.md
@@ -46,6 +46,58 @@
 - Имена `plan-coordinator`, `implement-coordinator`, `review-sidecar`, `security-sidecar`, `rules-sidecar` зарезервированы для bundled agents и не должны использоваться extension agent files без namespace.
 - Prefix `aifhub-` сразу показывает, что агент относится к extension contract AIFHub.
 
+## Agent-assisted OpenSpec workflow
+
+Manual commands remain the source of truth. Agents are bounded helpers.
+
+### Planning
+
+- `/aif-plan full <request>`
+- optional `aifhub-plan-polisher`
+- optional `/aif-improve <change-id>`
+- recommended `/aif-mode sync --change <change-id>`
+
+`aifhub-plan-polisher` may edit canonical OpenSpec change artifacts and must validate touched artifacts through the OpenSpec runner when available.
+
+### Implementation
+
+- `aifhub-implement-worker`
+- writes implementation traces only under `.ai-factory/state/<change-id>/implementation/`
+
+After implementation, optional read-only gates are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
+
+### Read-only sidecars
+
+Run after code changes and before or during verification:
+
+- `aifhub-rules-sidecar` -> `gate: "rules"`
+- `aifhub-review-sidecar` -> `gate: "review"`
+- `aifhub-security-sidecar` -> `gate: "security"`
+
+All sidecars are read-only and end with final `aif-gate-result`.
+
+### Verification and fix loop
+
+- `aifhub-verifier`
+- if fail: `aifhub-fixer`
+- rerun `aifhub-verifier`
+
+Verifier writes QA evidence under `.ai-factory/qa/<change-id>/`.
+
+### Finalization
+
+- `aifhub-done-finalizer`
+- requires passing verify gate
+- archives only through OpenSpec CLI
+- writes final evidence/summaries
+- recommends `/aif-mode sync`
+- recommends `/aif-commit`
+- does not create commits or PRs automatically
+
+### Optional learning
+
+- `/aif-evolve` after commit/finalization when durable learnings exist.
+
 ## Примеры явного вызова
 
 Используйте те же имена, что записаны в поле `name` frontmatter:

--- a/docs/codex-agents.md
+++ b/docs/codex-agents.md
@@ -41,6 +41,58 @@
 - Имена остаются стабильными между manifest, файлами в `agent-files/codex/` и явным spawn-запросом.
 - Prefix сразу показывает, что агент относится к extension contract AIFHub, а не к встроенному generic поведению Codex.
 
+## Agent-assisted OpenSpec workflow
+
+Manual commands remain the source of truth. Agents are bounded helpers.
+
+### Planning
+
+- `/aif-plan full <request>`
+- optional `aifhub-plan-polisher`
+- optional `/aif-improve <change-id>`
+- recommended `/aif-mode sync --change <change-id>`
+
+`aifhub-plan-polisher` may edit canonical OpenSpec change artifacts and must validate touched artifacts through the OpenSpec runner when available.
+
+### Implementation
+
+- `aifhub-implement-worker`
+- writes implementation traces only under `.ai-factory/state/<change-id>/implementation/`
+
+After implementation, optional read-only gates are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
+
+### Read-only sidecars
+
+Run after code changes and before or during verification:
+
+- `aifhub-rules-sidecar` -> `gate: "rules"`
+- `aifhub-review-sidecar` -> `gate: "review"`
+- `aifhub-security-sidecar` -> `gate: "security"`
+
+All sidecars are read-only and end with final `aif-gate-result`.
+
+### Verification and fix loop
+
+- `aifhub-verifier`
+- if fail: `aifhub-fixer`
+- rerun `aifhub-verifier`
+
+Verifier writes QA evidence under `.ai-factory/qa/<change-id>/`.
+
+### Finalization
+
+- `aifhub-done-finalizer`
+- requires passing verify gate
+- archives only through OpenSpec CLI
+- writes final evidence/summaries
+- recommends `/aif-mode sync`
+- recommends `/aif-commit`
+- does not create commits or PRs automatically
+
+### Optional learning
+
+- `/aif-evolve` after commit/finalization when durable learnings exist.
+
 ## Примеры явного вызова
 
 Используйте те же имена, что записаны в поле `name`:

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -84,7 +84,29 @@ Runner output from OpenSpec CLI commands is runtime guidance or evidence. It doe
 | `/aif-fix` | no, unless explicitly requested for selected finding scope | `.ai-factory/state/<change-id>/fixes/` |
 | `/aif-verify` | no | `.ai-factory/qa/<change-id>/` |
 | `/aif-rules-check` | no | no |
+| `/aif-review` | no | no |
+| `/aif-security-checklist` | no | no |
 | `/aif-done` | `openspec/specs/**` only through OpenSpec CLI archive | `.ai-factory/qa/<change-id>/`, `.ai-factory/state/<change-id>/final-summary.md` |
+| `/aif-commit` | no | git commit only |
+| `/aif-evolve` | no | skill-context or evolution artifacts only |
+
+## Quality Gates and Finalization Tail
+
+OpenSpec-native quality gates:
+
+| Command | Reads | Writes |
+|---|---|---|
+| `/aif-rules-check` | generated rules, project rules, changed files, optional OpenSpec context | none |
+| `/aif-review` | changed files, OpenSpec context, generated rules | none |
+| `/aif-security-checklist` | changed files, OpenSpec context, generated rules | none |
+| `/aif-verify` | canonical OpenSpec artifacts, generated rules, runtime state, gate outputs when available | `.ai-factory/qa/<change-id>/` |
+| `/aif-done` | passing verify evidence, verify gate result, OpenSpec change | final QA/state evidence and OpenSpec archive via CLI |
+| `/aif-commit` | staged changes, done evidence, final summary, OpenSpec archive/spec changes | git commit |
+| `/aif-evolve` | patches, evidence, skill-context inputs | skill-context/evolution artifacts |
+
+`/aif-done` owns OpenSpec lifecycle finalization. `/aif-commit` owns git commit creation. `/aif-evolve` owns learning/evolution.
+
+After `/aif-done`, `/aif-commit` may read finalization evidence and OpenSpec archive/spec mutations, but must not mutate OpenSpec lifecycle artifacts manually.
 
 ## Legacy Artifact Boundaries
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -85,6 +85,31 @@ paths:
 
 Do not route users to OpenSpec slash commands such as `/opsx:propose`, `/opsx:apply`, or `/opsx:archive`.
 
+## Artifact Sync Points
+
+Recommended sync points:
+
+- after `/aif-plan full` or `/aif-improve`: `/aif-mode sync --change <change-id>`
+- after spec/task edits during implementation or fix: `/aif-mode sync --change <change-id>`
+- after `/aif-done` archive: `/aif-mode sync`
+
+`/aif-mode sync` compiles generated rules and requests OpenSpec validation/status when configured and available. Missing OpenSpec CLI is degraded mode for sync validation, not an install failure.
+
+When no active changes exist after archive, `/aif-mode sync` still refreshes `.ai-factory/rules/generated/openspec-base.md` from `openspec/specs/**`, skips change-specific generated rules, skips change validation, writes a sync report, and returns OK.
+
+For `/aif-mode sync --all`, selected active changes without `openspec/changes/<change-id>/specs/**/spec.md` delta specs are reported as `no-delta-specs` warnings and skipped for sync validation. Changes with delta specs are still validated/statused when the CLI is available.
+
+## Rules Gate
+
+`/aif-rules-check` is read-only. It uses AIFHub generated rules in OpenSpec-native mode and returns a machine-readable `aif-gate-result` with `gate: "rules"`.
+
+If generated rules are missing or stale, run:
+
+```text
+/aif-mode sync --change <change-id>
+/aif-rules-check
+```
+
 ## Mode Controller
 
 `/aif-mode` is the extension-owned controller for artifact protocol changes:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,15 +5,42 @@
 This guide documents the v1 OpenSpec-native workflow for AIFHub Extension.
 
 ```text
-/aif-mode status
-/aif-analyze
-  -> /aif-plan full "<request>"
-  -> optional /aif-explore "<topic>"
-  -> optional /aif-improve <change-id>
-  -> /aif-implement <change-id>
-  -> /aif-verify <change-id>
-      fail -> /aif-fix <change-id> -> /aif-verify <change-id>
-  -> /aif-done <change-id>
+setup and mode:
+  /aif-mode status                                  # recommended
+  /aif-analyze                                      # required once per project
+  /aif-mode openspec                                # required when switching modes
+  /aif-mode doctor                                  # optional readiness check
+
+optional discovery:
+  /aif-explore "<topic>"                            # optional
+  /aif-grounded "<question>"                        # optional upstream certainty gate
+
+planning:
+  /aif-plan full "<request>"                        # required
+  /aif-improve <change-id>                          # optional, repeatable
+  /aif-mode sync --change <change-id>               # recommended
+
+implementation:
+  /aif-implement <change-id>                        # required
+
+optional gates:
+  /aif-mode sync --change <change-id>               # optional if specs/rules changed
+  /aif-rules-check                                  # optional/recommended rules gate
+  /aif-review                                       # optional read-only review gate
+  /aif-security-checklist                           # optional for security-sensitive changes
+
+verification:
+  /aif-verify <change-id>                           # required
+    fail -> /aif-fix <change-id>                    # required only after failed verify
+         -> optional /aif-rules-check
+         -> /aif-verify <change-id>
+
+finalization:
+  /aif-mode doctor --change <change-id>             # recommended before archive
+  /aif-done <change-id>                             # required after passing verify
+  /aif-mode sync                                    # recommended after archive
+  /aif-commit                                       # recommended AI Factory commit gate
+  /aif-evolve                                       # optional learning step
 ```
 
 OpenSpec-native mode uses OpenSpec artifacts as canonical planning/spec artifacts and AI Factory paths for runtime state, QA evidence, and generated rules.
@@ -71,6 +98,12 @@ Does not write:
 - runtime files under `openspec/changes/<change-id>/`
 
 Use `--dry-run` for planned switching or sync writes. Use `--all` or `--change <id>` to control change selection. Use `--export-openspec` only for compatibility legacy exports from OpenSpec changes. In OpenSpec mode, sync respects `aifhub.openspec.compileRulesOnSync` and `aifhub.openspec.validateOnSync`.
+
+`/aif-mode sync --change <change-id>` is recommended after `/aif-plan full` or `/aif-improve` and whenever canonical specs or tasks changed during implementation or fixes. It ensures OpenSpec skeleton paths, compiles `.ai-factory/rules/generated/openspec-base.md`, `.ai-factory/rules/generated/openspec-change-<change-id>.md`, and `.ai-factory/rules/generated/openspec-merged-<change-id>.md`, requests OpenSpec validation/status when the CLI is available and `validateOnSync` is enabled, detects legacy plans in OpenSpec mode, and writes a sync report under `.ai-factory/state/mode-switches/`.
+
+`/aif-mode sync` without `--change` is recommended after `/aif-done`. After archive, there may be no active change. Sync still refreshes `.ai-factory/rules/generated/openspec-base.md` from `openspec/specs/**`, skips change-specific generated rules and change validation when no active changes exist, and writes a sync report. OpenSpec skills are not installed.
+
+`/aif-mode sync --all` is a maintenance sweep. It refreshes generated rules for active changes, validates only selected changes that contain `openspec/changes/<change-id>/specs/**/spec.md` delta specs, and reports selected no-delta changes as `no-delta-specs` warnings instead of failing solely because old or docs-only active changes have no delta specs. `/aif-verify <change-id>` remains the stricter verification gate for a specific change.
 
 ### `/aif-analyze`
 
@@ -198,6 +231,67 @@ Does not write:
 - legacy `.ai-factory/plans/<id>/task.md`
 - canonical OpenSpec artifacts outside the selected implementation scope unless the user explicitly expands scope
 
+After implementation, optional read-only gates are available before final verification:
+
+```text
+/aif-rules-check
+/aif-review
+/aif-security-checklist
+```
+
+The authoritative final verification remains `/aif-verify <change-id>`.
+
+### `/aif-rules-check`
+
+Reads:
+
+- `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
+- `.ai-factory/rules/generated/openspec-change-<change-id>.md`
+- `.ai-factory/rules/generated/openspec-base.md`
+- `.ai-factory/RULES.md`
+- `.ai-factory/rules/base.md`
+- optional canonical OpenSpec context under `openspec/specs/**` and `openspec/changes/<change-id>/**`
+
+Writes:
+
+- none
+
+`/aif-rules-check` is optional after implementation or fixes and useful for strict/high-risk changes. In OpenSpec-native mode it uses generated rules first, returns a final `aif-gate-result` with `gate: "rules"`, and does not regenerate generated rules.
+
+If generated rules are missing or stale:
+
+```text
+/aif-rules-check
+/aif-mode sync --change <change-id>
+/aif-rules-check
+```
+
+### `/aif-review`
+
+Reads:
+
+- changed files
+- OpenSpec context and generated rules when available
+
+Writes:
+
+- none
+
+`/aif-review` is an optional read-only code review gate. It returns a final `aif-gate-result` with `gate: "review"`, is useful before `/aif-verify` or for high-risk changes, and does not write OpenSpec, runtime, or QA artifacts.
+
+### `/aif-security-checklist`
+
+Reads:
+
+- changed files
+- OpenSpec context and generated rules when available
+
+Writes:
+
+- none
+
+`/aif-security-checklist` is an optional security gate. It is recommended for auth, secrets, permissions, filesystem, shell, external service, API boundary, or data-handling changes. It returns a final `aif-gate-result` with `gate: "security"` and does not write artifacts.
+
 ### `/aif-verify`
 
 Reads:
@@ -275,6 +369,40 @@ Does not write:
 
 Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true.
 
+Next steps after `/aif-done`:
+
+1. Run `/aif-mode sync` to refresh derived artifacts after OpenSpec archive.
+2. Run `/aif-commit` to commit implementation, OpenSpec archive/spec changes, QA evidence, and final summaries.
+3. Optionally run `/aif-evolve` when the change produced durable workflow or skill learnings.
+
+`/aif-done` finalizes the OpenSpec lifecycle. It does not replace `/aif-commit`.
+
+### `/aif-commit`
+
+Reads:
+
+- staged changes and current diff
+- `.ai-factory/qa/<change-id>/done.md` when present
+- `.ai-factory/qa/<change-id>/openspec-archive.json` when present
+- `.ai-factory/state/<change-id>/final-summary.md` when present
+- OpenSpec archive/spec changes produced by `/aif-done`
+
+Writes:
+
+- git commit through the upstream AI Factory commit workflow
+
+Does not write:
+
+- OpenSpec lifecycle artifacts manually
+- `.ai-factory/qa/<change-id>/`
+- `.ai-factory/state/<change-id>/`
+
+In OpenSpec-native mode, `/aif-commit` normally runs after `/aif-done`.
+
+### `/aif-evolve`
+
+`/aif-evolve` is optional after commit/finalization. Use it when the implementation, fix, or finalization evidence contains durable lessons that should improve future skills or skill-context. It should not mutate OpenSpec canonical artifacts.
+
 ## OAuth Example
 
 Create the change:
@@ -295,13 +423,19 @@ openspec/changes/add-oauth-login/
       spec.md
 ```
 
-Refine, implement, verify, and finalize:
+Refine, sync, implement, gate, verify, finalize, sync, commit, and optionally evolve:
 
 ```text
 /aif-improve add-oauth-login
+/aif-mode sync --change add-oauth-login
 /aif-implement add-oauth-login
+/aif-rules-check
 /aif-verify add-oauth-login
+/aif-mode doctor --change add-oauth-login
 /aif-done add-oauth-login
+/aif-mode sync
+/aif-commit
+/aif-evolve
 ```
 
 Expected runtime and QA output:
@@ -383,8 +517,11 @@ Refresh derived artifacts without changing mode:
 
 ```text
 /aif-mode sync --change <change-id>
+/aif-mode sync
 /aif-mode doctor
 ```
+
+Use `/aif-mode sync --change <change-id>` before implementation and after refinement. Use `/aif-mode sync` after `/aif-done` to refresh base generated rules from accepted specs after archive.
 
 ## Recommended Codex App Flow
 
@@ -395,11 +532,15 @@ Codex cannot switch modes from extension prompts. The user controls the mode man
 /aif-explore "task description"
 /aif-plan full "task description"
 /aif-improve <change-id>
+/aif-mode sync --change <change-id>
 
 # Default mode, user action
 /aif-implement <change-id>
+/aif-rules-check
 /aif-verify <change-id>
 /aif-done <change-id>
+/aif-mode sync
+/aif-commit
 ```
 
 In Codex Default mode, prompts must ask plain-text questions rather than using `request_user_input`.

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json",
   "name": "aifhub-extension",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Upstream-first extension for AI Factory 2.11+: bootstrap remains extension-owned; `aif-plan`, `aif-implement`, `aif-verify`, and `aif-fix` connect through injections; upstream `aif-rules-check` is augmented by the AIFHub OpenSpec generated-rules injection; `aif-done` and `aif-mode` remain extension-owned finalizers/orchestrators; Codex and Claude runtime files publish through top-level `agentFiles`.",
   "commands": [
     {

--- a/injections/core/aif-implement-plan-folder.md
+++ b/injections/core/aif-implement-plan-folder.md
@@ -77,6 +77,14 @@ Normal implementation responses should report:
 - task progress from the OpenSpec `tasks.md`;
 - next step `/aif-verify <change-id>` when implementation is ready.
 
+After implementation, optional read-only gates are:
+
+- `/aif-rules-check`
+- `/aif-review`
+- `/aif-security-checklist`
+
+The authoritative final verification remains `/aif-verify <change-id>`.
+
 Do not install OpenSpec skills or slash commands.
 Do not route users to deprecated workflow aliases or legacy `*-plus` command names.
 

--- a/injections/core/aif-rules-check-openspec-generated-rules.md
+++ b/injections/core/aif-rules-check-openspec-generated-rules.md
@@ -39,7 +39,7 @@ Load rules in this priority order:
 
 OpenSpec-native mode does not require plan-local `rules.md`. Ignore plan-local `rules.md` unless the run is explicitly in Legacy AI Factory-only mode.
 
-If generated rules are missing or stale, return `WARN`, report which generated rules are present, missing, or stale, and ask the caller to regenerate rules through the compiler-owning workflow such as `/aif-mode sync`. This gate must not regenerate or edit generated rules.
+If generated rules are missing or stale, return `WARN`, report which generated rules are present, missing, or stale, and ask the caller to regenerate rules through the compiler-owning workflow: `/aif-mode sync --change <change-id>`, then rerun `/aif-rules-check`. This gate must not regenerate or edit generated rules.
 
 Runtime state and QA evidence are external context only:
 

--- a/injections/core/aif-verify-plan-folder.md
+++ b/injections/core/aif-verify-plan-folder.md
@@ -80,6 +80,8 @@ Normal verification responses should report:
 - fix guidance `/aif-fix <change-id>` when verification fails;
 - optional finalization guidance `/aif-done <change-id>` when verification passes.
 
+Optional read-only gates before or during verification are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
+
 End verification output and `.ai-factory/qa/<change-id>/verify.md` with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase JSON `status`: `pass`, `warn`, or `fail`. Use `fail` for blocking OpenSpec validation, test, lint, build, review, security, or rules failures; use `warn` only for non-blocking notes after verification completes.
 
 Do not install OpenSpec skills or slash commands.

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -259,7 +259,7 @@ export async function syncOpenSpecArtifacts(options = {}) {
       ...options,
       rootDir,
       changeIds: changes.changeIds,
-      skipNoDeltaChanges: true
+      skipNoDeltaChanges: Boolean(options.all)
     })
     : createSkippedValidationSync('validateOnSync-disabled');
   const legacy = await discoverLegacyPlans({ rootDir });

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -9,6 +9,7 @@ import {
   writeCurrentChangePointer
 } from './active-change-resolver.mjs';
 import {
+  compileOpenSpecBaseRules,
   collectOpenSpecRuleSources,
   compileOpenSpecRules,
   renderGeneratedRules
@@ -257,7 +258,8 @@ export async function syncOpenSpecArtifacts(options = {}) {
     ? await validateOpenSpecChanges({
       ...options,
       rootDir,
-      changeIds: changes.changeIds
+      changeIds: changes.changeIds,
+      skipNoDeltaChanges: true
     })
     : createSkippedValidationSync('validateOnSync-disabled');
   const legacy = await discoverLegacyPlans({ rootDir });
@@ -721,6 +723,27 @@ async function syncGeneratedRules(options = {}) {
   const changeIds = Array.from(options.changeIds ?? []);
   const results = [];
 
+  if (changeIds.length === 0) {
+    const result = await compileOpenSpecBaseRules({ ...options, rootDir, dryRun });
+
+    return {
+      ok: result.ok,
+      dryRun,
+      baseOnly: true,
+      changeSpecificSkipped: true,
+      results: [result],
+      files: result.files ?? [],
+      warnings: dedupeDiagnostics([
+        ...(result.warnings ?? []),
+        {
+          code: 'no-active-change-specific-rules',
+          message: 'No active OpenSpec changes were selected; refreshed base generated rules only.'
+        }
+      ]),
+      errors: result.errors ?? []
+    };
+  }
+
   for (const changeId of changeIds) {
     if (dryRun) {
       const collected = await collectOpenSpecRuleSources(changeId, { ...options, rootDir });
@@ -767,6 +790,46 @@ async function syncGeneratedRules(options = {}) {
 async function validateOpenSpecChanges(options = {}) {
   const rootDir = resolveRootDir(options);
   const changeIds = Array.from(options.changeIds ?? []);
+
+  if (changeIds.length === 0) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'no-selected-changes',
+      detection: null,
+      results: [],
+      skippedChanges: [],
+      warnings: [
+        {
+          code: 'no-selected-changes',
+          message: 'OpenSpec validation skipped because no active changes were selected.'
+        }
+      ],
+      errors: []
+    };
+  }
+
+  const selected = options.skipNoDeltaChanges
+    ? await selectValidatableChanges(rootDir, changeIds)
+    : {
+      changeIds,
+      skippedChanges: [],
+      warnings: []
+    };
+
+  if (selected.changeIds.length === 0) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'no-validatable-changes',
+      detection: null,
+      results: [],
+      skippedChanges: selected.skippedChanges,
+      warnings: selected.warnings,
+      errors: []
+    };
+  }
+
   const detection = await detectOpenSpecCapability(rootDir, options);
 
   if (!detection.canValidate) {
@@ -776,7 +839,11 @@ async function validateOpenSpecChanges(options = {}) {
       reason: detection.reason ?? 'openspec-cli-unavailable',
       detection: summarizeOpenSpecDetection(detection),
       results: [],
-      warnings: normalizeDetectionWarnings(detection),
+      skippedChanges: selected.skippedChanges,
+      warnings: dedupeDiagnostics([
+        ...selected.warnings,
+        ...normalizeDetectionWarnings(detection)
+      ]),
       errors: []
     };
   }
@@ -785,7 +852,7 @@ async function validateOpenSpecChanges(options = {}) {
   const getOpenSpecStatus = options.getOpenSpecStatus ?? defaultGetOpenSpecStatus;
   const results = [];
 
-  for (const changeId of changeIds) {
+  for (const changeId of selected.changeIds) {
     const validation = await validateOpenSpecChange(changeId, createRunOptions(rootDir, options));
     const status = validation.ok
       ? await getOpenSpecStatus(changeId, createRunOptions(rootDir, options))
@@ -804,13 +871,43 @@ async function validateOpenSpecChanges(options = {}) {
     skipped: false,
     detection: summarizeOpenSpecDetection(detection),
     results,
-    warnings: [],
+    skippedChanges: selected.skippedChanges,
+    warnings: selected.warnings,
     errors: results
       .filter((result) => !result.ok)
       .map((result) => ({
         code: 'openspec-validation-failed',
         message: `OpenSpec validation/status failed for '${result.changeId}'.`
       }))
+  };
+}
+
+async function selectValidatableChanges(rootDir, changeIds) {
+  const validatable = [];
+  const skippedChanges = [];
+
+  for (const changeId of changeIds) {
+    const specRoot = path.join(rootDir, 'openspec', 'changes', changeId, 'specs');
+    const specFiles = await listSpecFiles(specRoot, rootDir);
+
+    if (specFiles.length === 0) {
+      skippedChanges.push({
+        changeId,
+        reason: 'no-delta-specs'
+      });
+      continue;
+    }
+
+    validatable.push(changeId);
+  }
+
+  return {
+    changeIds: validatable,
+    skippedChanges,
+    warnings: skippedChanges.map((item) => ({
+      code: 'no-delta-specs',
+      message: `OpenSpec validation skipped for '${item.changeId}' because the change has no delta spec files.`
+    }))
   };
 }
 
@@ -1674,6 +1771,8 @@ function renderGeneratedRulesSection(generatedRules) {
     '## Generated Rules',
     '',
     `Files: ${generatedRules.files.length}`,
+    `Base-only sync: ${generatedRules.baseOnly ? 'yes' : 'no'}`,
+    `Change-specific rules skipped: ${generatedRules.changeSpecificSkipped ? 'yes' : 'no'}`,
     ...renderDiagnostics('Warnings', generatedRules.warnings),
     ...renderDiagnostics('Errors', generatedRules.errors)
   ].join('\n');
@@ -1685,6 +1784,7 @@ function renderValidationSection(validation) {
     '',
     `Skipped: ${validation.skipped ? 'yes' : 'no'}`,
     `Results: ${validation.results.length}`,
+    `Skipped changes: ${validation.skippedChanges?.length ?? 0}`,
     ...renderDiagnostics('Warnings', validation.warnings),
     ...renderDiagnostics('Errors', validation.errors)
   ].join('\n');

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -244,8 +244,177 @@ describe('artifact sync and export', () => {
     });
 
     assert.equal(result.ok, true);
+    assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md'), /No base OpenSpec requirements found/);
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-change-add-mfa.md'), /Requirement: Require MFA/);
+    assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-merged-add-mfa.md'), /Requirement: Require MFA/);
+    assert.equal(result.validation.skipped, true);
+    assert.equal(result.validation.reason, 'missing-cli');
     assert.equal(await pathExists(rootDir, '.ai-factory/state/mode-switches/2026-04-29T00-00-00-000Z-sync-openspec.md'), true);
+  });
+
+  it('syncs generated rules for all active OpenSpec changes', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## Requirements',
+      '',
+      '### Requirement: Base Auth',
+      '',
+      'The system MUST preserve accepted authentication behavior.',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-mfa/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-mfa/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Require MFA',
+      '',
+      'The system MUST require MFA for administrators.',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-passkeys/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-passkeys/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Support Passkeys',
+      '',
+      'The system MUST support passkey sign-in.',
+      ''
+    ].join('\n'));
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      all: true,
+      detectOpenSpec: async () => missingCliDetection(),
+      timestamp: '2026-04-29T01-00-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.changes.changeIds, ['add-mfa', 'add-passkeys']);
+    assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md'), /Requirement: Base Auth/);
+    assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-change-add-mfa.md'), /Requirement: Require MFA/);
+    assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-merged-add-passkeys.md'), /Requirement: Support Passkeys/);
+  });
+
+  it('skips sync validation for active changes without delta specs', async () => {
+    const rootDir = await createTempRoot();
+    const validated = [];
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/changes/docs-only/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-mfa/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-mfa/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Require MFA',
+      '',
+      'The system MUST require MFA for administrators.',
+      '',
+      '#### Scenario: administrator signs in',
+      '',
+      '- GIVEN an administrator account',
+      '- WHEN the administrator signs in',
+      '- THEN an MFA challenge is required',
+      ''
+    ].join('\n'));
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      all: true,
+      detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async (changeId) => {
+        validated.push(changeId);
+        return { ok: true, stdout: '{"valid":true}', stderr: '', json: { valid: true } };
+      },
+      getOpenSpecStatus: async (changeId) => ({
+        ok: true,
+        stdout: JSON.stringify({ changeId }),
+        stderr: '',
+        json: { changeId }
+      }),
+      timestamp: '2026-04-29T01-30-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(validated, ['add-mfa']);
+    assert.equal(result.validation.results.length, 1);
+    assert.equal(result.validation.skippedChanges.length, 1);
+    assert.equal(result.validation.skippedChanges[0].changeId, 'docs-only');
+    assert.ok(result.validation.warnings.some((warning) => warning.code === 'no-delta-specs'));
+  });
+
+  it('refreshes base generated rules after archive when no active changes exist', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## Requirements',
+      '',
+      '### Requirement: Accepted Auth',
+      '',
+      'The system MUST support accepted authentication.',
+      ''
+    ].join('\n'));
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      getCurrentBranch: async () => 'main',
+      timestamp: '2026-04-29T02-00-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changes.source, 'none');
+    assert.deepEqual(result.changes.changeIds, []);
+    assert.equal(result.generatedRules.baseOnly, true);
+    assert.equal(result.generatedRules.changeSpecificSkipped, true);
+    assert.equal(result.validation.skipped, true);
+    assert.equal(result.validation.reason, 'no-selected-changes');
+    assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md'), /Requirement: Accepted Auth/);
+    assert.equal(await pathExists(rootDir, '.ai-factory/rules/generated/openspec-change-accepted-auth.md'), false);
+    assert.equal(await pathExists(rootDir, 'openspec/changes/.ai-factory'), false);
+    assert.equal(await pathExists(rootDir, '.ai-factory/state/mode-switches/2026-04-29T02-00-00-000Z-sync-openspec.md'), true);
   });
 
   it('respects compileRulesOnSync and validateOnSync config toggles', async () => {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -372,6 +372,61 @@ describe('artifact sync and export', () => {
     assert.ok(result.validation.warnings.some((warning) => warning.code === 'no-delta-specs'));
   });
 
+  it('does not skip no-delta validation for targeted sync', async () => {
+    const rootDir = await createTempRoot();
+    const validated = [];
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/changes/docs-only/proposal.md', '# Proposal\n');
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      changeId: 'docs-only',
+      detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async (changeId) => {
+        validated.push(changeId);
+        return {
+          ok: false,
+          stdout: '',
+          stderr: 'Change must have at least one delta.',
+          json: null,
+          errors: [
+            {
+              code: 'openspec-validation-failed',
+              message: 'Change must have at least one delta.'
+            }
+          ]
+        };
+      },
+      getOpenSpecStatus: async (changeId) => ({
+        ok: true,
+        stdout: JSON.stringify({ changeId }),
+        stderr: '',
+        json: { changeId }
+      }),
+      timestamp: '2026-04-29T01-45-00-000Z'
+    });
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(validated, ['docs-only']);
+    assert.equal(result.validation.skipped, false);
+    assert.deepEqual(result.validation.skippedChanges, []);
+    assert.equal(result.validation.results.length, 1);
+    assert.equal(result.validation.results[0].changeId, 'docs-only');
+    assert.ok(result.validation.errors.some((error) => error.code === 'openspec-validation-failed'));
+    assert.ok(!result.validation.warnings.some((warning) => warning.code === 'no-delta-specs'));
+  });
+
   it('refreshes base generated rules after archive when no active changes exist', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, '.ai-factory/config.yaml', [

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -1,0 +1,114 @@
+// docs-workflow-contract.test.mjs - docs coverage for the complete OpenSpec workflow tail
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+async function readRepoFile(relativePath) {
+  return readFile(join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function assertIncludes(source, expected, label) {
+  assert.ok(source.includes(expected), `${label} should include ${JSON.stringify(expected)}`);
+}
+
+function assertOrder(source, orderedFragments, label) {
+  let cursor = -1;
+
+  for (const fragment of orderedFragments) {
+    const index = source.indexOf(fragment, cursor + 1);
+    assert.notEqual(index, -1, `${label} should include ${JSON.stringify(fragment)} after index ${cursor}`);
+    assert.ok(index > cursor, `${label} should order ${JSON.stringify(fragment)} after previous fragment`);
+    cursor = index;
+  }
+}
+
+function extractSection(markdown, heading) {
+  const lines = markdown.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.trim() === heading);
+  assert.notEqual(startIndex, -1, `Expected heading ${heading}`);
+  const level = heading.match(/^#+/)?.[0].length ?? 1;
+  let endIndex = lines.length;
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(#{1,6})\s+/);
+    if (match && match[1].length <= level) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+describe('complete OpenSpec workflow documentation contract', () => {
+  it('documents the complete quick-start tail in README.md in workflow order', async () => {
+    const readme = await readRepoFile('README.md');
+    const quickStart = extractSection(readme, '## Quick Start');
+
+    for (const expected of [
+      '/aif-mode sync --change add-oauth-login',
+      '/aif-rules-check',
+      '/aif-review',
+      '/aif-security-checklist',
+      '/aif-verify add-oauth-login',
+      '/aif-done add-oauth-login',
+      '/aif-mode sync',
+      '/aif-commit',
+      '/aif-evolve'
+    ]) {
+      assertIncludes(quickStart, expected, 'README.md Quick Start');
+    }
+
+    assertOrder(quickStart, [
+      '/aif-plan full "add OAuth login"',
+      '/aif-improve add-oauth-login',
+      '/aif-mode sync --change add-oauth-login',
+      '/aif-implement add-oauth-login',
+      '/aif-rules-check',
+      '/aif-verify add-oauth-login',
+      '/aif-done add-oauth-login',
+      '/aif-mode sync',
+      '/aif-commit',
+      '/aif-evolve'
+    ], 'README.md Quick Start');
+
+    assertIncludes(quickStart, '/aif-done` finalizes the OpenSpec lifecycle', 'README.md Quick Start');
+    assertIncludes(quickStart, 'It does not replace `/aif-commit`', 'README.md Quick Start');
+  });
+
+  it('documents the complete manual workflow in docs/usage.md in workflow order', async () => {
+    const usage = await readRepoFile('docs/usage.md');
+
+    for (const expected of [
+      '/aif-mode sync --change <change-id>',
+      '/aif-rules-check',
+      '/aif-review',
+      '/aif-security-checklist',
+      '/aif-verify <change-id>',
+      '/aif-done <change-id>',
+      '/aif-mode sync',
+      '/aif-commit',
+      '/aif-evolve',
+      'required',
+      'recommended',
+      'optional'
+    ]) {
+      assertIncludes(usage, expected, 'docs/usage.md');
+    }
+
+    assertOrder(usage, [
+      '/aif-plan full "<request>"',
+      '/aif-implement <change-id>',
+      '/aif-verify <change-id>',
+      '/aif-done <change-id>',
+      '/aif-mode sync',
+      '/aif-commit',
+      '/aif-evolve'
+    ], 'docs/usage.md workflow');
+  });
+});

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -27,6 +27,12 @@ const VERIFY_PROMPT_ASSETS = [
   'agent-files/claude/aifhub-verifier.md'
 ];
 
+const IMPLEMENT_PROMPT_ASSETS = [
+  'injections/core/aif-implement-plan-folder.md',
+  'agent-files/codex/aifhub-implement-worker.toml',
+  'agent-files/claude/aifhub-implement-worker.md'
+];
+
 const PLAN_POLISHER_PROMPT_ASSETS = [
   'agent-files/codex/aifhub-plan-polisher.toml',
   'agent-files/claude/aifhub-plan-polisher.md'
@@ -37,6 +43,15 @@ const DONE_PROMPT_ASSETS = [
   'skills/aif-done/references/finalization-contract.md',
   'agent-files/codex/aifhub-done-finalizer.toml',
   'agent-files/claude/aifhub-done-finalizer.md'
+];
+
+const SIDECAR_PROMPT_ASSETS = [
+  ['agent-files/codex/aifhub-rules-sidecar.toml', 'rules'],
+  ['agent-files/claude/aifhub-rules-sidecar.md', 'rules'],
+  ['agent-files/codex/aifhub-review-sidecar.toml', 'review'],
+  ['agent-files/claude/aifhub-review-sidecar.md', 'review'],
+  ['agent-files/codex/aifhub-security-sidecar.toml', 'security'],
+  ['agent-files/claude/aifhub-security-sidecar.md', 'security']
 ];
 
 const CANONICAL_CHANGE_FILES = [
@@ -434,6 +449,63 @@ describe('OpenSpec-native prompt asset contract', () => {
         /archive integration (?:is )?deferred to issue #33|deferred archive status/i,
         `${relativePath} should no longer describe OpenSpec archive integration as deferred`
       );
+    }
+  });
+
+  it('requires done prompts to hand off to sync, commit, and optional evolve without replacing commit', async () => {
+    for (const relativePath of DONE_PROMPT_ASSETS) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      for (const expected of [
+        '/aif-mode sync',
+        '/aif-commit',
+        '/aif-evolve'
+      ]) {
+        assertIncludes(asset, expected, relativePath);
+      }
+
+      assert.match(
+        asset,
+        /do not (?:create|make) commits|does not create commits|never create commits/i,
+        `${relativePath} should forbid commit creation from done finalization`
+      );
+      assert.match(
+        asset,
+        /do not (?:create|open) PRs|does not create PRs|never auto-create PRs/i,
+        `${relativePath} should forbid PR creation from done finalization`
+      );
+      assert.match(
+        asset,
+        /does not replace `?\/aif-commit`?|do not present `?\/aif-done`?.*replac(?:e|ing) `?\/aif-commit`?/i,
+        `${relativePath} should state that /aif-done does not replace /aif-commit`
+      );
+    }
+  });
+
+  it('mentions optional read-only gates in implement and verifier prompts while preserving authoritative verify', async () => {
+    for (const relativePath of [...IMPLEMENT_PROMPT_ASSETS, ...VERIFY_PROMPT_ASSETS]) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      for (const expected of [
+        '/aif-rules-check',
+        '/aif-review',
+        '/aif-security-checklist'
+      ]) {
+        assertIncludes(asset, expected, relativePath);
+      }
+
+      assert.match(
+        asset,
+        /authoritative final verification remains `?\/aif-verify <change-id>`?|\/aif-verify <change-id>.*authoritative final verification/i,
+        `${relativePath} should keep /aif-verify as authoritative final verification`
+      );
+    }
+  });
+
+  it('keeps sidecar prompt assets on explicit rules, review, and security gate values', async () => {
+    for (const [relativePath, gate] of SIDECAR_PROMPT_ASSETS) {
+      const asset = await readRepoFile(relativePath);
+      assertIncludes(asset, `"gate": "${gate}"`, relativePath);
     }
   });
 

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -151,6 +151,89 @@ export async function collectOpenSpecRuleSources(changeId, options = {}) {
   });
 }
 
+export async function compileOpenSpecBaseRules(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const collected = await collectOpenSpecBaseRuleSources({
+    ...options,
+    rootDir
+  });
+
+  if (!collected.ok) {
+    return createCompilerResult({
+      ok: false,
+      changeId: null,
+      mode: collected.mode,
+      warnings: collected.warnings,
+      errors: collected.errors,
+      sources: collected.sources
+    });
+  }
+
+  const rendered = renderDocument({
+    kind: 'base',
+    title: 'Base OpenSpec Rules',
+    changeId: null,
+    sources: sortSources(collected.sources),
+    emptyMessage: 'No base OpenSpec requirements found.'
+  });
+  const written = await writeGeneratedBaseRules(rendered, {
+    ...options,
+    rootDir
+  });
+
+  if (!written.ok) {
+    return createCompilerResult({
+      ok: false,
+      changeId: null,
+      mode: collected.mode,
+      warnings: [...collected.warnings, ...written.warnings],
+      errors: written.errors,
+      sources: collected.sources,
+      files: written.files
+    });
+  }
+
+  return createCompilerResult({
+    ok: true,
+    changeId: null,
+    mode: collected.mode,
+    warnings: [...collected.warnings, ...written.warnings],
+    errors: [],
+    sources: collected.sources,
+    files: written.files
+  });
+}
+
+async function collectOpenSpecBaseRuleSources(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const warnings = [];
+  const cli = await detectOpenSpecCapability(rootDir, options);
+  warnings.push(...cli.warnings);
+
+  const baseSpecsDir = path.join(rootDir, 'openspec', 'specs');
+  const baseFiles = await collectSpecFiles(baseSpecsDir);
+  const sources = [];
+
+  for (const filePath of baseFiles) {
+    const source = await readRuleSource(filePath, {
+      rootDir,
+      kind: 'base',
+      specsDir: baseSpecsDir,
+      changeId: null,
+      cli
+    });
+    warnings.push(...source.warnings);
+    sources.push(source.item);
+  }
+
+  return createSourceResult({
+    ok: true,
+    mode: chooseMode(sources, cli),
+    warnings: dedupeDiagnostics(warnings),
+    sources: sortSources(sources)
+  });
+}
+
 export function renderGeneratedRules(sources, options = {}) {
   const normalized = normalizeChangeId(options.changeId);
   const changeId = normalized.ok ? normalized.changeId : options.changeId;
@@ -271,6 +354,53 @@ export async function writeGeneratedRules(changeId, rendered, options = {}) {
   return createWriteResult({
     ok: true,
     files
+  });
+}
+
+async function writeGeneratedBaseRules(content, options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const generatedDir = path.resolve(rootDir, GENERATED_DIR);
+  const targetPath = path.resolve(generatedDir, BASE_FILE);
+  const relativePath = toPosix(path.relative(rootDir, targetPath));
+
+  if (!isWithinDirectory(targetPath, generatedDir)) {
+    return createWriteResult({
+      errors: [
+        {
+          code: 'unsafe-generated-path',
+          message: `Generated output path escapes '${GENERATED_DIR}': ${BASE_FILE}`
+        }
+      ]
+    });
+  }
+
+  if (options.dryRun) {
+    return createWriteResult({
+      ok: true,
+      files: [
+        {
+          kind: 'base',
+          path: targetPath,
+          relativePath,
+          written: false
+        }
+      ]
+    });
+  }
+
+  await mkdir(generatedDir, { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+
+  return createWriteResult({
+    ok: true,
+    files: [
+      {
+        kind: 'base',
+        path: targetPath,
+        relativePath,
+        written: true
+      }
+    ]
   });
 }
 

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -79,7 +79,19 @@ Normal output must report:
 - runtime state and QA evidence paths;
 - final evidence under `.ai-factory/qa/<change-id>/`;
 - final summaries under `.ai-factory/state/<change-id>/`;
-- commit/PR summary draft.
+- commit/PR summary draft;
+- next steps: `/aif-mode sync`, `/aif-commit`, and optional `/aif-evolve`.
+
+### Post-Finalization Handoff
+
+After successful finalization:
+
+1. Recommend `/aif-mode sync` to refresh derived artifacts after archive.
+2. Recommend `/aif-commit` as the next AI Factory command.
+3. Optionally recommend `/aif-evolve` when durable learning evidence exists.
+4. Do not create commits automatically.
+5. Do not create PRs automatically.
+6. `/aif-done` does not replace `/aif-commit`.
 
 ## Legacy AI Factory-only mode
 
@@ -183,9 +195,10 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 - Never invent governance changes without evidence from the verified plan.
 - When governance updates belong to another owner, use the owning path or return an exact handoff instead of silently skipping the change.
 - Never auto-create a PR — always present drafts for user approval.
+- Never create commits from `/aif-done`; hand commit creation to `/aif-commit` or the user's normal git workflow.
 - If `gh` is unavailable, provide manual instructions instead of failing.
 - Keep direct archival writes bounded to the plan status, specs directory, and specs index.
-- Do not reintroduce `/aif-done` as the canonical upstream workflow step — this is an AIFHub/Handoff finalizer only.
+- Do not reintroduce `/aif-done` as the canonical upstream workflow step, and do not present `/aif-done` as replacing `/aif-commit`.
 
 ## Example Requests
 

--- a/skills/aif-done/references/finalization-contract.md
+++ b/skills/aif-done/references/finalization-contract.md
@@ -69,7 +69,16 @@ Do not write runtime-only files into `openspec/changes/<change-id>/`.
 
 ### Output
 
-Report selected `change-id`, verification status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, `--skip-specs` state, commit draft, and PR draft.
+Report selected `change-id`, verification status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, `--skip-specs` state, commit draft, PR draft, and next steps: `/aif-mode sync`, `/aif-commit`, and optional `/aif-evolve`.
+
+After successful finalization:
+
+1. Recommend `/aif-mode sync` to refresh derived artifacts after archive.
+2. Recommend `/aif-commit` as the next AI Factory command.
+3. Optionally recommend `/aif-evolve` when durable learning evidence exists.
+4. Do not create commits automatically.
+5. Do not create PRs automatically.
+6. `/aif-done` does not replace `/aif-commit`.
 
 ## Legacy AI Factory-only mode
 
@@ -145,6 +154,8 @@ Apply only when the verified plan contains evidence:
 | Evolution candidates identified | Run `/aif-evolve` when explicitly requested and supported, otherwise recommend it |
 
 Never invent governance changes without plan evidence. If the current runtime cannot safely perform the owning update, return the exact next command/instruction instead of silently skipping it.
+
+OpenSpec-native `/aif-done` prepares commit and PR drafts only. It does not create commits, does not create PRs, and does not replace `/aif-commit`.
 
 ## Status Update on Finalization
 

--- a/skills/aif-mode/SKILL.md
+++ b/skills/aif-mode/SKILL.md
@@ -91,6 +91,7 @@ When `--export-openspec` is passed, export compatibility artifacts from OpenSpec
 Refresh derived or compatibility artifacts without changing mode.
 
 - In OpenSpec-native mode: ensure skeleton paths, compile generated rules when `compileRulesOnSync` is enabled, validate selected changes when `validateOnSync` is enabled and a compatible CLI is available, detect legacy plans, optionally update `.ai-factory/state/current.yaml` with `--current`, and write a sync report.
+- During `sync --all`, skip sync validation for selected changes that do not contain `openspec/changes/<id>/specs/**/spec.md` delta specs; report `no-delta-specs` warnings while still compiling generated rules and validating selected changes that do contain delta specs.
 - In AI Factory-only mode: ensure legacy paths, optionally export OpenSpec changes with `--export-openspec`, preserve OpenSpec artifacts, and write a sync report.
 
 ### `doctor`

--- a/skills/aif-mode/references/ARTIFACT-SYNC.md
+++ b/skills/aif-mode/references/ARTIFACT-SYNC.md
@@ -11,6 +11,10 @@ OpenSpec sync performs these actions without changing mode:
 5. Detect legacy plans that may need migration.
 6. Write a sync report under `.ai-factory/state/mode-switches/`.
 
+When no active changes are selected, sync still refreshes `.ai-factory/rules/generated/openspec-base.md`, skips change-specific generated rules, skips change validation with `no-selected-changes`, writes a report, and returns OK.
+
+When `--all` selects active changes that have no `openspec/changes/<change-id>/specs/**/spec.md` delta specs, sync reports `no-delta-specs` warnings and skips validation/status for those changes. This keeps maintenance sync usable for old migrated or docs-only active changes while preserving stricter per-change verification in `/aif-verify <change-id>`.
+
 Generated rules are derived artifacts:
 
 ```text


### PR DESCRIPTION
- Enhanced the usage documentation in `docs/usage.md` to clarify the OpenSpec-native workflow, including optional gates and finalization steps.
- Bumped version in `extension.json` from 1.0.8 to 1.0.9.
- Added details about optional read-only gates after implementation in `aif-implement-plan-folder.md`.
- Updated `aif-rules-check-openspec-generated-rules.md` to specify the process for handling missing or stale generated rules.
- Clarified verification process in `aif-verify-plan-folder.md` with optional gates before final verification.
- Improved artifact synchronization logic in `aif-artifact-sync.mjs` to handle cases with no active changes and to skip validation for changes without delta specs.
- Added tests for artifact synchronization and documentation workflow contracts to ensure compliance with the updated processes.
- Updated `SKILL.md` files for `aif-done` and `aif-mode` to reflect new recommendations and clarify the role of `/aif-commit`.
- Introduced new helper functions in `openspec-rules-compiler.mjs` for compiling base rules and handling validation of changes without delta specs.