### PR TITLE
test(openspec): cover lifecycle runner contracts

### DIFF
--- a/agent-files/claude/aifhub-verifier.md
+++ b/agent-files/claude/aifhub-verifier.md
@@ -17,6 +17,7 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 
 - Verify exactly one active OpenSpec change.
 - Before lint, tests, review, security, or rules checks, use `scripts/openspec-verification-context.mjs` and `scripts/openspec-runner.mjs` when available.
+- Request OpenSpec validation through `validateOpenSpecChange(changeId)` and status through `getOpenSpecStatus(changeId)` from `scripts/openspec-runner.mjs`.
 - Fail-fast OpenSpec validation before code checks: fail invalid OpenSpec artifacts before code checks and use `shouldRunCodeVerification` as the handoff signal.
 - Missing CLI remains degraded missing-CLI behavior unless strict config `requireCliForVerify` requires the CLI.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.

--- a/agent-files/codex/aifhub-verifier.toml
+++ b/agent-files/codex/aifhub-verifier.toml
@@ -14,6 +14,7 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 
 - Verify exactly one active OpenSpec change.
 - Before lint, tests, review, security, or rules checks, use scripts/openspec-verification-context.mjs and scripts/openspec-runner.mjs when available.
+- Request OpenSpec validation through validateOpenSpecChange(changeId) and status through getOpenSpecStatus(changeId) from scripts/openspec-runner.mjs.
 - Fail-fast OpenSpec validation before code checks: fail invalid OpenSpec artifacts before code checks and use shouldRunCodeVerification as the handoff signal.
 - Missing CLI remains degraded missing-CLI behavior unless strict config requireCliForVerify requires the CLI.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.

