### PR TITLE
Clarify OpenSpec-native bug-fix workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,52 @@ Optional gates:
 - `/aif-mode doctor` - mode/config/artifact readiness.
 - `/aif-mode sync` - derived artifact refresh and OpenSpec validation/status when available.
 
+## Bug Fix Workflows
+
+OpenSpec-native mode has two distinct bug-fix workflows.
+
+### Workflow A: New Bug Report
+
+A new bug report starts as planned OpenSpec work:
+
+```text
+/aif-plan full "fix <bug description>"
+/aif-improve <change-id>
+/aif-mode sync --change <change-id>
+/aif-implement <change-id>
+/aif-rules-check                  # optional
+/aif-verify <change-id>
+/aif-done <change-id>
+/aif-mode sync
+/aif-commit
+```
+
+- A bug fix is still an OpenSpec change when it changes product or workflow behavior.
+- Create delta specs when behavior changes.
+- Docs/tooling-only bug fixes may omit delta specs only when the proposal explains why no product or workflow behavior changes.
+- Missing OpenSpec CLI means degraded validation, not planning failure.
+- No OpenSpec-native bug-fix path creates `.ai-factory/plans/<id>/`.
+
+### Workflow B: Fix After Failed Verification
+
+`/aif-fix` is for findings inside an existing active OpenSpec change:
+
+```text
+/aif-verify <change-id> -> fail
+/aif-fix <change-id>
+/aif-mode sync --change <change-id>     # optional if canonical artifacts changed
+/aif-rules-check                        # optional
+/aif-verify <change-id>
+```
+
+- `/aif-fix` requires existing QA evidence or selected findings.
+- `/aif-fix` does not create a new OpenSpec change.
+- `/aif-fix` writes fix traces under `.ai-factory/state/<change-id>/fixes/`.
+- `/aif-fix` does not write QA verdicts.
+- `/aif-fix` does not archive.
+- `/aif-fix` routes back to `/aif-verify <change-id>`.
+- No OpenSpec-native bug-fix path creates `.ai-factory/plans/<id>/`.
+
 ## Artifact Layout
 
 OpenSpec-native v1 uses this ownership model in user projects:

--- a/agent-files/claude/aifhub-fixer.md
+++ b/agent-files/claude/aifhub-fixer.md
@@ -21,6 +21,14 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present.
 - Allowed write scope: files already inside the selected finding's changed scope plus fix traces under `.ai-factory/state/<change-id>/`.
+- A new bug report is not a post-verify fix. If invoked with a bug description but no active OpenSpec change and no QA evidence, stop with: No active OpenSpec change or QA evidence was found for this bug fix. For a new bug report, create an OpenSpec change first: `/aif-plan full "fix <bug description>"`.
+- `/aif-fix` requires existing QA evidence or selected findings.
+- `/aif-fix` does not create a new OpenSpec change.
+- `/aif-fix` writes fix traces under `.ai-factory/state/<change-id>/fixes/`.
+- `/aif-fix` does not write QA verdicts.
+- `/aif-fix` does not archive.
+- `/aif-fix` routes back to `/aif-verify <change-id>`.
+- In OpenSpec-native mode, `/aif-fix` must not create `.ai-factory/plans/<id>/` or invent legacy fix artifacts.
 - Do not write QA verdicts, do not archive, and do not create legacy plan artifacts in OpenSpec-native mode.
 - Return finding IDs fixed, files modified, active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, remaining blockers, and the next re-verify command.
 

--- a/agent-files/codex/aifhub-fixer.toml
+++ b/agent-files/codex/aifhub-fixer.toml
@@ -18,6 +18,14 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present.
 - Allowed write scope: files already inside the selected finding's changed scope plus fix traces under .ai-factory/state/<change-id>/.
