### PR TITLE
Add GitHub-aware roadmap evidence sync

### DIFF
--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/code-verification.json
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/code-verification.json
@@ -1,0 +1,75 @@
+{
+  "changeId": "feat-add-github-aware-roadmap-sync",
+  "mode": "OpenSpec-native mode",
+  "verifyMode": "strict",
+  "verdict": "PASS-with-notes",
+  "blockingFindings": 0,
+  "warnings": [
+    {
+      "id": "roadmap-context-drift",
+      "severity": "warning",
+      "file": ".ai-factory/ROADMAP.md",
+      "summary": "Existing roadmap context is stale relative to current verification evidence; owner command is /aif-roadmap check."
+    },
+    {
+      "id": "line-ending-normalization-note",
+      "severity": "note",
+      "file": "injections/core/aif-roadmap-maturity-audit.md",
+      "summary": "git diff --check reported no whitespace errors, only a CRLF-to-LF normalization warning from Git."
+    }
+  ],
+  "commands": [
+    {
+      "command": "buildVerificationContext({ changeId })",
+      "status": "pass",
+      "summary": "OpenSpec validation/status evidence written; shouldRunCodeVerification=true."
+    },
+    {
+      "command": "node --test scripts/openspec-prompt-assets.test.mjs",
+      "status": "pass",
+      "summary": "18 tests passed."
+    },
+    {
+      "command": "npm run validate",
+      "status": "pass",
+      "summary": "Manifest, agent files, and docs link validation passed."
+    },
+    {
+      "command": "npm test",
+      "status": "pass",
+      "summary": "244 tests passed."
+    },
+    {
+      "command": "git diff --check",
+      "status": "pass",
+      "summary": "No whitespace errors; non-blocking CRLF/LF warning for roadmap injection."
+    },
+    {
+      "command": "rg unfinished markers/env refs in changed files",
+      "status": "pass",
+      "summary": "No TODO/FIXME/HACK/PLACEHOLDER/debug/env-var matches in changed files."
+    }
+  ],
+  "taskCompletion": {
+    "complete": 11,
+    "total": 11,
+    "note": "Commit Plan checkboxes were intentionally not marked; commit creation is outside /aif-verify ownership."
+  },
+  "contextGates": [
+    {
+      "gate": "Architecture",
+      "status": "PASS",
+      "summary": "Changes stay in prompt assets, references, docs, tests, and QA evidence; no runtime writes under canonical OpenSpec paths."
+    },
+    {
+      "gate": "Rules",
+      "status": "PASS",
+      "summary": "Project rules and ownership boundaries are respected; no bridge files or unrelated context writes were introduced."
+    },
+    {
+      "gate": "Roadmap",
+      "status": "WARN",
+      "summary": "Existing roadmap artifact is stale and has no direct milestone linkage for this feat; no contradiction with roadmap direction was found."
+    }
+  ]
+}

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/done.md
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/done.md
@@ -1,0 +1,74 @@
+# Done: feat-add-github-aware-roadmap-sync
+
+## Finalization status
+
+PASS
+
+## Verification gate
+
+PASS
+
+## OpenSpec archive
+
+Archived: yes
+Skip specs: no
+
+## Canonical artifacts finalized
+
+- openspec/changes/feat-add-github-aware-roadmap-sync/proposal.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/design.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/tasks.md
+- openspec/specs/openspec-cli-runner/spec.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/specs/roadmap-github-sync/spec.md
+
+## QA evidence
+
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/verify.md
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-archive.json
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/done.md
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-validation.json
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-status.json
+
+## Runtime traces
+
+- .ai-factory/state/feat-add-github-aware-roadmap-sync/implementation/run-2026-05-03T05-51-06-818Z.md
+
+## Working tree
+
+-  M README.md
+-  M docs/README.md
+-  M docs/context-loading-policy.md
+-  M docs/usage.md
+-  M injections/core/aif-roadmap-maturity-audit.md
+-  M injections/references/aif-roadmap/roadmap-template.md
+-  M injections/references/aif-roadmap/slice-checklist.md
+-  M scripts/openspec-prompt-assets.test.mjs
+
+## Suggested commit message
+
+feat: finalize feat-add-github-aware-roadmap-sync
+
+## Suggested PR summary
+
+## Summary
+
+- Finalized OpenSpec change `feat-add-github-aware-roadmap-sync`.
+- Prepared final QA and state summaries for `feat-add-github-aware-roadmap-sync`.
+
+## OpenSpec
+
+- Change: feat-add-github-aware-roadmap-sync
+- Archived: yes
+- Skip specs: no
+
+## Verification
+
+- /aif-verify: PASS
+- OpenSpec validation: PASS
+- Code verification: PASS
+
+## Artifacts
+
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/done.md
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-archive.json
+- .ai-factory/state/feat-add-github-aware-roadmap-sync/final-summary.md

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-archive.json
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-archive.json
@@ -1,0 +1,65 @@
+{
+  "changeId": "feat-add-github-aware-roadmap-sync",
+  "archived": true,
+  "skipSpecs": false,
+  "command": "openspec",
+  "args": [
+    "archive",
+    "feat-add-github-aware-roadmap-sync",
+    "--yes",
+    "--no-color"
+  ],
+  "exitCode": 0,
+  "ok": true,
+  "status": "PASS",
+  "preArchiveStatus": {
+    "ok": true,
+    "command": "openspec",
+    "args": [
+      "status",
+      "--change",
+      "feat-add-github-aware-roadmap-sync",
+      "--json",
+      "--no-color"
+    ],
+    "exitCode": 0,
+    "json": {
+      "changeName": "feat-add-github-aware-roadmap-sync",
+      "schemaName": "spec-driven",
+      "isComplete": true,
+      "applyRequires": [
+        "tasks"
+      ],
+      "artifacts": [
+        {
+          "id": "proposal",
+          "outputPath": "proposal.md",
+          "status": "done"
+        },
+        {
+          "id": "design",
+          "outputPath": "design.md",
+          "status": "done"
+        },
+        {
+          "id": "specs",
+          "outputPath": "specs/**/*.md",
+          "status": "done"
+        },
+        {
+          "id": "tasks",
+          "outputPath": "tasks.md",
+          "status": "done"
+        }
+      ]
+    },
+    "stdout": "{\n  \"changeName\": \"feat-add-github-aware-roadmap-sync\",\n  \"schemaName\": \"spec-driven\",\n  \"isComplete\": true,\n  \"applyRequires\": [\n    \"tasks\"\n  ],\n  \"artifacts\": [\n    {\n      \"id\": \"proposal\",\n      \"outputPath\": \"proposal.md\",\n      \"status\": \"done\"\n    },\n    {\n      \"id\": \"design\",\n      \"outputPath\": \"design.md\",\n      \"status\": \"done\"\n    },\n    {\n      \"id\": \"specs\",\n      \"outputPath\": \"specs/**/*.md\",\n      \"status\": \"done\"\n    },\n    {\n      \"id\": \"tasks\",\n      \"outputPath\": \"tasks.md\",\n      \"status\": \"done\"\n    }\n  ]\n}\n",
+    "stderr": "",
+    "error": null
+  },
+  "rawStdoutPath": ".ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-archive.stdout",
+  "rawStderrPath": ".ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-archive.stderr",
+  "error": null,
+  "warnings": [],
+  "errors": []
+}

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-status.json
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-status.json
@@ -1,0 +1,52 @@
+{
+  "changeId": "feat-add-github-aware-roadmap-sync",
+  "command": "openspec",
+  "args": [
+    "status",
+    "--change",
+    "feat-add-github-aware-roadmap-sync",
+    "--json",
+    "--no-color"
+  ],
+  "exitCode": 0,
+  "ok": true,
+  "skipped": false,
+  "reason": null,
+  "message": null,
+  "parsedJson": {
+    "changeName": "feat-add-github-aware-roadmap-sync",
+    "schemaName": "spec-driven",
+    "isComplete": true,
+    "applyRequires": [
+      "tasks"
+    ],
+    "artifacts": [
+      {
+        "id": "proposal",
+        "outputPath": "proposal.md",
+        "status": "done"
+      },
+      {
+        "id": "design",
+        "outputPath": "design.md",
+        "status": "done"
+      },
+      {
+        "id": "specs",
+        "outputPath": "specs/**/*.md",
+        "status": "done"
+      },
+      {
+        "id": "tasks",
+        "outputPath": "tasks.md",
+        "status": "done"
+      }
+    ]
+  },
+  "jsonParseError": null,
+  "rawStdoutPath": ".ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-status.stdout",
+  "rawStderrPath": ".ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-status.stderr",
+  "stdout": "{\n  \"changeName\": \"feat-add-github-aware-roadmap-sync\",\n  \"schemaName\": \"spec-driven\",\n  \"isComplete\": true,\n  \"applyRequires\": [\n    \"tasks\"\n  ],\n  \"artifacts\": [\n    {\n      \"id\": \"proposal\",\n      \"outputPath\": \"proposal.md\",\n      \"status\": \"done\"\n    },\n    {\n      \"id\": \"design\",\n      \"outputPath\": \"design.md\",\n      \"status\": \"done\"\n    },\n    {\n      \"id\": \"specs\",\n      \"outputPath\": \"specs/**/*.md\",\n      \"status\": \"done\"\n    },\n    {\n      \"id\": \"tasks\",\n      \"outputPath\": \"tasks.md\",\n      \"status\": \"done\"\n    }\n  ]\n}\n",
+  "stderr": "",
+  "error": null
+}

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-validation.json
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-validation.json
@@ -1,0 +1,51 @@
+{
+  "changeId": "feat-add-github-aware-roadmap-sync",
+  "command": "openspec",
+  "args": [
+    "validate",
+    "feat-add-github-aware-roadmap-sync",
+    "--type",
+    "change",
+    "--strict",
+    "--json",
+    "--no-interactive",
+    "--no-color"
+  ],
+  "exitCode": 0,
+  "ok": true,
+  "skipped": false,
+  "reason": null,
+  "message": null,
+  "parsedJson": {
+    "items": [
+      {
+        "id": "feat-add-github-aware-roadmap-sync",
+        "type": "change",
+        "valid": true,
+        "issues": [],
+        "durationMs": 2
+      }
+    ],
+    "summary": {
+      "totals": {
+        "items": 1,
+        "passed": 1,
+        "failed": 0
+      },
+      "byType": {
+        "change": {
+          "items": 1,
+          "passed": 1,
+          "failed": 0
+        }
+      }
+    },
+    "version": "1.0"
+  },
+  "jsonParseError": null,
+  "rawStdoutPath": ".ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-validate.stdout",
+  "rawStderrPath": ".ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-validate.stderr",
+  "stdout": "{\n  \"items\": [\n    {\n      \"id\": \"feat-add-github-aware-roadmap-sync\",\n      \"type\": \"change\",\n      \"valid\": true,\n      \"issues\": [],\n      \"durationMs\": 2\n    }\n  ],\n  \"summary\": {\n    \"totals\": {\n      \"items\": 1,\n      \"passed\": 1,\n      \"failed\": 0\n    },\n    \"byType\": {\n      \"change\": {\n        \"items\": 1,\n        \"passed\": 1,\n        \"failed\": 0\n      }\n    }\n  },\n  \"version\": \"1.0\"\n}\n",
+  "stderr": "",
+  "error": null
+}

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-archive.stdout
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-archive.stdout
@@ -1,0 +1,13 @@
+
+Proposal warnings in proposal.md (non-blocking):
+  ⚠ Change must have a Why section. Missing required sections. Expected headers: "## Why" and "## What Changes". Ensure deltas are documented in specs/ using delta headers.
+Task status: 11/14 tasks
+Warning: 3 incomplete task(s) found. Continuing due to --yes flag.
+
+Specs to update:
+  roadmap-github-sync: create
+Applying changes to openspec/specs/roadmap-github-sync/spec.md:
+  + 6 added
+Totals: + 6, ~ 0, - 0, → 0
+Specs updated successfully.
+Change 'feat-add-github-aware-roadmap-sync' archived as '2026-05-03-feat-add-github-aware-roadmap-sync'.

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-status.stdout
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-status.stdout
@@ -1,0 +1,30 @@
+{
+  "changeName": "feat-add-github-aware-roadmap-sync",
+  "schemaName": "spec-driven",
+  "isComplete": true,
+  "applyRequires": [
+    "tasks"
+  ],
+  "artifacts": [
+    {
+      "id": "proposal",
+      "outputPath": "proposal.md",
+      "status": "done"
+    },
+    {
+      "id": "design",
+      "outputPath": "design.md",
+      "status": "done"
+    },
+    {
+      "id": "specs",
+      "outputPath": "specs/**/*.md",
+      "status": "done"
+    },
+    {
+      "id": "tasks",
+      "outputPath": "tasks.md",
+      "status": "done"
+    }
+  ]
+}

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-validate.stdout
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/raw/openspec-validate.stdout
@@ -1,0 +1,26 @@
+{
+  "items": [
+    {
+      "id": "feat-add-github-aware-roadmap-sync",
+      "type": "change",
+      "valid": true,
+      "issues": [],
+      "durationMs": 2
+    }
+  ],
+  "summary": {
+    "totals": {
+      "items": 1,
+      "passed": 1,
+      "failed": 0
+    },
+    "byType": {
+      "change": {
+        "items": 1,
+        "passed": 1,
+        "failed": 0
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/.ai-factory/qa/feat-add-github-aware-roadmap-sync/verify.md
+++ b/.ai-factory/qa/feat-add-github-aware-roadmap-sync/verify.md
@@ -1,0 +1,88 @@
+# Verify: feat-add-github-aware-roadmap-sync
+
+Verdict: PASS-with-notes
+/aif-verify: PASS
+Code verification: PASS
+
+## Scope
+
+- Mode: OpenSpec-native mode
+- Verify mode: strict
+- Resolver source: explicit
+- QA evidence path: `.ai-factory/qa/feat-add-github-aware-roadmap-sync/`
+
+## OpenSpec
+
+- OpenSpec validation: PASS
+- OpenSpec status: PASS
+- OpenSpec CLI: available, version 1.3.1
+- shouldRunCodeVerification: true
+- Canonical artifacts inspected: proposal.md, design.md, tasks.md, base spec, delta spec
+- Generated rules: PASS, `openspec-base`, `openspec-change`, and `openspec-merged` are present and fresh
+
+## Task Completion
+
+| Area | Result | Evidence |
+|---|---:|---|
+| Planning/spec refinement | 2/2 complete | OpenSpec change artifacts inspected and valid |
+| Contract tests | 2/2 complete | `scripts/openspec-prompt-assets.test.mjs` includes GitHub-aware roadmap assertions |
+| Prompt/reference behavior | 4/4 complete | roadmap injection, template, and checklist contain supporting-only GitHub evidence rules |
+| Documentation | 1/1 complete | usage, context-loading policy, docs index, root README updated |
+| Verification | 2/2 complete | targeted and full repository checks passed |
+
+Commit Plan checkboxes remain unchecked because commit creation is outside `/aif-verify` ownership.
+
+## Code Quality
+
+- Build: N/A, no `build` script is configured in `package.json`.
+- Lint: N/A, no lint script/configured linter is present for this repo.
+- Prompt contract tests: PASS, 18 passed.
+- Repository validation: PASS.
+- Full tests: PASS, 244 passed.
+- Whitespace: PASS; `git diff --check` reported no whitespace errors and only a non-blocking CRLF/LF normalization warning for `injections/core/aif-roadmap-maturity-audit.md`.
+- Unfinished markers/debug/env refs: PASS; no matches in changed files.
+
+## Context Gates
+
+- PASS [architecture] Changes stay within the documented upstream-first prompt/docs/test surface and QA evidence paths.
+- PASS [rules] Project rules and OpenSpec/AI Factory ownership boundaries are respected.
+- WARN [roadmap] `.ai-factory/ROADMAP.md` is stale relative to current evidence: it still describes earlier audit state such as OpenSpec CLI/generate-rules gaps, while this verification saw OpenSpec CLI 1.3.1 and fresh generated rules. This is non-blocking and belongs to `/aif-roadmap check`.
+
+## Issues Found
+
+- Blocking findings: none.
+- Non-blocking findings: roadmap context drift as noted above.
+
+## QA Evidence Files
+
+- `.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-validation.json`
+- `.ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-status.json`
+- `.ai-factory/qa/feat-add-github-aware-roadmap-sync/code-verification.json`
+- `.ai-factory/qa/feat-add-github-aware-roadmap-sync/verify.md`
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "warn",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [
+    "README.md",
+    "docs/README.md",
+    "docs/context-loading-policy.md",
+    "docs/usage.md",
+    "injections/core/aif-roadmap-maturity-audit.md",
+    "injections/references/aif-roadmap/roadmap-template.md",
+    "injections/references/aif-roadmap/slice-checklist.md",
+    "scripts/openspec-prompt-assets.test.mjs",
+    "openspec/changes/feat-add-github-aware-roadmap-sync/proposal.md",
+    "openspec/changes/feat-add-github-aware-roadmap-sync/design.md",
+    "openspec/changes/feat-add-github-aware-roadmap-sync/tasks.md",
+    "openspec/changes/feat-add-github-aware-roadmap-sync/specs/roadmap-github-sync/spec.md",
+    ".ai-factory/state/feat-add-github-aware-roadmap-sync/implementation/run-2026-05-03T05-51-06-818Z.md",
+    ".ai-factory/ROADMAP.md"
+  ],
+  "suggested_next": null
+}
+```

--- a/.ai-factory/rules/generated/openspec-base.md
+++ b/.ai-factory/rules/generated/openspec-base.md
@@ -1,0 +1,184 @@
+# Generated OpenSpec Rules
+
+View: Base OpenSpec Rules
+Source of truth: OpenSpec canonical specs
+Generated files are derived guidance and are safe to delete, overwrite, and regenerate.
+
+## Source Fingerprints
+- sha256:6a509c016b59f5c1b54a24042dfd1fd472ea4881e3ac8616a2a5ea28fbcceb19 openspec/specs/openspec-cli-runner/spec.md
+- sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43 openspec/specs/roadmap-github-sync/spec.md
+
+## Requirements
+
+### Requirement: Windows npm command shims are supported
+
+Source:
+- Kind: base
+- Path: openspec/specs/openspec-cli-runner/spec.md
+- Capability: openspec-cli-runner
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:6a509c016b59f5c1b54a24042dfd1fd472ea4881e3ac8616a2a5ea28fbcceb19
+
+The shared OpenSpec runner MUST detect and execute Windows npm command shims when the bare `openspec` command is available through a `.cmd` or `.bat` file on `PATH`.
+
+#### Scenario: Detect OpenSpec through an npm cmd shim
+- GIVEN the current platform is Windows
+- AND `openspec.cmd` is present on `PATH`
+- WHEN `detectOpenSpec()` checks the OpenSpec CLI version
+- THEN the runner executes the shim successfully
+- AND reports `available: true`
+- AND enables validation and archive capabilities when the OpenSpec and Node versions are supported.
+
+### Requirement: GitHub state does not replace local proof
+
+Source:
+- Kind: base
+- Path: openspec/specs/roadmap-github-sync/spec.md
+- Capability: roadmap-github-sync
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43
+
+`/aif-roadmap` MUST treat GitHub issue and PR state as supporting evidence only. A closed issue, completed milestone, or merged PR MUST NOT be the sole reason to mark a roadmap slice or roadmap item `done`.
+
+#### Scenario: Closed issue without local evidence
+- GIVEN a GitHub issue is closed
+- AND local OpenSpec artifacts, source changes, tests, CI evidence, runtime state, or QA evidence do not support the completed behavior
+- WHEN `/aif-roadmap` evaluates the related roadmap item
+- THEN it does not mark the item `done` only because the issue is closed
+- AND it reports a drift or evidence gap.
+
+#### Scenario: Merged PR with matching local evidence
+- GIVEN a GitHub PR is merged
+- AND the current git tree, source files, tests, OpenSpec artifacts, or QA evidence confirm the merged behavior
+- WHEN `/aif-roadmap` evaluates the related roadmap item
+- THEN it may use the PR as supporting evidence for progress
+- AND it links or names the PR where useful.
+
+### Requirement: Roadmap audit detects GitHub/local drift
+
+Source:
+- Kind: base
+- Path: openspec/specs/roadmap-github-sync/spec.md
+- Capability: roadmap-github-sync
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43
+
+`/aif-roadmap` MUST call out material drift between GitHub tracker state and local canonical evidence.
+
+#### Scenario: GitHub says done but local evidence is missing
+- GIVEN GitHub issue, milestone, or PR state implies work is complete
+- AND local OpenSpec artifacts, source tree, tests, CI, runtime state, or QA evidence are missing or contradictory
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it reports the mismatch as drift or an evidence gap.
+
+#### Scenario: Local implementation exists but GitHub is stale
+- GIVEN local source, tests, OpenSpec artifacts, runtime state, or QA evidence show implemented work
+- AND the related GitHub issue, milestone, or roadmap link appears stale or absent
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it reports the stale GitHub linkage as drift instead of discarding local evidence.
+
+#### Scenario: OpenSpec change lacks tracker linkage
+- GIVEN an active or archived OpenSpec change exists
+- AND no related roadmap, GitHub issue, milestone, or PR link is visible
+- WHEN `/aif-roadmap` evaluates planning traceability
+- THEN it may report missing linkage as a traceability gap
+- AND it does not treat the missing GitHub link alone as implementation failure.
+
+### Requirement: Roadmap audit handles GitHub credentials safely
+
+Source:
+- Kind: base
+- Path: openspec/specs/roadmap-github-sync/spec.md
+- Capability: roadmap-github-sync
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43
+
+`/aif-roadmap` MUST keep GitHub evidence collection non-blocking and MUST NOT write tokens, authorization headers, raw credential helper output, or private authentication diagnostics into `.ai-factory/ROADMAP.md`.
+
+#### Scenario: GitHub command reports authentication details
+- GIVEN a GitHub tool or connector returns authentication, authorization, token, or credential-related diagnostics
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN the roadmap may state that GitHub evidence was unavailable or partial
+- AND it does not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.
+
+#### Scenario: GitHub read access is unavailable
+- GIVEN GitHub read access fails because the runtime is unauthenticated, offline, rate-limited, or missing `gh`
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues from local repository evidence
+- AND it does not ask the user to mutate GitHub state as part of roadmap generation.
+
+### Requirement: Roadmap audit uses GitHub as supporting evidence when available
+
+Source:
+- Kind: base
+- Path: openspec/specs/roadmap-github-sync/spec.md
+- Capability: roadmap-github-sync
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43
+
+`/aif-roadmap` MUST be able to include GitHub milestones, issues, PRs, labels, linked branches, and local git tree state in the roadmap audit evidence set when that context is available.
+
+#### Scenario: GitHub evidence is available
+- GIVEN the repository has GitHub context from `gh`, a connector, explicit issue/PR URLs, or caller-provided metadata
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN the audit may reference relevant GitHub milestones, issues, PRs, labels, and linked branches
+- AND the normal response summarizes that GitHub evidence was used.
+
+#### Scenario: GitHub evidence is unavailable
+- GIVEN GitHub context is not available in the current runtime
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues from local repository evidence
+- AND the normal response states that GitHub evidence was unavailable or skipped.
+
+#### Scenario: GitHub evidence is partially available
+- GIVEN some GitHub context is available
+- AND other requested GitHub data is missing, rate-limited, unauthenticated, or otherwise unavailable
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues with the available GitHub and local evidence
+- AND the normal response summarizes the missing or partial GitHub evidence without treating it as a roadmap failure.
+
+### Requirement: Roadmap entries must preserve useful local and GitHub evidence links
+
+Source:
+- Kind: base
+- Path: openspec/specs/roadmap-github-sync/spec.md
+- Capability: roadmap-github-sync
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43
+
+Roadmap entries MUST include GitHub milestone, issue, or PR links where useful, alongside local artifact paths that justify the roadmap assessment.
+
+#### Scenario: Item has both local and GitHub evidence
+- GIVEN a roadmap item maps to local OpenSpec artifacts and GitHub tracker items
+- WHEN `/aif-roadmap` writes the item
+- THEN it includes enough local evidence paths to justify the status
+- AND it includes GitHub links or identifiers where useful.
+
+#### Scenario: Manual roadmap notes still match evidence
+- GIVEN existing manual roadmap notes are still consistent with local and GitHub evidence
+- WHEN `/aif-roadmap` updates `.ai-factory/ROADMAP.md`
+- THEN it preserves those notes unless contradicted by repository evidence.
+
+### Requirement: Roadmap writes remain owner-bounded
+
+Source:
+- Kind: base
+- Path: openspec/specs/roadmap-github-sync/spec.md
+- Capability: roadmap-github-sync
+- Change: none
+- Section: Requirements
+- Fingerprint: sha256:5fcee1859c0ff8e16b41f8d472f693c2ffc23cee8b82e1e8d71e106f28840d43
+
+`/aif-roadmap` MUST keep write ownership limited to the configured roadmap artifact and MUST NOT mutate GitHub, canonical OpenSpec artifacts, runtime state, QA evidence, generated rules, or implementation files.
+
+#### Scenario: Roadmap refresh with GitHub context
+- GIVEN GitHub context is available
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it may update `.ai-factory/ROADMAP.md`
+- AND it does not edit GitHub issues, GitHub milestones, PRs, `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/state/**`, `.ai-factory/qa/**`, or `.ai-factory/rules/generated/**`.

--- a/.ai-factory/state/feat-add-github-aware-roadmap-sync/final-summary.md
+++ b/.ai-factory/state/feat-add-github-aware-roadmap-sync/final-summary.md
@@ -1,0 +1,30 @@
+# Final Summary: feat-add-github-aware-roadmap-sync
+
+## Suggested commit message
+
+feat: finalize feat-add-github-aware-roadmap-sync
+
+## Suggested PR summary
+
+## Summary
+
+- Finalized OpenSpec change `feat-add-github-aware-roadmap-sync`.
+- Prepared final QA and state summaries for `feat-add-github-aware-roadmap-sync`.
+
+## OpenSpec
+
+- Change: feat-add-github-aware-roadmap-sync
+- Archived: yes
+- Skip specs: no
+
+## Verification
+
+- /aif-verify: PASS
+- OpenSpec validation: PASS
+- Code verification: PASS
+
+## Artifacts
+
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/done.md
+- .ai-factory/qa/feat-add-github-aware-roadmap-sync/openspec-archive.json
+- .ai-factory/state/feat-add-github-aware-roadmap-sync/final-summary.md

--- a/.ai-factory/state/feat-add-github-aware-roadmap-sync/implementation/run-2026-05-03T05-51-06-818Z.md
+++ b/.ai-factory/state/feat-add-github-aware-roadmap-sync/implementation/run-2026-05-03T05-51-06-818Z.md
@@ -1,0 +1,34 @@
+# Implementation Trace: feat-add-github-aware-roadmap-sync
+
+## Summary
+
+Implemented GitHub-aware roadmap sync guidance across prompt assets, roadmap references, documentation, and contract tests. GitHub evidence is optional, read-only, credential-safe, supporting-only context; local OpenSpec/source/test/QA evidence remains required for done status.
+
+## Canonical artifacts read
+
+- openspec/changes/feat-add-github-aware-roadmap-sync/proposal.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/design.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/tasks.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/specs/roadmap-github-sync/spec.md
+
+## Generated rules read
+
+- .ai-factory/rules/generated/openspec-base.md
+- .ai-factory/rules/generated/openspec-change-feat-add-github-aware-roadmap-sync.md
+- .ai-factory/rules/generated/openspec-merged-feat-add-github-aware-roadmap-sync.md
+
+## Changed files
+
+- scripts/openspec-prompt-assets.test.mjs
+- injections/core/aif-roadmap-maturity-audit.md
+- injections/references/aif-roadmap/roadmap-template.md
+- injections/references/aif-roadmap/slice-checklist.md
+- docs/context-loading-policy.md
+- docs/usage.md
+- docs/README.md
+- README.md
+- openspec/changes/feat-add-github-aware-roadmap-sync/tasks.md
+
+## Next step
+
+/aif-verify feat-add-github-aware-roadmap-sync

--- a/.ai-factory/state/mode-switches/2026-05-03T05-43-27-314Z-sync-openspec.md
+++ b/.ai-factory/state/mode-switches/2026-05-03T05-43-27-314Z-sync-openspec.md
@@ -1,0 +1,73 @@
+# Artifact Sync: OpenSpec
+
+Mode: openspec
+Dry run: no
+
+## Skeleton
+
+- preserve: openspec/specs
+- preserve: openspec/changes
+- preserve: .ai-factory/state
+- preserve: .ai-factory/qa
+- preserve: .ai-factory/rules/generated
+- preserve: openspec\config.yaml
+## Change Selection
+
+Source: explicit
+Changes: feat-add-github-aware-roadmap-sync
+## Generated Rules
+
+Files: 3
+Base-only sync: no
+Change-specific rules skipped: no
+Warnings:
+- cli-json-empty: OpenSpec CLI JSON for 'openspec-cli-runner' did not contain requirements; using filesystem fallback.
+- cli-json-unavailable: OpenSpec CLI JSON was unavailable for 'roadmap-github-sync'; using filesystem fallback.
+Errors: none
+## OpenSpec Validation
+
+Skipped: no
+Results: 1
+Skipped changes: 0
+Warnings: none
+Errors: none
+## Legacy Plans
+
+Detected: 29
+- active-change-resolver-runtime-state-layout
+- archive-openspec-changes-during-done
+- artifact-metadata-contract
+- chore-sync-ai-factory-baseline-and-normalize-extension-docs
+- chore-update-openspec-compatibility-policy
+- compile-openspec-specs-into-generated-rules
+- consume-openspec-artifacts-implement-fix
+- docs-clarify-legacy-aliases-and-current-public-workflow
+- emit-openspec-native-plan-artifacts
+- explore-extension-integration
+- extension-compat-sources
+- feat-aif-plan-workflow-migration
+- feat-claude-add-namespaced-aifhub-subagents
+- feat-codex-add-verifier-fixer-rules-and-done-agents
+- feat-done-add-aif-done-finalization-skill
+- feat-handoff-add-aifhub-handoff-profile-prompts-and-docs
+- feat-rules-add-read-only-aif-rules-check-gate
+- fix-codex-make-bundled-codex-agents-schema-compliant
+- fix-runtime-harden-question-handling-and-codex-plan-mode-gui
+- migrate-askuserquestion-to-tool
+- openspec-cli-runner-capability-detection
+- openspec-native-artifact-protocol-adr
+- openspec-native-bootstrap-mode
+- refactor-split-core-and-handoff-specific-injections
+- test-add-extension-manifest-and-agent-file-validation
+- update-explore-improve-openspec-artifacts
+- update-prompt-assets-openspec-native-mode
+- validate-openspec-changes-during-verify
+- workflow-aif-apply-orchestration
+Warnings: none
+Errors: none
+## Current Pointer
+
+Skipped: yes
+- none
+Warnings: none
+Errors: none

--- a/.ai-factory/state/mode-switches/2026-05-03T06-07-19-783Z-sync-openspec.md
+++ b/.ai-factory/state/mode-switches/2026-05-03T06-07-19-783Z-sync-openspec.md
@@ -1,0 +1,75 @@
+# Artifact Sync: OpenSpec
+
+Mode: openspec
+Dry run: no
+
+## Skeleton
+
+- preserve: openspec/specs
+- preserve: openspec/changes
+- preserve: .ai-factory/state
+- preserve: .ai-factory/qa
+- preserve: .ai-factory/rules/generated
+- preserve: openspec\config.yaml
+## Change Selection
+
+Source: active
+Changes: none
+## Generated Rules
+
+Files: 1
+Base-only sync: yes
+Change-specific rules skipped: yes
+Warnings:
+- cli-json-empty: OpenSpec CLI JSON for 'openspec-cli-runner' did not contain requirements; using filesystem fallback.
+- cli-json-empty: OpenSpec CLI JSON for 'roadmap-github-sync' did not contain requirements; using filesystem fallback.
+- no-active-change-specific-rules: No active OpenSpec changes were selected; refreshed base generated rules only.
+Errors: none
+## OpenSpec Validation
+
+Skipped: yes
+Results: 0
+Skipped changes: 0
+Warnings:
+- no-selected-changes: OpenSpec validation skipped because no active changes were selected.
+Errors: none
+## Legacy Plans
+
+Detected: 29
+- active-change-resolver-runtime-state-layout
+- archive-openspec-changes-during-done
+- artifact-metadata-contract
+- chore-sync-ai-factory-baseline-and-normalize-extension-docs
+- chore-update-openspec-compatibility-policy
+- compile-openspec-specs-into-generated-rules
+- consume-openspec-artifacts-implement-fix
+- docs-clarify-legacy-aliases-and-current-public-workflow
+- emit-openspec-native-plan-artifacts
+- explore-extension-integration
+- extension-compat-sources
+- feat-aif-plan-workflow-migration
+- feat-claude-add-namespaced-aifhub-subagents
+- feat-codex-add-verifier-fixer-rules-and-done-agents
+- feat-done-add-aif-done-finalization-skill
+- feat-handoff-add-aifhub-handoff-profile-prompts-and-docs
+- feat-rules-add-read-only-aif-rules-check-gate
+- fix-codex-make-bundled-codex-agents-schema-compliant
+- fix-runtime-harden-question-handling-and-codex-plan-mode-gui
+- migrate-askuserquestion-to-tool
+- openspec-cli-runner-capability-detection
+- openspec-native-artifact-protocol-adr
+- openspec-native-bootstrap-mode
+- refactor-split-core-and-handoff-specific-injections
+- test-add-extension-manifest-and-agent-file-validation
+- update-explore-improve-openspec-artifacts
+- update-prompt-assets-openspec-native-mode
+- validate-openspec-changes-during-verify
+- workflow-aif-apply-orchestration
+Warnings: none
+Errors: none
+## Current Pointer
+
+Skipped: yes
+- none
+Warnings: none
+Errors: none

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 |---|---|
 | [Documentation Index](docs/README.md) | Reading order and docs map |
 | [Usage](docs/usage.md) | Full command flow, read/write boundaries, examples, and troubleshooting |
-| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, ownership, and legacy boundaries |
+| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
 | [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy and capability flags |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |
 | [Active Change Resolver](docs/active-change-resolver.md) | Active change selection and runtime paths |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 
 1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
 2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
-3. [Context Loading Policy](context-loading-policy.md) for consumer context, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
+3. [Context Loading Policy](context-loading-policy.md) for consumer context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
 4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, capability flags, and degraded mode.
 5. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
 6. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
@@ -35,7 +35,7 @@ The remaining runtime-specific guides are supporting references:
 | Guide | Purpose |
 |---|---|
 | [Usage](usage.md) | Full OpenSpec-native command flow, gates, finalization tail, commit, and examples |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, ownership, gates, commit handoff, and legacy boundaries |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, sync points, rules gate, version support, and degraded mode |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
 | [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -71,12 +71,26 @@ Generated rules are derived guidance only. If generated rules conflict with cano
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
 
+## GitHub-Aware Roadmap Context
+
+`/aif-roadmap` may additionally read GitHub and git-tracker context when available:
+
+- GitHub milestones, issues, PRs, labels, and linked branches
+- current git tree, changed files, tags, and recent commits
+
+This context is supporting evidence only. Closed GitHub issues, completed milestones, and merged PRs do not by themselves make roadmap items `done`; local evidence from OpenSpec artifacts, source files, tests, CI, runtime state, QA evidence, or generated rules remains required.
+
+GitHub access is non-blocking. If `gh`, connector data, network access, authentication, or rate limits prevent complete GitHub evidence loading, `/aif-roadmap` should continue from local evidence and summarize whether GitHub evidence was unavailable or partial.
+
+`/aif-roadmap` may update only the configured roadmap artifact. It must not mutate GitHub issues, milestones, PRs, labels, linked branches, canonical OpenSpec artifacts, runtime state, QA evidence, generated rules, or implementation files. It must not write tokens, authorization headers, raw credential helper output, or private authentication diagnostics into roadmap output.
+
 ## Command Ownership
 
 | Command | May write canonical OpenSpec artifacts | May write runtime or QA artifacts |
 |---|---|---|
 | `/aif-mode` | skeleton only; never manual `openspec/specs/**` mutations | mode reports, generated rules, optional migration/export outputs |
 | `/aif-analyze` | Optional `openspec/` skeleton only when configured | capability/config setup |
+| `/aif-roadmap` | no | no |
 | `/aif-plan full` | `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md` | optional `.ai-factory/state/<change-id>/` |
 | `/aif-explore` | no | `.ai-factory/RESEARCH.md`, `.ai-factory/state/<change-id>/` |
 | `/aif-improve` | `proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md` | optional `.ai-factory/state/<change-id>/` |
@@ -89,6 +103,8 @@ Runner output from OpenSpec CLI commands is runtime guidance or evidence. It doe
 | `/aif-done` | `openspec/specs/**` only through OpenSpec CLI archive | `.ai-factory/qa/<change-id>/`, `.ai-factory/state/<change-id>/final-summary.md` |
 | `/aif-commit` | no | git commit only |
 | `/aif-evolve` | no | skill-context or evolution artifacts only |
+
+`/aif-roadmap` writes only the configured roadmap artifact, `.ai-factory/ROADMAP.md` by default.
 
 ## Quality Gates and Finalization Tail
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,6 +183,34 @@ Does not write:
 
 Exploration is research-only until promoted into canonical OpenSpec artifacts by planning or refinement.
 
+### `/aif-roadmap`
+
+Reads:
+
+- `.ai-factory/config.yaml`
+- project context and rules
+- current `.ai-factory/ROADMAP.md`
+- OpenSpec-native evidence under `openspec/specs/**` and `openspec/changes/**`
+- local source, tests, CI, runtime state, QA evidence, and generated rules when relevant
+- optional GitHub milestones, issues, PRs, labels, and linked branches when available
+- current git tree, changed files, tags, and recent commits when available
+
+Writes:
+
+- configured roadmap artifact, `.ai-factory/ROADMAP.md` by default
+
+Does not write:
+
+- GitHub issues, milestones, PRs, labels, or linked branches
+- `openspec/changes/**`
+- `openspec/specs/**`
+- `.ai-factory/state/<change-id>/`
+- `.ai-factory/qa/<change-id>/`
+- `.ai-factory/rules/generated/**`
+- implementation source files
+
+GitHub state is supporting evidence only. Closed issues, completed milestones, and merged PRs are useful signals, but local artifact evidence remains required before marking roadmap items `done`. If GitHub evidence is unavailable, unauthenticated, rate-limited, offline, or partial, `/aif-roadmap` continues from local evidence and summarizes the limitation without writing credentials or private authentication diagnostics.
+
 ### `/aif-improve`
 
 Reads:

--- a/injections/core/aif-roadmap-maturity-audit.md
+++ b/injections/core/aif-roadmap-maturity-audit.md
@@ -34,6 +34,32 @@ Use these as evidence only. `/aif-roadmap` must not write runtime state, QA evid
 
 When OpenSpec-native evidence is used, summarize the artifact source set in the normal response.
 
+### GitHub-aware evidence
+
+When GitHub context is available, `/aif-roadmap` may read GitHub-aware evidence as supporting evidence only:
+
+- milestones
+- open and closed issues
+- open, merged, and closed PRs
+- labels
+- linked branches
+- current git tree, changed files, tags, and recent commits
+
+GitHub context may come from `gh`, a GitHub connector, explicit issue/PR URLs, or caller-provided metadata. GitHub access is optional and non-blocking. If GitHub data is missing, unauthenticated, rate-limited, offline, or only partially available, continue from local repository evidence and summarize whether GitHub evidence was used, unavailable, or partially available.
+
+GitHub state must never replace local proof. A closed issue, completed milestone, or merged PR must never be the sole reason to mark a slice or roadmap item `done`; require local evidence from OpenSpec artifacts, source files, tests, CI, runtime state, QA evidence, generated rules, or other repository artifacts.
+
+Detect and report drift when material:
+
+- GitHub says done, but local evidence is missing
+- local implementation exists, but GitHub is stale
+- OpenSpec change exists, but no linked roadmap/milestone/issue is visible
+- merged PR exists, but current git tree does not contain the expected local evidence
+
+GitHub-aware roadmap output must be credential-safe. It may include public or user-provided identifiers such as issue numbers, PR numbers, milestone names, titles, states, and URLs. It must not write tokens, authorization headers, raw credential helper output, or private authentication diagnostics into `.ai-factory/ROADMAP.md` or normal responses.
+
+`/aif-roadmap` is read-only with respect to GitHub: it must not mutate GitHub issues, milestones, PRs, labels, or linked branches. It must also not write runtime state, QA evidence, generated rules, canonical OpenSpec artifacts, or implementation files.
+
 ### Legacy AI Factory-only evidence
 
 When OpenSpec-native mode is not enabled, legacy `.ai-factory/plans/<plan-id>/` and `.ai-factory/specs/<plan-id>/` records may be used as historical roadmap evidence.
@@ -69,7 +95,7 @@ Evidence priority is strict:
 
 - Primary evidence: source code, config files, schemas, tests, pipelines, automation definitions.
 - Secondary evidence: project documentation only when it matches the repository state.
-- Git history is supporting context only and must never be the sole reason to mark a slice `done`.
+- Git history and GitHub state are supporting context only and must never be the sole reason to mark a slice `done`.
 
 ### Output Rules
 
@@ -77,6 +103,7 @@ Evidence priority is strict:
 - Preserve manual notes that still match the codebase.
 - Treat the roadmap as an audit artifact, not as a generic task list.
 - In check mode, call out regressions explicitly.
+- Link to GitHub milestones, issues, or PRs where useful, but keep local artifact evidence as the basis for status decisions.
 - Summarize strongest areas, critical gaps, and any status changes.
 
 ### Reference Assets

--- a/injections/references/aif-roadmap/roadmap-template.md
+++ b/injections/references/aif-roadmap/roadmap-template.md
@@ -18,6 +18,8 @@ Create `.ai-factory/ROADMAP.md` with this structure:
 **Evidence:**
 - [File or pattern found]
 
+**GitHub evidence:** [optional milestone/issue/PR links or "not available"]
+
 **Commentary:**
 - [Assessment]
 
@@ -59,3 +61,7 @@ Create `.ai-factory/ROADMAP.md` with this structure:
 - Preserve valid manual notes when updating an existing roadmap.
 - In check mode, mention slices whose status changed and explain why.
 - Make next steps concrete enough to become implementation tasks later.
+- GitHub evidence may include milestones, issues, PRs, labels, linked branches, and current git tree state when available.
+- GitHub links are optional; do not require them for every roadmap entry.
+- local artifact evidence remains required for `done` status decisions.
+- Do not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.

--- a/injections/references/aif-roadmap/slice-checklist.md
+++ b/injections/references/aif-roadmap/slice-checklist.md
@@ -75,5 +75,11 @@ Mark a slice `done` only when the repository shows comprehensive evidence. When 
 ## Evidence Notes
 
 - Use git history only as supporting context.
+- Use GitHub evidence only as supporting context. GitHub evidence may include milestones, issues, PRs, labels, linked branches, and current git tree state when available.
+- GitHub links are optional; do not require them for every slice or roadmap entry.
 - Prefer direct file paths, configs, tests, and automation definitions as evidence.
+- local artifact evidence remains required before marking a slice or roadmap item `done`.
+- If GitHub says work is complete but local evidence is missing, report drift instead of marking `done`.
+- If local implementation exists but GitHub or roadmap linkage is stale, report drift instead of discarding local evidence.
+- Do not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.
 - If a slice is unclear, explain what is missing instead of guessing.

--- a/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/design.md
+++ b/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/design.md
@@ -1,0 +1,80 @@
+# Design: feat: add GitHub-aware roadmap sync
+
+## Technical Approach
+
+This is a prompt-asset and contract-test change. `/aif-roadmap` remains an upstream AI Factory command augmented by `injections/core/aif-roadmap-maturity-audit.md`; the extension should not add a new orchestration skill for roadmap sync.
+
+The implementation should update the roadmap injection so it has three evidence layers:
+
+1. Canonical local evidence:
+   - `openspec/specs/**`
+   - `openspec/changes/<change-id>/proposal.md`
+   - `openspec/changes/<change-id>/design.md`
+   - `openspec/changes/<change-id>/tasks.md`
+   - `openspec/changes/<change-id>/specs/**/spec.md`
+   - `.ai-factory/rules/generated/**`
+   - `.ai-factory/state/<change-id>/`
+   - `.ai-factory/qa/<change-id>/`
+   - source tree, tests, and CI definitions
+2. Git and checkout evidence:
+   - current branch and remote;
+   - dirty working tree;
+   - recent commits, tags, and merge commits;
+   - current tree and changed files.
+3. GitHub supporting evidence when available:
+   - milestones;
+   - issues with state, labels, assignees, and milestone;
+   - PRs with state, merge status, base/head refs, and linked issues;
+   - linked branches.
+
+The roadmap audit should use GitHub items as links and planning signals, not as automatic completion proof.
+
+GitHub evidence acquisition should be adapter-agnostic. The prompt can ask the agent to use whatever GitHub context is already available in the runtime, including `gh`, connector results, explicit issue/PR URLs, or caller-provided metadata. It should not require a new helper module for this change, and it should not fail roadmap generation when GitHub access is missing, unauthenticated, rate-limited, or partial.
+
+Credential safety belongs in the prompt contract: roadmap output may include stable public identifiers such as issue numbers, PR numbers, milestone names, titles, states, and URLs, but must not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.
+
+## Data / Artifact Model
+
+No new runtime data model is required.
+
+Relevant write targets:
+
+- `.ai-factory/ROADMAP.md` remains owned by `/aif-roadmap`.
+
+Relevant read targets:
+
+- Existing OpenSpec-native evidence from `injections/core/aif-roadmap-maturity-audit.md`.
+- GitHub evidence provided by the caller/runtime, `gh` output, connector output, or explicit URLs.
+- Git state available through local git commands.
+
+Prompt contract tests should model the behavior as text contracts in `scripts/openspec-prompt-assets.test.mjs` or a focused companion test. They should not require network access.
+
+Test-first implementation is preferred:
+
+1. Add failing contract assertions for the roadmap injection and reference assets.
+2. Update prompt/reference assets until the targeted tests pass.
+3. Update documentation only where evidence loading behavior is described.
+4. Run full validation.
+
+## Integration Points
+
+- `extension.json` already injects `./injections/core/aif-roadmap-maturity-audit.md` into upstream `aif-roadmap`.
+- `injections/references/aif-roadmap/roadmap-template.md` controls the expected roadmap layout.
+- `injections/references/aif-roadmap/slice-checklist.md` defines evidence slices and evidence notes.
+- `scripts/openspec-prompt-assets.test.mjs` already owns instruction-level prompt contracts and should be extended before broad prompt edits.
+- `.ai-factory/ROADMAP.md` is the output artifact updated by `/aif-roadmap`, but this plan must not update it directly.
+- GitHub issue #13 is the source issue and should be referenced in implementation notes or docs where useful.
+
+## Alternatives Considered
+
+- Add a deterministic Node helper that calls GitHub APIs. Rejected for this change because issue #13 is about `/aif-roadmap` behavior and evidence guidance; introducing runtime API code would expand scope into authentication, rate limits, offline behavior, and connector differences.
+- Treat GitHub as primary roadmap source. Rejected because the project architecture says OpenSpec is canonical and AI Factory is runtime; GitHub issue state must not override missing local artifacts or QA evidence.
+- Update `.ai-factory/ROADMAP.md` immediately during planning. Rejected because `/aif-plan` owns canonical OpenSpec planning artifacts, while `/aif-roadmap` owns roadmap updates.
+
+## Risks
+
+- Overly rigid prompt tests could fail harmless wording changes. Prefer assertions for core concepts: GitHub supporting evidence, local proof requirement, drift detection, and write boundaries.
+- The roadmap template can become noisy if every entry requires multiple GitHub links. The prompt should say "where useful" and preserve manual notes.
+- If `gh` is unavailable, the roadmap command must continue with local evidence and report that GitHub evidence was unavailable.
+- If `gh` returns authentication or rate-limit errors, the prompt must not copy raw credential diagnostics into the roadmap.
+- Merged PRs may not map one-to-one to OpenSpec changes. The audit should link them as supporting evidence and call out unmatched items as drift only when local evidence is actually missing or contradictory.

--- a/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/proposal.md
+++ b/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: feat: add GitHub-aware roadmap sync
+
+## Intent
+
+`/aif-roadmap` уже работает как evidence-based maturity audit, но его evidence source set локален: `.ai-factory` context, OpenSpec artifacts, generated rules, runtime state, QA evidence, source tree, tests и CI. Issue #13 требует добавить GitHub-aware evidence layer, чтобы roadmap мог учитывать milestones, issues, PRs, labels, linked branches и git tree state, не превращая GitHub в единственный source of truth.
+
+Цель изменения: расширить roadmap planning/audit guidance так, чтобы GitHub context использовался как supporting evidence, а статусы `done` продолжали требовать локального подтверждения через canonical OpenSpec artifacts, QA evidence, source tree, tests или CI.
+
+## Scope
+
+- In scope:
+  - Обновить `injections/core/aif-roadmap-maturity-audit.md` GitHub-aware evidence правилами.
+  - Обновить `injections/references/aif-roadmap/roadmap-template.md` и при необходимости `slice-checklist.md`, чтобы roadmap мог ссылаться на GitHub milestones/issues/PRs рядом с локальными evidence paths.
+  - Добавить prompt/contract tests, которые фиксируют GitHub как supporting evidence, запрет `done` только по closed issue/merged PR, drift detection, credential-safe output и OpenSpec-native canonical priority.
+  - Обновить минимальную пользовательскую документацию, если `/aif-roadmap` behavior или context-loading policy описывают evidence source set.
+  - Использовать issue #13 как source issue для формулировок и acceptance criteria.
+- Out of scope:
+  - Создание GitHub API runtime helper или MCP/connector abstraction.
+  - Автоматическое закрытие GitHub issues, изменение milestones или создание PRs.
+  - Требование обязательной GitHub authentication, network access или `gh` availability для roadmap generation.
+  - Перегенерация `.ai-factory/ROADMAP.md` в рамках этого plan step.
+  - Изменение `/aif-done`, `/aif-verify`, OpenSpec archive/finalization behavior.
+  - Возврат legacy `.ai-factory/plans` как canonical workflow.
+
+## Approach
+
+1. Treat `/aif-roadmap` as GitHub-aware when GitHub context is available through the runtime environment, `gh`, connector output, or already-provided issue/PR links.
+2. Make GitHub evidence additive:
+   - milestones;
+   - open/closed issues;
+   - open/merged/closed PRs;
+   - labels;
+   - linked branches;
+   - current git tree, changed files, tags, and recent commits.
+3. Keep GitHub collection non-blocking:
+   - if `gh` is missing, unauthenticated, rate-limited, or unavailable, continue from local evidence;
+   - summarize unavailable or partial GitHub evidence in the normal response;
+   - never write tokens, credentials, or raw authentication diagnostics into `.ai-factory/ROADMAP.md`.
+4. Require comparison against local evidence before status changes:
+   - `openspec/specs/**`;
+   - `openspec/changes/**`;
+   - `.ai-factory/state/**`;
+   - `.ai-factory/qa/**`;
+   - `.ai-factory/rules/generated/**`;
+   - source tree;
+   - tests and CI.
+5. Add drift detection rules:
+   - GitHub says done, but local artifacts/tests/QA are missing;
+   - local implementation exists, but roadmap or GitHub issue remains stale;
+   - OpenSpec change exists, but no linked roadmap/milestone/issue is visible;
+   - merged PR exists, but current tree does not contain the expected files or evidence.
+6. Keep write ownership unchanged: `/aif-roadmap` may update only `.ai-factory/ROADMAP.md`; it must not mutate GitHub, OpenSpec canonical artifacts, runtime state, QA evidence, generated rules, or implementation files.
+
+## Risks / Open Questions
+
+- GitHub availability can vary by runtime. The prompt must support `gh`, connectors, web-provided issue URLs, or no GitHub access without failing roadmap generation.
+- GitHub issue/PR state can be stale relative to the local checkout. The roadmap must report drift instead of blindly trusting remote status.
+- The current `.ai-factory/ROADMAP.md` is already stale relative to recent PRs `#57`, `#58`, and `#59`; implementation must avoid rewriting roadmap during planning, but the new behavior should detect this later.
+- Existing prompt tests focus on OpenSpec-native prompt assets broadly. This change needs targeted roadmap evidence assertions without over-constraining natural roadmap wording.
+- No interactive preferences were requested in this Codex Default-mode plan. Assumptions: tests `yes`, docs `yes`, logging `minimal`, roadmap linkage to issue #13 and current roadmap release-confidence/drift priorities.

--- a/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/specs/roadmap-github-sync/spec.md
+++ b/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/specs/roadmap-github-sync/spec.md
@@ -1,0 +1,121 @@
+# Delta for Roadmap GitHub Sync
+
+## ADDED Requirements
+
+### Requirement: Roadmap audit uses GitHub as supporting evidence when available
+
+`/aif-roadmap` MUST be able to include GitHub milestones, issues, PRs, labels, linked branches, and local git tree state in the roadmap audit evidence set when that context is available.
+
+#### Scenario: GitHub evidence is available
+
+- GIVEN the repository has GitHub context from `gh`, a connector, explicit issue/PR URLs, or caller-provided metadata
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN the audit may reference relevant GitHub milestones, issues, PRs, labels, and linked branches
+- AND the normal response summarizes that GitHub evidence was used.
+
+#### Scenario: GitHub evidence is unavailable
+
+- GIVEN GitHub context is not available in the current runtime
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues from local repository evidence
+- AND the normal response states that GitHub evidence was unavailable or skipped.
+
+#### Scenario: GitHub evidence is partially available
+
+- GIVEN some GitHub context is available
+- AND other requested GitHub data is missing, rate-limited, unauthenticated, or otherwise unavailable
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues with the available GitHub and local evidence
+- AND the normal response summarizes the missing or partial GitHub evidence without treating it as a roadmap failure.
+
+### Requirement: Roadmap audit handles GitHub credentials safely
+
+`/aif-roadmap` MUST keep GitHub evidence collection non-blocking and MUST NOT write tokens, authorization headers, raw credential helper output, or private authentication diagnostics into `.ai-factory/ROADMAP.md`.
+
+#### Scenario: GitHub command reports authentication details
+
+- GIVEN a GitHub tool or connector returns authentication, authorization, token, or credential-related diagnostics
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN the roadmap may state that GitHub evidence was unavailable or partial
+- AND it does not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.
+
+#### Scenario: GitHub read access is unavailable
+
+- GIVEN GitHub read access fails because the runtime is unauthenticated, offline, rate-limited, or missing `gh`
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues from local repository evidence
+- AND it does not ask the user to mutate GitHub state as part of roadmap generation.
+
+### Requirement: GitHub state does not replace local proof
+
+`/aif-roadmap` MUST treat GitHub issue and PR state as supporting evidence only. A closed issue, completed milestone, or merged PR MUST NOT be the sole reason to mark a roadmap slice or roadmap item `done`.
+
+#### Scenario: Closed issue without local evidence
+
+- GIVEN a GitHub issue is closed
+- AND local OpenSpec artifacts, source changes, tests, CI evidence, runtime state, or QA evidence do not support the completed behavior
+- WHEN `/aif-roadmap` evaluates the related roadmap item
+- THEN it does not mark the item `done` only because the issue is closed
+- AND it reports a drift or evidence gap.
+
+#### Scenario: Merged PR with matching local evidence
+
+- GIVEN a GitHub PR is merged
+- AND the current git tree, source files, tests, OpenSpec artifacts, or QA evidence confirm the merged behavior
+- WHEN `/aif-roadmap` evaluates the related roadmap item
+- THEN it may use the PR as supporting evidence for progress
+- AND it links or names the PR where useful.
+
+### Requirement: Roadmap audit detects GitHub/local drift
+
+`/aif-roadmap` MUST call out material drift between GitHub tracker state and local canonical evidence.
+
+#### Scenario: GitHub says done but local evidence is missing
+
+- GIVEN GitHub issue, milestone, or PR state implies work is complete
+- AND local OpenSpec artifacts, source tree, tests, CI, runtime state, or QA evidence are missing or contradictory
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it reports the mismatch as drift or an evidence gap.
+
+#### Scenario: Local implementation exists but GitHub is stale
+
+- GIVEN local source, tests, OpenSpec artifacts, runtime state, or QA evidence show implemented work
+- AND the related GitHub issue, milestone, or roadmap link appears stale or absent
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it reports the stale GitHub linkage as drift instead of discarding local evidence.
+
+#### Scenario: OpenSpec change lacks tracker linkage
+
+- GIVEN an active or archived OpenSpec change exists
+- AND no related roadmap, GitHub issue, milestone, or PR link is visible
+- WHEN `/aif-roadmap` evaluates planning traceability
+- THEN it may report missing linkage as a traceability gap
+- AND it does not treat the missing GitHub link alone as implementation failure.
+
+### Requirement: Roadmap writes remain owner-bounded
+
+`/aif-roadmap` MUST keep write ownership limited to the configured roadmap artifact and MUST NOT mutate GitHub, canonical OpenSpec artifacts, runtime state, QA evidence, generated rules, or implementation files.
+
+#### Scenario: Roadmap refresh with GitHub context
+
+- GIVEN GitHub context is available
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it may update `.ai-factory/ROADMAP.md`
+- AND it does not edit GitHub issues, GitHub milestones, PRs, `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/state/**`, `.ai-factory/qa/**`, or `.ai-factory/rules/generated/**`.
+
+### Requirement: Roadmap entries must preserve useful local and GitHub evidence links
+
+Roadmap entries MUST include GitHub milestone, issue, or PR links where useful, alongside local artifact paths that justify the roadmap assessment.
+
+#### Scenario: Item has both local and GitHub evidence
+
+- GIVEN a roadmap item maps to local OpenSpec artifacts and GitHub tracker items
+- WHEN `/aif-roadmap` writes the item
+- THEN it includes enough local evidence paths to justify the status
+- AND it includes GitHub links or identifiers where useful.
+
+#### Scenario: Manual roadmap notes still match evidence
+
+- GIVEN existing manual roadmap notes are still consistent with local and GitHub evidence
+- WHEN `/aif-roadmap` updates `.ai-factory/ROADMAP.md`
+- THEN it preserves those notes unless contradicted by repository evidence.

--- a/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/tasks.md
+++ b/openspec/changes/archive/2026-05-03-feat-add-github-aware-roadmap-sync/tasks.md
@@ -1,0 +1,80 @@
+# Tasks
+
+## 1. Planning and specs
+
+- [x] 1.1 Review issue #13 and current `/aif-roadmap` prompt assets.
+  Files: `injections/core/aif-roadmap-maturity-audit.md`, `injections/references/aif-roadmap/roadmap-template.md`, `injections/references/aif-roadmap/slice-checklist.md`
+  Logging: no runtime logging; document source issue and assumptions in implementation notes.
+
+- [x] 1.2 Refine this delta spec if `/aif-improve` finds missing scenarios.
+  Files: `openspec/changes/feat-add-github-aware-roadmap-sync/specs/roadmap-github-sync/spec.md`
+  Logging: no runtime logging; report touched canonical OpenSpec artifact paths.
+
+## 2. Contract tests
+
+- [x] 2.1 Add targeted prompt contract tests for GitHub-aware roadmap rules.
+  Files: `scripts/openspec-prompt-assets.test.mjs`
+  Deliverable: assertions cover GitHub evidence availability, partial/unavailable GitHub handling, supporting-evidence status, local proof requirement, write boundaries, drift detection, credential-safe output, and optional link behavior.
+  Logging: assertion messages must name the prompt or reference asset and missing contract phrase.
+  Dependency notes: tests should not call GitHub or require network.
+
+- [x] 2.2 Ensure roadmap reference assets are included in the targeted contract surface.
+  Files: `scripts/openspec-prompt-assets.test.mjs`, `injections/references/aif-roadmap/roadmap-template.md`, `injections/references/aif-roadmap/slice-checklist.md`
+  Deliverable: tests verify the roadmap template/checklist can preserve local evidence paths plus optional GitHub milestone/issue/PR links without requiring GitHub links for every item.
+  Logging: assertion messages should stay file-specific.
+  Dependency notes: depends on Task 2.1.
+
+## 3. Prompt asset behavior
+
+- [x] 3.1 Add GitHub-aware evidence guidance to the roadmap injection.
+  Files: `injections/core/aif-roadmap-maturity-audit.md`
+  Deliverable: `/aif-roadmap` may read GitHub milestones, issues, PRs, labels, linked branches, and local git tree state when available; GitHub remains supporting evidence and collection is non-blocking when unavailable or partial.
+  Logging: roadmap responses should summarize whether GitHub evidence was used, unavailable, or partially available.
+  Dependency notes: depends on Tasks 2.1-2.2.
+
+- [x] 3.2 Add explicit completion and drift rules.
+  Files: `injections/core/aif-roadmap-maturity-audit.md`
+  Deliverable: closed issues and merged PRs never mark roadmap entries `done` without local OpenSpec/source/test/QA evidence; roadmap audit reports drift between GitHub and local repository state.
+  Logging: roadmap responses should name drift categories and evidence paths or GitHub links.
+  Dependency notes: can be implemented with Task 3.1.
+
+- [x] 3.3 Add credential-safe output and read-only GitHub boundaries.
+  Files: `injections/core/aif-roadmap-maturity-audit.md`
+  Deliverable: prompt says not to mutate GitHub issues, milestones, PRs, or labels; roadmap output must not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.
+  Logging: roadmap responses may summarize GitHub access failures in sanitized form.
+  Dependency notes: can be implemented with Task 3.1.
+
+- [x] 3.4 Update roadmap reference assets for GitHub-linked evidence.
+  Files: `injections/references/aif-roadmap/roadmap-template.md`, `injections/references/aif-roadmap/slice-checklist.md`
+  Deliverable: template/checklist allow local artifact links plus optional GitHub milestone/issue/PR links without making links mandatory for every entry.
+  Logging: no runtime logging; keep template concise.
+  Dependency notes: depends on Task 3.1 wording.
+
+## 4. Documentation
+
+- [x] 4.1 Update docs only where `/aif-roadmap` evidence sources or GitHub context policy are described.
+  Files: `docs/usage.md`, `docs/context-loading-policy.md`, `docs/README.md`, `README.md` if affected
+  Deliverable: docs explain GitHub-aware roadmap sync as supporting evidence and preserve OpenSpec-native canonical priority.
+  Logging: docs-only; no runtime logging.
+  Dependency notes: avoid broad docs rewrite.
+
+## 5. Verification
+
+- [x] 5.1 Run targeted tests.
+  Files: `scripts/openspec-prompt-assets.test.mjs`
+  Commands: `openspec validate feat-add-github-aware-roadmap-sync --type change --strict --json --no-interactive --no-color`, `node --test scripts/openspec-prompt-assets.test.mjs`
+  Logging: report command result in normal response and later QA evidence.
+
+- [x] 5.2 Run repository validation and tests.
+  Files: changed prompt assets, docs, and tests
+  Commands: `npm run validate`, `npm test`, `git diff --check`
+  Logging: report command results in normal response and later QA evidence.
+
+## Commit Plan
+
+- [ ] `test: cover github-aware roadmap evidence contracts`
+  Scope: Tasks 2.1-2.2
+- [ ] `feat: add github-aware roadmap guidance`
+  Scope: Tasks 3.1-3.4
+- [ ] `docs: document github-aware roadmap evidence`
+  Scope: Tasks 4.1-5.2

--- a/openspec/specs/roadmap-github-sync/spec.md
+++ b/openspec/specs/roadmap-github-sync/spec.md
@@ -1,0 +1,122 @@
+# roadmap-github-sync Specification
+
+## Purpose
+TBD - created by archiving change feat-add-github-aware-roadmap-sync. Update Purpose after archive.
+## Requirements
+### Requirement: Roadmap audit uses GitHub as supporting evidence when available
+
+`/aif-roadmap` MUST be able to include GitHub milestones, issues, PRs, labels, linked branches, and local git tree state in the roadmap audit evidence set when that context is available.
+
+#### Scenario: GitHub evidence is available
+
+- GIVEN the repository has GitHub context from `gh`, a connector, explicit issue/PR URLs, or caller-provided metadata
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN the audit may reference relevant GitHub milestones, issues, PRs, labels, and linked branches
+- AND the normal response summarizes that GitHub evidence was used.
+
+#### Scenario: GitHub evidence is unavailable
+
+- GIVEN GitHub context is not available in the current runtime
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues from local repository evidence
+- AND the normal response states that GitHub evidence was unavailable or skipped.
+
+#### Scenario: GitHub evidence is partially available
+
+- GIVEN some GitHub context is available
+- AND other requested GitHub data is missing, rate-limited, unauthenticated, or otherwise unavailable
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues with the available GitHub and local evidence
+- AND the normal response summarizes the missing or partial GitHub evidence without treating it as a roadmap failure.
+
+### Requirement: Roadmap audit handles GitHub credentials safely
+
+`/aif-roadmap` MUST keep GitHub evidence collection non-blocking and MUST NOT write tokens, authorization headers, raw credential helper output, or private authentication diagnostics into `.ai-factory/ROADMAP.md`.
+
+#### Scenario: GitHub command reports authentication details
+
+- GIVEN a GitHub tool or connector returns authentication, authorization, token, or credential-related diagnostics
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN the roadmap may state that GitHub evidence was unavailable or partial
+- AND it does not include tokens, authorization headers, raw credential helper output, or private authentication diagnostics.
+
+#### Scenario: GitHub read access is unavailable
+
+- GIVEN GitHub read access fails because the runtime is unauthenticated, offline, rate-limited, or missing `gh`
+- WHEN `/aif-roadmap` creates or refreshes `.ai-factory/ROADMAP.md`
+- THEN roadmap generation continues from local repository evidence
+- AND it does not ask the user to mutate GitHub state as part of roadmap generation.
+
+### Requirement: GitHub state does not replace local proof
+
+`/aif-roadmap` MUST treat GitHub issue and PR state as supporting evidence only. A closed issue, completed milestone, or merged PR MUST NOT be the sole reason to mark a roadmap slice or roadmap item `done`.
+
+#### Scenario: Closed issue without local evidence
+
+- GIVEN a GitHub issue is closed
+- AND local OpenSpec artifacts, source changes, tests, CI evidence, runtime state, or QA evidence do not support the completed behavior
+- WHEN `/aif-roadmap` evaluates the related roadmap item
+- THEN it does not mark the item `done` only because the issue is closed
+- AND it reports a drift or evidence gap.
+
+#### Scenario: Merged PR with matching local evidence
+
+- GIVEN a GitHub PR is merged
+- AND the current git tree, source files, tests, OpenSpec artifacts, or QA evidence confirm the merged behavior
+- WHEN `/aif-roadmap` evaluates the related roadmap item
+- THEN it may use the PR as supporting evidence for progress
+- AND it links or names the PR where useful.
+
+### Requirement: Roadmap audit detects GitHub/local drift
+
+`/aif-roadmap` MUST call out material drift between GitHub tracker state and local canonical evidence.
+
+#### Scenario: GitHub says done but local evidence is missing
+
+- GIVEN GitHub issue, milestone, or PR state implies work is complete
+- AND local OpenSpec artifacts, source tree, tests, CI, runtime state, or QA evidence are missing or contradictory
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it reports the mismatch as drift or an evidence gap.
+
+#### Scenario: Local implementation exists but GitHub is stale
+
+- GIVEN local source, tests, OpenSpec artifacts, runtime state, or QA evidence show implemented work
+- AND the related GitHub issue, milestone, or roadmap link appears stale or absent
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it reports the stale GitHub linkage as drift instead of discarding local evidence.
+
+#### Scenario: OpenSpec change lacks tracker linkage
+
+- GIVEN an active or archived OpenSpec change exists
+- AND no related roadmap, GitHub issue, milestone, or PR link is visible
+- WHEN `/aif-roadmap` evaluates planning traceability
+- THEN it may report missing linkage as a traceability gap
+- AND it does not treat the missing GitHub link alone as implementation failure.
+
+### Requirement: Roadmap writes remain owner-bounded
+
+`/aif-roadmap` MUST keep write ownership limited to the configured roadmap artifact and MUST NOT mutate GitHub, canonical OpenSpec artifacts, runtime state, QA evidence, generated rules, or implementation files.
+
+#### Scenario: Roadmap refresh with GitHub context
+
+- GIVEN GitHub context is available
+- WHEN `/aif-roadmap` refreshes the roadmap
+- THEN it may update `.ai-factory/ROADMAP.md`
+- AND it does not edit GitHub issues, GitHub milestones, PRs, `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/state/**`, `.ai-factory/qa/**`, or `.ai-factory/rules/generated/**`.
+
+### Requirement: Roadmap entries must preserve useful local and GitHub evidence links
+
+Roadmap entries MUST include GitHub milestone, issue, or PR links where useful, alongside local artifact paths that justify the roadmap assessment.
+
+#### Scenario: Item has both local and GitHub evidence
+
+- GIVEN a roadmap item maps to local OpenSpec artifacts and GitHub tracker items
+- WHEN `/aif-roadmap` writes the item
+- THEN it includes enough local evidence paths to justify the status
+- AND it includes GitHub links or identifiers where useful.
+
+#### Scenario: Manual roadmap notes still match evidence
+
+- GIVEN existing manual roadmap notes are still consistent with local and GitHub evidence
+- WHEN `/aif-roadmap` updates `.ai-factory/ROADMAP.md`
+- THEN it preserves those notes unless contradicted by repository evidence.

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -10,7 +10,9 @@ const REPO_ROOT = resolve(__dirname, '..');
 
 const EXPLICIT_REFERENCE_ASSETS = [
   'skills/aif-analyze/references/config-template.yaml',
-  'skills/aif-done/references/finalization-contract.md'
+  'skills/aif-done/references/finalization-contract.md',
+  'injections/references/aif-roadmap/roadmap-template.md',
+  'injections/references/aif-roadmap/slice-checklist.md'
 ];
 
 const MODE_GATED_PROMPTS = [
@@ -52,6 +54,13 @@ const SIDECAR_PROMPT_ASSETS = [
   ['agent-files/claude/aifhub-review-sidecar.md', 'review'],
   ['agent-files/codex/aifhub-security-sidecar.toml', 'security'],
   ['agent-files/claude/aifhub-security-sidecar.md', 'security']
+];
+
+const ROADMAP_PROMPT_ASSET = 'injections/core/aif-roadmap-maturity-audit.md';
+
+const ROADMAP_REFERENCE_ASSETS = [
+  'injections/references/aif-roadmap/roadmap-template.md',
+  'injections/references/aif-roadmap/slice-checklist.md'
 ];
 
 const CANONICAL_CHANGE_FILES = [
@@ -197,6 +206,8 @@ describe('OpenSpec-native prompt asset contract', () => {
       'skills/aif-analyze/SKILL.md',
       'skills/aif-done/SKILL.md',
       'injections/core/aif-rules-check-openspec-generated-rules.md',
+      ROADMAP_PROMPT_ASSET,
+      ...ROADMAP_REFERENCE_ASSETS,
       'injections/core/aif-implement-plan-folder.md',
       'agent-files/codex/aifhub-verifier.toml',
       'agent-files/claude/aifhub-verifier.md'
@@ -506,6 +517,56 @@ describe('OpenSpec-native prompt asset contract', () => {
     for (const [relativePath, gate] of SIDECAR_PROMPT_ASSETS) {
       const asset = await readRepoFile(relativePath);
       assertIncludes(asset, `"gate": "${gate}"`, relativePath);
+    }
+  });
+
+  it('defines GitHub-aware roadmap evidence as supporting and non-blocking', async () => {
+    const asset = stripFencedBlocks(await readRepoFile(ROADMAP_PROMPT_ASSET));
+
+    for (const expected of [
+      'GitHub-aware evidence',
+      'milestones',
+      'open and closed issues',
+      'open, merged, and closed PRs',
+      'labels',
+      'linked branches',
+      'current git tree',
+      'supporting evidence only',
+      'must never be the sole reason to mark a slice or roadmap item `done`',
+      'GitHub evidence was used, unavailable, or partially available'
+    ]) {
+      assertIncludes(asset, expected, ROADMAP_PROMPT_ASSET);
+    }
+  });
+
+  it('keeps GitHub-aware roadmap output owner-bounded and credential-safe', async () => {
+    const asset = stripFencedBlocks(await readRepoFile(ROADMAP_PROMPT_ASSET));
+
+    for (const expected of [
+      'must not mutate GitHub issues, milestones, PRs, labels, or linked branches',
+      'must not write tokens',
+      'authorization headers',
+      'raw credential helper output',
+      'private authentication diagnostics',
+      'GitHub says done, but local evidence is missing',
+      'local implementation exists, but GitHub is stale',
+      'OpenSpec change exists, but no linked roadmap/milestone/issue is visible'
+    ]) {
+      assertIncludes(asset, expected, ROADMAP_PROMPT_ASSET);
+    }
+  });
+
+  it('keeps roadmap references ready for optional GitHub links without requiring them everywhere', async () => {
+    for (const relativePath of ROADMAP_REFERENCE_ASSETS) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      for (const expected of [
+        'GitHub evidence',
+        'GitHub links are optional',
+        'local artifact evidence remains required'
+      ]) {
+        assertIncludes(asset, expected, relativePath);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Teach `/aif-roadmap` to treat GitHub milestones, issues, PRs, labels, linked branches, and git tree state as supporting evidence only.
- Keep roadmap completion tied to local OpenSpec, source, test, CI, runtime, and QA evidence.
- Update roadmap prompt assets, reference templates, and documentation to reflect read-only, credential-safe GitHub handling.
- Add contract tests for the GitHub-aware roadmap behavior and archive the accepted OpenSpec change.

## Testing
- `openspec validate` for the change and accepted spec
- `node --test scripts/openspec-prompt-assets.test.mjs`
- `npm run validate`
- `npm test`
- `git diff --check`