--- a/injections/core/aif-verify-plan-folder.md
+++ b/injections/core/aif-verify-plan-folder.md
@@ -27,7 +27,7 @@ Before resolving verification scope, read `.ai-factory/config.yaml` when it exis
 
 When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-verify` verifies implementation against the active OpenSpec change.
 
-Before running lint, tests, code review, security review, or rules review, resolve the active change, ensure runtime layout, and use `scripts/openspec-verification-context.mjs` with `scripts/openspec-runner.mjs` when available. Fail invalid OpenSpec artifacts before code checks. Treat missing CLI as degraded missing-CLI behavior unless strict config (`aifhub.openspec.requireCliForVerify`) requires the CLI. Use `shouldRunCodeVerification` as the handoff signal: `false` blocks code checks and routes to `/aif-fix <change-id>`; `true` allows normal code verification to continue.
+Before running lint, tests, code review, security review, or rules review, resolve the active change, ensure runtime layout, and use `scripts/openspec-verification-context.mjs` with `scripts/openspec-runner.mjs` when available. Request validation through `validateOpenSpecChange(changeId)` and status through `getOpenSpecStatus(changeId)` from the shared runner. Fail invalid OpenSpec artifacts before code checks. Treat missing CLI as degraded missing-CLI behavior unless strict config (`aifhub.openspec.requireCliForVerify`) requires the CLI. Use `shouldRunCodeVerification` as the handoff signal: `false` blocks code checks and routes to `/aif-fix <change-id>`; `true` allows normal code verification to continue.
 
 Use shared vocabulary consistently: `OpenSpec-native mode`, `canonical OpenSpec change`, `active change`, `change-id`, `base specs`, `delta specs`, `generated rules`, `runtime state`, `QA evidence`, and `legacy AI Factory-only mode`.
 

--- a/scripts/openspec-lifecycle-contract.test.mjs
+++ b/scripts/openspec-lifecycle-contract.test.mjs
@@ -1,0 +1,240 @@
+// openspec-lifecycle-contract.test.mjs - lifecycle-level OpenSpec CLI prompt contracts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const LIFECYCLE_ASSETS = {
+  planning: [
+    'injections/core/aif-plan-plan-folder.md'
+  ],
+  improvement: [
+    'injections/core/aif-improve-plan-folder.md'
+  ],
+  planPolisher: [
+    'agent-files/codex/aifhub-plan-polisher.toml',
+    'agent-files/claude/aifhub-plan-polisher.md'
+  ],
+  sync: [
+    'skills/aif-mode/SKILL.md',
+    'skills/aif-mode/references/ARTIFACT-SYNC.md'
+  ],
+  verify: [
+    'injections/core/aif-verify-plan-folder.md',
+    'agent-files/codex/aifhub-verifier.toml',
+    'agent-files/claude/aifhub-verifier.md'
+  ],
+  done: [
+    'skills/aif-done/SKILL.md',
+    'skills/aif-done/references/finalization-contract.md',
+    'agent-files/codex/aifhub-done-finalizer.toml',
+    'agent-files/claude/aifhub-done-finalizer.md'
+  ]
+};
+
+const OPENSPEC_SLASH_COMMAND_PATTERNS = [
+  /\/opsx:[\w-]+/i,
+  /\/openspec:[\w-]+/i
+];
+
+async function readRepoFile(relativePath) {
+  return readFile(join(REPO_ROOT, relativePath), 'utf8');
+}
+
+async function readJoined(paths) {
+  const parts = await Promise.all(paths.map(async (relativePath) => [
+    `\n\n<!-- ${relativePath} -->\n`,
+    await readRepoFile(relativePath)
+  ].join('')));
+
+  return parts.join('\n');
+}
+
+function stripFencedBlocks(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const kept = [];
+  let inFence = false;
+
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+
+    if (!inFence) kept.push(line);
+  }
+
+  return kept.join('\n');
+}
+
+function assertIncludes(source, expected, label) {
+  assert.ok(source.includes(expected), `${label} should include ${JSON.stringify(expected)}`);
+}
+
+function assertNotIncludes(source, unexpected, label) {
+  assert.ok(!source.includes(unexpected), `${label} should not include ${JSON.stringify(unexpected)}`);
+}
+
+function assertNoInstallGuidance(source, label) {
+  assert.doesNotMatch(
+    source,
+    /\b(?:must|should|need(?:s)? to|required to|recommended to|recommend)\s+install OpenSpec skills\b/i,
+    `${label} should not tell users or agents to install OpenSpec skills`
+  );
+  assert.doesNotMatch(
+    source,
+    /\b(?:must|should|need(?:s)? to|required to|recommended to|recommend)\s+install OpenSpec slash commands\b/i,
+    `${label} should not tell users or agents to install OpenSpec slash commands`
+  );
+}
+
+describe('OpenSpec lifecycle CLI integration contract', () => {
+  it('keeps OpenSpec CLI routing behind the shared runner and off OpenSpec slash commands', async () => {
+    const lifecyclePaths = Object.values(LIFECYCLE_ASSETS).flat();
+
+    for (const relativePath of lifecyclePaths) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      assertNoInstallGuidance(asset, relativePath);
+
+      for (const pattern of OPENSPEC_SLASH_COMMAND_PATTERNS) {
+        assert.doesNotMatch(
+          asset,
+          pattern,
+          `${relativePath} should not route users to OpenSpec slash commands`
+        );
+      }
+
+      if (/\b(?:validateOpenSpecChange|getOpenSpecStatus|archiveOpenSpecChange|getOpenSpecInstructions)\b/.test(asset)) {
+        assertIncludes(asset, 'scripts/openspec-runner.mjs', relativePath);
+      }
+    }
+  });
+
+  it('requires planning to create canonical artifacts and request degraded validation through the runner', async () => {
+    const planning = await readJoined(LIFECYCLE_ASSETS.planning);
+
+    for (const expected of [
+      'openspec/changes/<change-id>/proposal.md',
+      'openspec/changes/<change-id>/design.md',
+      'openspec/changes/<change-id>/tasks.md',
+      'openspec/changes/<change-id>/specs/<capability>/spec.md',
+      'validateOpenSpecChange(changeId)',
+      'scripts/openspec-runner.mjs',
+      'Missing or unsupported OpenSpec CLI is degraded validation, not planning failure'
+    ]) {
+      assertIncludes(planning, expected, 'planning lifecycle');
+    }
+  });
+
+  it('requires improvement to patch canonical artifacts, preserve user edits, and request validation', async () => {
+    const improvement = await readJoined(LIFECYCLE_ASSETS.improvement);
+
+    for (const expected of [
+      'openspec/changes/<change-id>/proposal.md',
+      'openspec/changes/<change-id>/design.md',
+      'openspec/changes/<change-id>/tasks.md',
+      'openspec/changes/<change-id>/specs/**/spec.md',
+      'Read current artifact content before editing',
+      'Preserve user-written sections',
+      'patch-style',
+      'validateOpenSpecChange(changeId)',
+      'scripts/openspec-runner.mjs',
+      'Missing or unsupported OpenSpec CLI is degraded validation'
+    ]) {
+      assertIncludes(improvement, expected, 'improvement lifecycle');
+    }
+  });
+
+  it('requires plan-polisher agents to validate touched canonical artifacts through the runner', async () => {
+    for (const relativePath of LIFECYCLE_ASSETS.planPolisher) {
+      const asset = await readRepoFile(relativePath);
+
+      for (const expected of [
+        'proposal.md',
+        'design.md',
+        'tasks.md',
+        'specs/**/spec.md',
+        'validateOpenSpecChange(changeId)',
+        'scripts/openspec-runner.mjs'
+      ]) {
+        assertIncludes(asset, expected, relativePath);
+      }
+
+      assert.match(
+        asset,
+        /degraded validation|CLI is unavailable|missing CLI/i,
+        `${relativePath} should report degraded validation when the CLI is missing`
+      );
+    }
+  });
+
+  it('requires sync to compile generated rules and request validation/status through the runner', async () => {
+    const sync = await readJoined(LIFECYCLE_ASSETS.sync);
+
+    for (const expected of [
+      'compile generated rules',
+      'validateOpenSpecChange(changeId)',
+      'getOpenSpecStatus(changeId)',
+      'scripts/openspec-runner.mjs',
+      'no-delta-specs',
+      'base-only sync',
+      'Missing or unsupported OpenSpec CLI is degraded'
+    ]) {
+      assertIncludes(sync, expected, 'sync lifecycle');
+    }
+  });
+
+  it('requires verify to validate/status through the runner, fail invalid OpenSpec first, and write verify evidence', async () => {
+    const verify = await readJoined(LIFECYCLE_ASSETS.verify);
+
+    for (const expected of [
+      'scripts/openspec-verification-context.mjs',
+      'scripts/openspec-runner.mjs',
+      'validateOpenSpecChange(changeId)',
+      'getOpenSpecStatus(changeId)',
+      'Fail invalid OpenSpec artifacts before code checks',
+      '.ai-factory/qa/<change-id>/',
+      'aif-gate-result',
+      '"gate": "verify"'
+    ]) {
+      assertIncludes(verify, expected, 'verify lifecycle');
+    }
+
+    assert.match(verify, /missing CLI.*degraded|degraded missing-CLI/i);
+    assert.match(verify, /strict config|requireCliForVerify/i);
+    assert.match(verify, /\/aif-verify.*does not archive|Do not archive/i);
+    assert.match(verify, /\/aif-done.*owns OpenSpec archive\/finalization/i);
+  });
+
+  it('requires done to own archive/finalization and only done to call archiveOpenSpecChange', async () => {
+    const done = await readJoined(LIFECYCLE_ASSETS.done);
+    const nonDone = await readJoined([
+      ...LIFECYCLE_ASSETS.planning,
+      ...LIFECYCLE_ASSETS.improvement,
+      ...LIFECYCLE_ASSETS.planPolisher,
+      ...LIFECYCLE_ASSETS.sync,
+      ...LIFECYCLE_ASSETS.verify
+    ]);
+
+    for (const expected of [
+      'archiveOpenSpecChange(changeId)',
+      'scripts/openspec-runner.mjs',
+      '--skip-specs',
+      'If OpenSpec CLI is missing or unsupported and archive is required, fail',
+      '/aif-verify does not archive',
+      'Do not directly mutate `openspec/specs/**`',
+      '.ai-factory/qa/<change-id>/',
+      '.ai-factory/state/<change-id>/'
+    ]) {
+      assertIncludes(done, expected, 'done lifecycle');
+    }
+
+    assert.match(done, /\/aif-done.*archive\/finalization|only OpenSpec-native archive\/finalization step/i);
+    assertNotIncludes(nonDone, 'archiveOpenSpecChange(changeId)', 'non-done lifecycle assets');
+  });
+});

--- a/skills/aif-done/references/finalization-contract.md
+++ b/skills/aif-done/references/finalization-contract.md
@@ -35,7 +35,7 @@ openspec/changes/<change-id>/specs/**/spec.md
 
 ### Archive Policy
 