+- A new bug report is not a post-verify fix. If invoked with a bug description but no active OpenSpec change and no QA evidence, stop with: No active OpenSpec change or QA evidence was found for this bug fix. For a new bug report, create an OpenSpec change first: /aif-plan full "fix <bug description>".
+- `/aif-fix` requires existing QA evidence or selected findings.
+- `/aif-fix` does not create a new OpenSpec change.
+- `/aif-fix` writes fix traces under `.ai-factory/state/<change-id>/fixes/`.
+- `/aif-fix` does not write QA verdicts.
+- `/aif-fix` does not archive.
+- `/aif-fix` routes back to `/aif-verify <change-id>`.
+- In OpenSpec-native mode, `/aif-fix` must not create `.ai-factory/plans/<id>/` or invent legacy fix artifacts.
 - Do not write QA verdicts, do not archive, and do not create legacy plan artifacts in OpenSpec-native mode.
 - Return finding IDs fixed, files modified, active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, remaining blockers, and the next re-verify command.
 

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -73,6 +73,23 @@ Generated rules are derived guidance only. If generated rules conflict with cano
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
 
+## Bug Fix Context
+
+OpenSpec-native bug fixes have two context shapes:
+
+- New bug reports are planning input.
+- Fresh bug reports must start with `/aif-plan full "fix <bug description>"`.
+- A planned bug fix reads base specs and writes a canonical OpenSpec change under `openspec/changes/<change-id>/`.
+- Bug fixes that change product or workflow behavior need delta specs.
+- Docs/tooling-only bug fixes may omit delta specs only when the proposal explains why no product or workflow behavior changes.
+- Missing OpenSpec CLI means degraded validation, not planning failure.
+- Post-verify fixes are execution input.
+- `/aif-fix` reads an existing active OpenSpec change and QA evidence or selected findings from `.ai-factory/qa/<change-id>/`.
+- `/aif-fix` writes fix traces under `.ai-factory/state/<change-id>/fixes/`.
+- `/aif-fix` must not create a canonical OpenSpec change, write QA verdicts, or archive.
+- `/aif-fix` must not create `.ai-factory/plans/<id>/`.
+- `/aif-fix` routes back to `/aif-verify <change-id>`.
+
 ## GitHub-Aware Roadmap Context
 
 `/aif-roadmap` may additionally read GitHub and git-tracker context when available:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,52 @@ The `aifhub-extension` package repository stays artifact-light: root `openspec/`
 
 AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Users should keep using `/aif-*` commands; this extension does not install or rely on OpenSpec slash commands.
 
+## Bug Fix Workflows
+
+OpenSpec-native mode separates new bug reports from fixes for failed verification findings.
+
+### Workflow A: New Bug Report
+
+A new bug report starts as planned OpenSpec work:
+
+```text
+/aif-plan full "fix <bug description>"
+/aif-improve <change-id>
+/aif-mode sync --change <change-id>
+/aif-implement <change-id>
+/aif-rules-check                  # optional
+/aif-verify <change-id>
+/aif-done <change-id>
+/aif-mode sync
+/aif-commit
+```
+
+- A bug fix is still an OpenSpec change when it changes product or workflow behavior.
+- Create delta specs when behavior changes.
+- Docs/tooling-only bug fixes may omit delta specs only when the proposal explains why no product or workflow behavior changes.
+- Missing OpenSpec CLI means degraded validation, not planning failure.
+- No OpenSpec-native bug-fix path creates `.ai-factory/plans/<id>/`.
+
+### Workflow B: Fix After Failed Verification
+
+`/aif-fix` handles selected findings inside an existing active OpenSpec change:
+
+```text
+/aif-verify <change-id> -> fail
+/aif-fix <change-id>
+/aif-mode sync --change <change-id>     # optional if canonical artifacts changed
+/aif-rules-check                        # optional
+/aif-verify <change-id>
+```
+
+- `/aif-fix` requires existing QA evidence or selected findings.
+- `/aif-fix` does not create a new OpenSpec change.
+- `/aif-fix` writes fix traces under `.ai-factory/state/<change-id>/fixes/`.
+- `/aif-fix` does not write QA verdicts.
+- `/aif-fix` does not archive.
+- `/aif-fix` routes back to `/aif-verify <change-id>`.
+- No OpenSpec-native bug-fix path creates `.ai-factory/plans/<id>/`.
+
 ## Artifact Ownership
 
 | Path | Role |

--- a/injections/core/aif-fix-plan-folder.md
+++ b/injections/core/aif-fix-plan-folder.md
@@ -31,6 +31,27 @@ Use `buildFixContext(options)` from `scripts/openspec-execution-context.mjs` whe
 
 Use shared vocabulary consistently: `OpenSpec-native mode`, `canonical OpenSpec change`, `active change`, `change-id`, `base specs`, `delta specs`, `generated rules`, `runtime state`, `QA evidence`, and `legacy AI Factory-only mode`.
 
+Bug-fix routing:
+
+- A new bug report is not a post-verify fix.
+- If `/aif-fix` is invoked with a bug description but no active OpenSpec change and no QA evidence, stop and say:
+
+```text
+No active OpenSpec change or QA evidence was found for this bug fix.
+
+For a new bug report, create an OpenSpec change first:
+
+/aif-plan full "fix <bug description>"
+```
+
+- `/aif-fix` requires existing QA evidence or selected findings.
+- `/aif-fix` does not create a new OpenSpec change.
+- `/aif-fix` writes fix traces under `.ai-factory/state/<change-id>/fixes/`.
+- `/aif-fix` does not write QA verdicts.
+- `/aif-fix` does not archive.
+- `/aif-fix` routes back to `/aif-verify <change-id>`.
+- In OpenSpec-native mode, `/aif-fix` must not create `.ai-factory/plans/<id>/` or invent legacy fix artifacts.
+
 Resolve the active change using `scripts/active-change-resolver.mjs` when available:
 
 - Prefer an explicit `<change-id>` or `@openspec/changes/<change-id>` input when provided.

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -16,6 +16,10 @@ function assertIncludes(source, expected, label) {
   assert.ok(source.includes(expected), `${label} should include ${JSON.stringify(expected)}`);
 }
 
+function assertNotIncludes(source, unexpected, label) {
+  assert.ok(!source.includes(unexpected), `${label} should not include ${JSON.stringify(unexpected)}`);
+}
+
 function assertOrder(source, orderedFragments, label) {
   let cursor = -1;
 
@@ -110,5 +114,59 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '/aif-commit',
       '/aif-evolve'
     ], 'docs/usage.md workflow');
+  });
+
+  it('documents planned bug fixes separately from post-verify fixes', async () => {
+    const readme = await readRepoFile('README.md');
+    const usage = await readRepoFile('docs/usage.md');
+    const contextPolicy = await readRepoFile('docs/context-loading-policy.md');
+    const readmeBugFixes = extractSection(readme, '## Bug Fix Workflows');
+    const usageBugFixes = extractSection(usage, '## Bug Fix Workflows');
+    const contextBugFixes = extractSection(contextPolicy, '## Bug Fix Context');
+
+    for (const [label, section] of [
+      ['README.md Bug Fix Workflows', readmeBugFixes],
+      ['docs/usage.md Bug Fix Workflows', usageBugFixes]
+    ]) {
+      for (const expected of [
+        '/aif-plan full "fix <bug description>"',
+        '/aif-improve <change-id>',
+        '/aif-mode sync --change <change-id>',
+        '/aif-implement <change-id>',
+        '/aif-rules-check',
+        '/aif-verify <change-id>',
+        '/aif-done <change-id>',
+        '/aif-mode sync',
+        '/aif-commit',
+        '/aif-verify <change-id> -> fail',
+        '/aif-fix <change-id>',
+        'A bug fix is still an OpenSpec change when it changes product or workflow behavior.',
+        'Create delta specs when behavior changes.',
+        'Docs/tooling-only bug fixes may omit delta specs only when the proposal explains why no product or workflow behavior changes.',
+        'Missing OpenSpec CLI means degraded validation, not planning failure.',
+        '`/aif-fix` requires existing QA evidence or selected findings.',
+        '`/aif-fix` does not create a new OpenSpec change.',
+        '`.ai-factory/state/<change-id>/fixes/`',
+        '`/aif-fix` does not write QA verdicts.',
+        '`/aif-fix` does not archive.',
+        '`/aif-fix` routes back to `/aif-verify <change-id>`.',
+        'No OpenSpec-native bug-fix path creates `.ai-factory/plans/<id>/`.'
+      ]) {
+        assertIncludes(section, expected, label);
+      }
+    }
+
+    for (const expected of [
+      'New bug reports are planning input.',
+      'Post-verify fixes are execution input.',
+      'Fresh bug reports must start with `/aif-plan full "fix <bug description>"`.',
+      '`/aif-fix` must not create a canonical OpenSpec change',
+      '`/aif-fix` must not create `.ai-factory/plans/<id>/`'
+    ]) {
+      assertIncludes(contextBugFixes, expected, 'docs/context-loading-policy.md Bug Fix Context');
+    }
+
+    assertNotIncludes(readmeBugFixes, '.ai-factory/plans/<id>/task.md', 'README.md Bug Fix Workflows');
+    assertNotIncludes(usageBugFixes, '.ai-factory/plans/<id>/task.md', 'docs/usage.md Bug Fix Workflows');
   });
 });

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -35,6 +35,12 @@ const IMPLEMENT_PROMPT_ASSETS = [
   'agent-files/claude/aifhub-implement-worker.md'
 ];
 