-OpenSpec-native `/aif-done` uses `scripts/openspec-done-finalizer.mjs`. Archive lifecycle mutation must happen through `archiveOpenSpecChange(changeId, options)` and never through custom folder movement or direct `openspec/specs` edits. Normal archive is `openspec archive <change-id> --yes`.
+OpenSpec-native `/aif-done` uses `scripts/openspec-done-finalizer.mjs`. Archive lifecycle mutation must happen through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs` and never through custom folder movement or direct `openspec/specs` edits. Normal archive is `openspec archive <change-id> --yes`.
 
 Normal archival corresponds to:
 

--- a/skills/aif-mode/SKILL.md
+++ b/skills/aif-mode/SKILL.md
@@ -90,8 +90,9 @@ When `--export-openspec` is passed, export compatibility artifacts from OpenSpec
 
 Refresh derived or compatibility artifacts without changing mode.
 
-- In OpenSpec-native mode: ensure skeleton paths, compile generated rules when `compileRulesOnSync` is enabled, validate selected changes when `validateOnSync` is enabled and a compatible CLI is available, detect legacy plans, optionally update `.ai-factory/state/current.yaml` with `--current`, and write a sync report.
+- In OpenSpec-native mode: ensure skeleton paths, compile generated rules when `compileRulesOnSync` is enabled, validate selected changes through `validateOpenSpecChange(changeId)` and collect status through `getOpenSpecStatus(changeId)` from `scripts/openspec-runner.mjs` when `validateOnSync` is enabled and a compatible CLI is available, detect legacy plans, optionally update `.ai-factory/state/current.yaml` with `--current`, and write a sync report.
 - During `sync --all`, skip sync validation for selected changes that do not contain `openspec/changes/<id>/specs/**/spec.md` delta specs; report `no-delta-specs` warnings while still compiling generated rules and validating selected changes that do contain delta specs.
+- Missing or unsupported OpenSpec CLI is degraded sync validation/status, not a sync failure unless strict command context requires CLI-backed evidence.
 - In AI Factory-only mode: ensure legacy paths, optionally export OpenSpec changes with `--export-openspec`, preserve OpenSpec artifacts, and write a sync report.
 
 ### `doctor`

--- a/skills/aif-mode/references/ARTIFACT-SYNC.md
+++ b/skills/aif-mode/references/ARTIFACT-SYNC.md
@@ -7,13 +7,15 @@ OpenSpec sync performs these actions without changing mode:
 1. Ensure `openspec/config.yaml`, `openspec/specs/`, `openspec/changes/`, `.ai-factory/state/`, `.ai-factory/qa/`, and `.ai-factory/rules/generated/`.
 2. Resolve selected changes from `--change <id>`, `--all`, or active change resolution.
 3. Compile generated rules through `scripts/openspec-rules-compiler.mjs` when `aifhub.openspec.compileRulesOnSync` is not `false`.
-4. Validate selected changes and collect status through `scripts/openspec-runner.mjs` when `aifhub.openspec.validateOnSync` is not `false` and compatible CLI capabilities are available.
+4. Validate selected changes through `validateOpenSpecChange(changeId)` and collect status through `getOpenSpecStatus(changeId)` from `scripts/openspec-runner.mjs` when `aifhub.openspec.validateOnSync` is not `false` and compatible CLI capabilities are available.
 5. Detect legacy plans that may need migration.
 6. Write a sync report under `.ai-factory/state/mode-switches/`.
 
-When no active changes are selected, sync still refreshes `.ai-factory/rules/generated/openspec-base.md`, skips change-specific generated rules, skips change validation with `no-selected-changes`, writes a report, and returns OK.
+When no active changes are selected, base-only sync still refreshes `.ai-factory/rules/generated/openspec-base.md`, skips change-specific generated rules, skips change validation with `no-selected-changes`, writes a report, and returns OK.
 
 When `--all` selects active changes that have no `openspec/changes/<change-id>/specs/**/spec.md` delta specs, sync reports `no-delta-specs` warnings and skips validation/status for those changes. This keeps maintenance sync usable for old migrated or docs-only active changes while preserving stricter per-change verification in `/aif-verify <change-id>`.
+
+Missing or unsupported OpenSpec CLI is degraded sync validation/status, not a sync failure unless strict command context requires CLI-backed evidence.
 
 Generated rules are derived artifacts:
 


### PR DESCRIPTION
Add a focused lifecycle contract test for OpenSpec-aware planning, improvement, plan-polisher, sync, verify, and done guidance.

Align sync, verify, and finalization prompt assets with the literal shared runner wrapper names required by the contract.

Fixes #65