+const FIX_PROMPT_ASSETS = [
+  'injections/core/aif-fix-plan-folder.md',
+  'agent-files/codex/aifhub-fixer.toml',
+  'agent-files/claude/aifhub-fixer.md'
+];
+
 const PLANNING_RUNTIME_PROMPT_ASSETS = [
   'injections/core/aif-explore-plan-folder.md',
   'injections/core/aif-plan-plan-folder.md',
@@ -357,6 +363,31 @@ describe('OpenSpec-native prompt asset contract', () => {
         /never archive|does not archive|no archive/i,
         `${relativePath} should forbid archive from /aif-verify`
       );
+    }
+  });
+
+  it('requires fix prompts to route new bug reports to planned OpenSpec changes', async () => {
+    for (const relativePath of FIX_PROMPT_ASSETS) {
+      const asset = await readRepoFile(relativePath);
+      const openspec = extractMarkdownSection(asset, 'OpenSpec-native mode');
+
+      for (const expected of [
+        'A new bug report is not a post-verify fix.',
+        'No active OpenSpec change or QA evidence was found for this bug fix.',
+        '/aif-plan full "fix <bug description>"',
+        '`/aif-fix` requires existing QA evidence or selected findings.',
+        '`/aif-fix` does not create a new OpenSpec change.',
+        '`.ai-factory/state/<change-id>/fixes/`',
+        '`/aif-fix` does not write QA verdicts.',
+        '`/aif-fix` does not archive.',
+        '`/aif-fix` routes back to `/aif-verify <change-id>`.',
+        'must not create `.ai-factory/plans/<id>/`'
+      ]) {
+        assertIncludes(openspec, expected, `${relativePath} OpenSpec-native mode`);
+      }
+
+      assertNotIncludes(openspec, '.ai-factory/plans/<id>/status.yaml', `${relativePath} OpenSpec-native mode`);
+      assertNotIncludes(openspec, 'legacy `status.yaml` source of truth', `${relativePath} OpenSpec-native mode`);
     }
   });
 


### PR DESCRIPTION
## Summary
- Document the split between new bug reports and post-verify fixes in `README.md` and `docs/usage.md`
- Tighten `/aif-fix` guidance so fresh bug reports route to `/aif-plan full "fix <bug description>"` instead of legacy plan artifacts
- Update context-loading policy and fixer agent assets to keep OpenSpec-native write boundaries explicit
- Add contract tests covering the docs and prompt behavior

## Testing
- `npm run validate` passed
- `npm test` passed
- `openspec validate docs-define-openspec-native-bug-fix-workflows --type change --strict` passed