### PR TITLE
[codex] feat: add OpenSpec artifact contract validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Usage](docs/usage.md) | Full command flow, read/write boundaries, examples, and troubleshooting |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
 | [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy and capability flags |
+| [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |
 | [Active Change Resolver](docs/active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](docs/adr/0001-openspec-native-artifact-protocol.md) | v1 artifact ownership decision |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,10 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
 3. [Context Loading Policy](context-loading-policy.md) for consumer context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
 4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, capability flags, and degraded mode.
-5. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
-6. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
-7. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+5. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
+6. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
+7. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
+8. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
 
 The remaining runtime-specific guides are supporting references:
 
@@ -37,6 +38,7 @@ The remaining runtime-specific guides are supporting references:
 | [Usage](usage.md) | Full OpenSpec-native command flow, gates, finalization tail, commit, and examples |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, sync points, rules gate, version support, and degraded mode |
+| [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator for canonical artifacts, runtime evidence, QA, and generated rules |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
 | [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec and AI Factory runtime state contract |
@@ -80,6 +82,7 @@ npm test
 - [Usage](usage.md)
 - [Context Loading Policy](context-loading-policy.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
+- [OpenSpec Artifact Validation](openspec-validation.md)
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [Active Change Resolver](active-change-resolver.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/legacy-plan-migration.md
+++ b/docs/legacy-plan-migration.md
@@ -1,4 +1,4 @@
-[Previous Page](openspec-compatibility.md) | [Back to Documentation](README.md) | [Next Page](active-change-resolver.md)
+[Previous Page](openspec-validation.md) | [Back to Documentation](README.md) | [Next Page](active-change-resolver.md)
 
 # Legacy Plan Migration
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -1,4 +1,4 @@
-[Previous Page](context-loading-policy.md) | [Back to Documentation](README.md) | [Next Page](legacy-plan-migration.md)
+[Previous Page](context-loading-policy.md) | [Back to Documentation](README.md) | [Next Page](openspec-validation.md)
 
 # OpenSpec Compatibility
 
@@ -81,9 +81,9 @@ paths:
 | `/aif-implement` | `openspec instructions apply --change <id>` when `useInstructionsApply` is enabled and CLI is available |
 | `/aif-verify` | `openspec validate`, optional `openspec status` evidence, and final `aif-gate-result` with `"gate": "verify"` |
 | `/aif-rules-check` | Upstream rules gate plus AIFHub generated-rules overlay for OpenSpec specs/deltas |
-| `/aif-done` | `openspec archive <change> --yes` when archive is required |
+| `/aif-done` | AIFHub artifact contract check, then `openspec archive <change> --yes` when archive is required |
 | `/aif-mode sync` | generated-rule compile plus validate/status according to sync flags |
-| `/aif-mode doctor` | CLI, Node, active change, generated rules, latest verify gate, and archive readiness diagnostics |
+| `/aif-mode doctor` | CLI, Node, active change, generated rules, latest verify gate, AIFHub artifact contract, and archive readiness diagnostics |
 
 Do not route users to OpenSpec slash commands such as `/opsx:propose`, `/opsx:apply`, or `/opsx:archive`.
 
@@ -223,9 +223,12 @@ openspec archive <change-id> --yes --no-color
 
 `/aif-done --skip-specs` may add `--skip-specs` for docs/tooling-only changes.
 
+AIFHub artifact contract validation is a separate read-only layer over the CLI adapter. It checks workflow ownership, runtime evidence placement, generated-rule freshness, and pre-archive verification evidence. See [OpenSpec Artifact Validation](openspec-validation.md).
+
 ## See Also
 
 - [Usage](usage.md)
 - [Context Loading Policy](context-loading-policy.md)
+- [OpenSpec Artifact Validation](openspec-validation.md)
 - [Active Change Resolver](active-change-resolver.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -1,0 +1,108 @@
+[Previous Page](openspec-compatibility.md) | [Back to Documentation](README.md) | [Next Page](legacy-plan-migration.md)
+
+# OpenSpec Artifact Validation
+
+`scripts/openspec-artifact-validator.mjs` is the read-only AIFHub contract validator for OpenSpec-native artifacts.
+
+It does not replace the OpenSpec CLI. The OpenSpec CLI validates OpenSpec syntax and archive behavior. This validator checks AIFHub workflow ownership: canonical change artifacts stay under `openspec/changes/<change-id>/`, runtime state stays under `.ai-factory/state/<change-id>/`, QA evidence stays under `.ai-factory/qa/<change-id>/`, and generated rules stay under `.ai-factory/rules/generated/`.
+
+## Usage
+
+Run the validator directly:
+
+```bash
+node scripts/openspec-artifact-validator.mjs --change <change-id> --json
+```
+
+Require verification evidence for finalization readiness:
+
+```bash
+node scripts/openspec-artifact-validator.mjs --change <change-id> --require-verification-evidence --json
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Contract status is `pass` or `warn` |
+| `1` | Contract status is `fail` |
+| `2` | Invalid arguments or unresolved change |
+
+## JSON Contract
+
+The output shape is stable:
+
+```json
+{
+  "schema_version": 1,
+  "validator": "aifhub-openspec-artifact-contract",
+  "change_id": "add-oauth-login",
+  "status": "pass",
+  "blocking": false,
+  "checks": [
+    {
+      "id": "delta-specs-present",
+      "status": "pass",
+      "path": "openspec/changes/add-oauth-login/specs/auth/spec.md",
+      "message": "Found 1 OpenSpec delta spec file(s)."
+    }
+  ],
+  "suggested_next": null
+}
+```
+
+`status` is `pass`, `warn`, or `fail`. `blocking` is true only for `fail`.
+
+## Checks
+
+The validator checks:
+
+| Check | Result |
+|---|---|
+| `proposal.md` and `tasks.md` exist | `fail` when missing |
+| `design.md` exists | `warn` when missing, or `fail` when `aifhub.openspec.requireDesign: true` |
+| `specs/**/spec.md` delta exists | `fail` unless `proposal.md` has an explicit docs/tooling-only `skip-specs` reason |
+| runtime or evidence files inside `openspec/changes/<change-id>/` | `fail` |
+| `.ai-factory/qa/<change-id>/openspec-validation.json` and `verify.md` | required only with `--require-verification-evidence` |
+| final verify `aif-gate-result` block | `fail` when verification evidence is required and the block is missing, invalid, or failing |
+| generated rules under `.ai-factory/rules/generated/` | `warn` when missing or stale |
+| supplied changed paths under `openspec/specs/**` | `fail` unless direct base spec mutation is explicitly allowed |
+
+Generated-rule warnings suggest:
+
+```text
+/aif-mode sync --change <change-id>
+```
+
+Missing verification evidence suggests:
+
+```text
+/aif-verify <change-id>
+```
+
+## Integrations
+
+`/aif-mode doctor --change <change-id>` includes the full validator result in JSON as `artifactContract` and adds a human diagnostic line. Doctor requires verification evidence because it is a pre-archive readiness check.
+
+`/aif-done` runs the validator with verification evidence required and refuses to archive when the validator returns `fail`.
+
+`/aif-verify` is unchanged. It still writes validation/status/verify evidence under `.ai-factory/qa/<change-id>/` and does not archive.
+
+## Read-Only Boundary
+
+The validator never:
+
+- runs the OpenSpec CLI
+- archives a change
+- writes canonical specs
+- writes generated rules
+- writes QA evidence
+- moves files between `openspec/changes` and archives
+
+Use `/aif-mode sync --change <change-id>` to regenerate derived rules and `/aif-done` to archive after passing verification.
+
+## See Also
+
+- [OpenSpec Compatibility](openspec-compatibility.md)
+- [Usage](usage.md)
+- [Active Change Resolver](active-change-resolver.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,6 +155,8 @@ Use `--dry-run` for planned switching or sync writes. Use `--all` or `--change <
 
 `/aif-mode sync --all` is a maintenance sweep. It refreshes generated rules for active changes, validates only selected changes that contain `openspec/changes/<change-id>/specs/**/spec.md` delta specs, and reports selected no-delta changes as `no-delta-specs` warnings instead of failing solely because old or docs-only active changes have no delta specs. `/aif-verify <change-id>` remains the stricter verification gate for a specific change.
 
+`/aif-mode doctor --change <change-id>` includes the read-only AIFHub OpenSpec artifact contract check. It reports the full JSON result as `artifactContract` and treats missing verification evidence as a pre-archive readiness failure. See [OpenSpec Artifact Validation](openspec-validation.md).
+
 For CLI or IDE runtimes, planning commands may recommend an available planning mode for structured questions, but they must not fabricate unavailable tools or client actions. Codex mode switching remains a user action; see [Codex Plan Mode](codex-plan-mode.md).
 
 ### `/aif-analyze`
@@ -439,6 +441,7 @@ Reads:
 - `openspec/changes/<change-id>/**`
 - passing verification evidence from `.ai-factory/qa/<change-id>/`
 - the latest valid verify `aif-gate-result` block from `.ai-factory/qa/<change-id>/verify.md`
+- the read-only AIFHub OpenSpec artifact contract result
 - git working tree state
 
 Writes:
@@ -455,7 +458,7 @@ Does not write:
 - manual file moves from `openspec/changes` to archives
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
-Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true.
+Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` refuses archive when the artifact contract validator returns `fail`.
 
 Next steps after `/aif-done`:
 
@@ -647,6 +650,7 @@ See [Codex Plan Mode](codex-plan-mode.md) for question-format guidance.
 | Ambiguous active change | More than one active change can be selected. | Pass `<change-id>` explicitly or update `.ai-factory/state/current.yaml`. |
 | Missing generated rules | Derived rules are absent. | Regenerate `.ai-factory/rules/generated/*.md` from OpenSpec specs before relying on rules guidance. |
 | Stale generated rules | Generated rules do not match canonical OpenSpec artifacts. | Regenerate them; do not edit generated rules as source of truth. |
+| Artifact contract failure | Canonical OpenSpec artifacts, runtime state, QA evidence, or generated rules violate the AIFHub contract. | Fix the reported path or run the suggested command from `artifactContract.suggested_next`. |
 | Dirty working tree before `/aif-done` | Finalization cannot prove archive/summary scope safely. | Commit, stash, or use an explicit supported dirty-state override when available. |
 
 ## Release Smoke Checks

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -26,6 +26,9 @@ import {
 import {
   getLatestGateResult
 } from './aif-gate-result.mjs';
+import {
+  validateOpenSpecArtifactContract as defaultValidateOpenSpecArtifactContract
+} from './openspec-artifact-validator.mjs';
 
 export const MODES = {
   openspec: 'openspec',
@@ -361,6 +364,7 @@ export async function doctorAifMode(options = {}) {
   const status = await getModeStatus({ ...options, rootDir });
   const openspecSettings = getOpenSpecSettings(status.config);
   const diagnostics = [];
+  let artifactContract = null;
 
   diagnostics.push(status.configExists && status.configMarker !== null
     ? pass('config-marker', `Config marker is ${status.configMarker}.`)
@@ -409,6 +413,14 @@ export async function doctorAifMode(options = {}) {
 
   if (status.mode === MODES.openspec && status.activeChange.state === 'resolved') {
     diagnostics.push(await inspectVerifyGateDiagnostic(rootDir, status));
+    const validateOpenSpecArtifactContract = options.validateOpenSpecArtifactContract ?? defaultValidateOpenSpecArtifactContract;
+    artifactContract = await validateOpenSpecArtifactContract({
+      ...options,
+      rootDir,
+      changeId: status.activeChange.changeId,
+      requireVerificationEvidence: true
+    });
+    diagnostics.push(renderArtifactContractDiagnostic(artifactContract));
   }
 
   if (status.mode === MODES.openspec && status.openspecCli.canValidate && status.activeChange.state === 'resolved') {
@@ -438,6 +450,7 @@ export async function doctorAifMode(options = {}) {
     ok: errors.length === 0,
     mode: status.mode,
     status,
+    artifactContract,
     diagnostics,
     warnings,
     errors
@@ -1842,6 +1855,32 @@ function warn(code, message) {
 
 function fail(code, message) {
   return { level: 'fail', code, message };
+}
+
+function renderArtifactContractDiagnostic(result) {
+  if (!result) {
+    return warn('aifhub-artifact-contract', 'AIFHub OpenSpec artifact contract validation did not run.');
+  }
+
+  const failed = (result.checks ?? []).filter((check) => check.status === 'fail');
+  const warned = (result.checks ?? []).filter((check) => check.status === 'warn');
+
+  if (result.status === 'pass') {
+    return pass('aifhub-artifact-contract', 'AIFHub OpenSpec artifact contract passes.');
+  }
+
+  if (result.status === 'warn') {
+    return warn(
+      'aifhub-artifact-contract',
+      `AIFHub OpenSpec artifact contract has ${warned.length} warning(s).`
+    );
+  }
+
+  const first = failed[0];
+  return fail(
+    'aifhub-artifact-contract',
+    `AIFHub OpenSpec artifact contract failed${first ? `: ${first.id}` : ''}.`
+  );
 }
 
 function createSkippedResult(reason) {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -651,6 +651,15 @@ describe('doctor', () => {
         validated.push(changeId);
         return { ok: true, stdout: '{"valid":true}', stderr: '', json: { valid: true } };
       },
+      validateOpenSpecArtifactContract: async (options) => ({
+        schema_version: 1,
+        validator: 'aifhub-openspec-artifact-contract',
+        change_id: options.changeId,
+        status: 'pass',
+        blocking: false,
+        checks: [],
+        suggested_next: null
+      }),
       getOpenSpecStatus: async () => ({
         ok: true,
         stdout: '{"ok":true}',

--- a/scripts/aif-mode.test.mjs
+++ b/scripts/aif-mode.test.mjs
@@ -142,6 +142,49 @@ describe('runModeCommand', () => {
     assert.equal(parsed.mode, 'ai-factory');
     assert.equal(parsed.config.raw, undefined);
   });
+
+  it('includes the OpenSpec artifact contract result in doctor JSON output', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      '  openspec:',
+      '    requireCliForDone: false',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/config.yaml', 'mode: openspec\n');
+    await writeFixture(rootDir, 'openspec/specs/.gitkeep', '');
+    await writeFixture(rootDir, '.ai-factory/state/.gitkeep', '');
+    await writeFixture(rootDir, '.ai-factory/qa/.gitkeep', '');
+    await writeFixture(rootDir, '.ai-factory/rules/generated/.gitkeep', '');
+
+    const result = await runModeCommand(['doctor', '--change', 'add-oauth', '--json'], {
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      validateOpenSpecArtifactContract: async (options) => ({
+        schema_version: 1,
+        validator: 'aifhub-openspec-artifact-contract',
+        change_id: options.changeId,
+        status: 'pass',
+        blocking: false,
+        checks: [],
+        suggested_next: null
+      })
+    });
+    const parsed = JSON.parse(result.stdout);
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(parsed.artifactContract.validator, 'aifhub-openspec-artifact-contract');
+    assert.equal(parsed.artifactContract.change_id, 'add-oauth');
+    assert.ok(parsed.diagnostics.some((diagnostic) => diagnostic.code === 'aifhub-artifact-contract'));
+  });
 });
 
 describe('extension manifest', () => {

--- a/scripts/openspec-artifact-validator.mjs
+++ b/scripts/openspec-artifact-validator.mjs
@@ -1,0 +1,755 @@
+#!/usr/bin/env node
+// openspec-artifact-validator.mjs - read-only AIFHub OpenSpec artifact contract checks
+import { access, readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  normalizeChangeId,
+  resolveActiveChange as defaultResolveActiveChange
+} from './active-change-resolver.mjs';
+import {
+  collectCanonicalChangeArtifacts,
+  collectGeneratedRules
+} from './openspec-execution-context.mjs';
+import {
+  readLatestVerificationEvidence as defaultReadLatestVerificationEvidence
+} from './openspec-verification-context.mjs';
+import {
+  getLatestGateResult
+} from './aif-gate-result.mjs';
+
+export const ARTIFACT_CONTRACT_SCHEMA_VERSION = 1;
+export const ARTIFACT_CONTRACT_VALIDATOR = 'aifhub-openspec-artifact-contract';
+
+const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
+const DEFAULT_CONFIG_PATH = path.join('.ai-factory', 'config.yaml');
+const REQUIRED_CHANGE_ARTIFACTS = ['proposal.md', 'tasks.md'];
+const RUNTIME_FILE_NAMES = new Set([
+  'verify.md',
+  'validation.md',
+  'status.md',
+  'done.md',
+  'final-summary.md',
+  'openspec-validation.json',
+  'openspec-status.json',
+  'openspec-archive.json',
+  'implementation.md',
+  'fixes.md',
+  'raw-stdout.txt',
+  'raw-stderr.txt'
+]);
+const RUNTIME_DIR_NAMES = new Set([
+  '.ai-factory',
+  'qa',
+  'state',
+  'implementation',
+  'fixes',
+  'raw',
+  'generated',
+  'reports'
+]);
+
+export async function validateOpenSpecArtifactContract(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const config = await readValidatorConfig(rootDir);
+  const resolved = await resolveChange(options, rootDir);
+
+  if (!resolved.ok) {
+    return createResult({
+      changeId: resolved.changeId,
+      checks: [
+        createCheck({
+          id: 'active-change-resolved',
+          status: 'fail',
+          message: resolved.errors[0]?.message ?? 'Unable to resolve an active OpenSpec change.'
+        })
+      ],
+      suggestedNext: {
+        command: '/aif-mode status',
+        reason: 'Select or pass an active OpenSpec change before running artifact validation.'
+      }
+    });
+  }
+
+  const checks = [];
+  const changeId = resolved.changeId;
+  const changeDir = resolved.changePath;
+  const canonical = await collectCanonicalChangeArtifacts(changeId, {
+    ...options,
+    rootDir
+  });
+  const artifacts = canonical.canonicalArtifacts ?? {};
+
+  checks.push(...inspectRequiredArtifacts(artifacts));
+  checks.push(inspectDesignArtifact(artifacts.design, config.requireDesign));
+  checks.push(inspectDeltaSpecs(artifacts, config));
+  checks.push(...await inspectRuntimeFiles(rootDir, changeDir));
+  checks.push(...await inspectVerificationEvidence(changeId, {
+    ...options,
+    rootDir,
+    qaDir: config.qaDir
+  }));
+  checks.push(...await inspectGeneratedRules(changeId, {
+    ...options,
+    rootDir
+  }));
+  checks.push(inspectBaseSpecMutation(options.changedPaths, options.allowBaseSpecMutation));
+
+  return createResult({
+    changeId,
+    checks,
+    suggestedNext: chooseSuggestedNext(changeId, checks)
+  });
+}
+
+export function parseArtifactValidatorArgs(argv) {
+  const args = Array.from(argv ?? []);
+  const result = {
+    ok: true,
+    changeId: null,
+    json: false,
+    requireVerificationEvidence: false,
+    allowBaseSpecMutation: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--change') {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        return invalidArgs('Missing value for --change.');
+      }
+
+      result.changeId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--json') {
+      result.json = true;
+      continue;
+    }
+
+    if (arg === '--require-verification-evidence') {
+      result.requireVerificationEvidence = true;
+      continue;
+    }
+
+    if (arg === '--allow-base-spec-mutation') {
+      result.allowBaseSpecMutation = true;
+      continue;
+    }
+
+    return invalidArgs(`Unknown option: ${arg}.`);
+  }
+
+  return result;
+}
+
+export async function runArtifactValidatorCommand(argv, options = {}) {
+  const parsed = parseArtifactValidatorArgs(argv);
+  if (!parsed.ok) {
+    return {
+      exitCode: 2,
+      stdout: '',
+      stderr: `${parsed.error}\n`
+    };
+  }
+
+  const result = await validateOpenSpecArtifactContract({
+    ...options,
+    changeId: parsed.changeId ?? options.changeId,
+    requireVerificationEvidence: parsed.requireVerificationEvidence || options.requireVerificationEvidence,
+    allowBaseSpecMutation: parsed.allowBaseSpecMutation || options.allowBaseSpecMutation
+  });
+  const stdout = parsed.json
+    ? `${JSON.stringify(result, null, 2)}\n`
+    : `${renderArtifactValidatorResult(result)}\n`;
+
+  return {
+    exitCode: isUnresolvedChangeResult(result) ? 2 : result.status === 'fail' ? 1 : 0,
+    stdout,
+    stderr: ''
+  };
+}
+
+export function renderArtifactValidatorResult(result) {
+  const suggested = result.suggested_next
+    ? [
+      '',
+      `Suggested next: ${result.suggested_next.command}`,
+      `Reason: ${result.suggested_next.reason}`
+    ]
+    : [];
+
+  return [
+    `AIFHub OpenSpec artifact contract: ${String(result.status).toUpperCase()}`,
+    `Change: ${result.change_id ?? 'unresolved'}`,
+    `Blocking: ${result.blocking ? 'yes' : 'no'}`,
+    '',
+    'Checks:',
+    ...result.checks.map((check) => renderCheckLine(check)),
+    ...suggested
+  ].join('\n');
+}
+
+function inspectRequiredArtifacts(artifacts) {
+  return REQUIRED_CHANGE_ARTIFACTS.map((artifactName) => {
+    const artifact = artifacts[path.basename(artifactName, '.md')];
+    return createCheck({
+      id: `${path.basename(artifactName, '.md')}-present`,
+      status: artifact?.exists ? 'pass' : 'fail',
+      path: artifact?.path ?? `openspec/changes/<change-id>/${artifactName}`,
+      message: artifact?.exists
+        ? `${artifactName} is present.`
+        : `${artifactName} is required for an AIFHub OpenSpec change.`
+    });
+  });
+}
+
+function inspectDesignArtifact(design, requireDesign) {
+  const required = Boolean(requireDesign);
+
+  return createCheck({
+    id: 'design-present',
+    status: design?.exists ? 'pass' : required ? 'fail' : 'warn',
+    path: design?.path ?? 'openspec/changes/<change-id>/design.md',
+    message: design?.exists
+      ? 'design.md is present.'
+      : required
+        ? 'design.md is required by aifhub.openspec.requireDesign.'
+        : 'design.md is missing; it is optional unless aifhub.openspec.requireDesign is true.'
+  });
+}
+
+function inspectDeltaSpecs(artifacts, config) {
+  const deltaSpecs = Array.isArray(artifacts.deltaSpecs) ? artifacts.deltaSpecs : [];
+  const proposal = artifacts.proposal;
+  const hasSkipReason = proposal?.exists && hasExplicitSkipSpecsReason(proposal.content);
+
+  if (deltaSpecs.length > 0) {
+    return createCheck({
+      id: 'delta-specs-present',
+      status: 'pass',
+      path: deltaSpecs[0].path,
+      message: `Found ${deltaSpecs.length} OpenSpec delta spec file(s).`
+    });
+  }
+
+  if (hasSkipReason) {
+    return createCheck({
+      id: 'delta-specs-present',
+      status: 'pass',
+      path: proposal.path,
+      message: 'No delta specs are required because proposal.md contains an explicit docs/tooling-only skip-specs reason.'
+    });
+  }
+
+  return createCheck({
+    id: 'delta-specs-present',
+    status: config.allowMissingSpecs ? 'warn' : 'fail',
+    path: `openspec/changes/${config.changeIdPlaceholder ?? '<change-id>'}/specs/**/spec.md`,
+    message: 'OpenSpec changes must include specs/**/spec.md unless proposal.md has an explicit docs/tooling-only skip-specs reason.'
+  });
+}
+
+async function inspectRuntimeFiles(rootDir, changeDir) {
+  const files = await collectFiles(rootDir, changeDir);
+  const offenders = files.filter((file) => isRuntimeOrEvidenceFile(file.path));
+
+  if (offenders.length === 0) {
+    return [
+      createCheck({
+        id: 'runtime-files-outside-change',
+        status: 'pass',
+        path: toPosix(path.relative(rootDir, changeDir)),
+        message: 'No runtime state, QA evidence, or generated rule files were found inside the canonical change folder.'
+      })
+    ];
+  }
+
+  return offenders.map((file) => createCheck({
+    id: 'runtime-files-outside-change',
+    status: 'fail',
+    path: file.repoPath,
+    message: 'Runtime state, QA evidence, and generated files must stay outside openspec/changes/<change-id>.'
+  }));
+}
+
+async function inspectVerificationEvidence(changeId, options) {
+  if (!options.requireVerificationEvidence) {
+    return [
+      createCheck({
+        id: 'qa-verify-evidence',
+        status: 'pass',
+        path: path.join(options.qaDir ?? DEFAULT_QA_DIR, changeId).replaceAll('\\', '/'),
+        message: 'Verification evidence is not required for this validator stage.'
+      })
+    ];
+  }
+
+  const readLatestVerificationEvidence = options.readLatestVerificationEvidence ?? defaultReadLatestVerificationEvidence;
+  const qaDir = options.qaDir ?? DEFAULT_QA_DIR;
+  const evidence = await readLatestVerificationEvidence(changeId, {
+    ...options,
+    qaDir
+  });
+  const checks = [];
+  const qaPath = path.join(qaDir, changeId).replaceAll('\\', '/');
+  const qaAbsolutePath = path.isAbsolute(qaDir)
+    ? path.join(qaDir, changeId)
+    : path.join(options.rootDir, qaDir, changeId);
+  const validationExists = evidence?.ok === true || evidence?.validation !== null && evidence?.validation !== undefined;
+  const verifyExists = evidence?.verify?.exists === true;
+
+  checks.push(createCheck({
+    id: 'qa-openspec-validation-present',
+    status: validationExists ? evidence.validation?.ok === false ? 'fail' : 'pass' : 'fail',
+    path: `${qaPath}/openspec-validation.json`,
+    message: validationExists
+      ? evidence.validation?.ok === false
+        ? 'OpenSpec validation evidence exists but reports failure.'
+        : 'OpenSpec validation evidence is present.'
+      : 'OpenSpec validation evidence is missing.'
+  }));
+
+  checks.push(createCheck({
+    id: 'qa-verify-evidence',
+    status: verifyExists ? 'pass' : 'fail',
+    path: evidence?.verify?.path ?? `${qaPath}/verify.md`,
+    message: verifyExists
+      ? 'Verify evidence is present.'
+      : 'Verify evidence is missing.'
+  }));
+
+  if (verifyExists) {
+    checks.push(inspectVerifyGate(evidence.verify.content, evidence.gateResult, evidence.verify.path));
+  } else {
+    checks.push(createCheck({
+      id: 'qa-verify-gate',
+      status: 'fail',
+      path: `${qaPath}/verify.md`,
+      message: 'Verify evidence must contain a final aif-gate-result block for the verify gate.'
+    }));
+  }
+
+  checks.push(...await inspectDoneEvidence(qaPath, qaAbsolutePath));
+  return checks;
+}
+
+function inspectVerifyGate(content, gateResult, verifyPath) {
+  const gate = gateResult ?? getLatestGateResult(content, { gate: 'verify' });
+
+  if (gate === null) {
+    return createCheck({
+      id: 'qa-verify-gate',
+      status: 'fail',
+      path: verifyPath,
+      message: 'Verify evidence is missing the final aif-gate-result block for the verify gate.'
+    });
+  }
+
+  if (!gate.ok) {
+    return createCheck({
+      id: 'qa-verify-gate',
+      status: 'fail',
+      path: verifyPath,
+      message: 'Verify evidence contains an invalid aif-gate-result block for the verify gate.',
+      details: gate.errors
+    });
+  }
+
+  return createCheck({
+    id: 'qa-verify-gate',
+    status: gate.result.status === 'fail' ? 'fail' : 'pass',
+    path: verifyPath,
+    message: gate.result.status === 'fail'
+      ? 'The latest verify gate result is failing.'
+      : 'The latest verify gate result is present and non-failing.'
+  });
+}
+
+async function inspectDoneEvidence(qaPath, qaAbsolutePath) {
+  const donePath = path.join(qaAbsolutePath, 'done.md');
+  const archivePath = path.join(qaAbsolutePath, 'openspec-archive.json');
+  const doneExists = await pathExists(donePath);
+  const archiveExists = await pathExists(archivePath);
+
+  if (!doneExists) {
+    return [
+      createCheck({
+        id: 'qa-done-evidence',
+        status: 'pass',
+        path: `${qaPath}/done.md`,
+        message: 'No done.md evidence is present before finalization.'
+      })
+    ];
+  }
+
+  return [
+    createCheck({
+      id: 'qa-done-evidence',
+      status: archiveExists ? 'pass' : 'fail',
+      path: `${qaPath}/done.md`,
+      message: archiveExists
+        ? 'done.md has matching archive evidence.'
+        : 'done.md must only exist after finalization and should have matching openspec-archive.json evidence.'
+    })
+  ];
+}
+
+async function inspectGeneratedRules(changeId, options) {
+  const generated = await collectGeneratedRules(changeId, options);
+
+  if (generated.errors.length > 0) {
+    return generated.errors.map((error) => createCheck({
+      id: 'generated-rules-current',
+      status: 'fail',
+      message: error.message,
+      details: error
+    }));
+  }
+
+  const missing = generated.generatedRules.filter((rule) => !rule.exists);
+  const stale = generated.generatedRules.filter((rule) => rule.stale === true);
+
+  if (missing.length === 0 && stale.length === 0) {
+    return [
+      createCheck({
+        id: 'generated-rules-current',
+        status: 'pass',
+        path: '.ai-factory/rules/generated',
+        message: 'Generated OpenSpec rules are present and current.'
+      })
+    ];
+  }
+
+  return [
+    ...missing.map((rule) => createCheck({
+      id: 'generated-rules-current',
+      status: 'warn',
+      path: rule.path,
+      message: 'Generated OpenSpec rules are missing.'
+    })),
+    ...stale.map((rule) => createCheck({
+      id: 'generated-rules-current',
+      status: 'warn',
+      path: rule.path,
+      message: 'Generated OpenSpec rules are stale.'
+    }))
+  ];
+}
+
+function inspectBaseSpecMutation(changedPaths, allowBaseSpecMutation) {
+  const paths = Array.isArray(changedPaths) ? changedPaths.map((item) => toPosix(item)) : [];
+  const offenders = paths.filter((item) => item.startsWith('openspec/specs/'));
+
+  if (offenders.length === 0 || allowBaseSpecMutation) {
+    return createCheck({
+      id: 'base-specs-not-directly-mutated',
+      status: 'pass',
+      path: 'openspec/specs',
+      message: allowBaseSpecMutation
+        ? 'Direct base spec mutation check was explicitly allowed for this run.'
+        : 'No direct openspec/specs mutation was detected from supplied changed paths.'
+    });
+  }
+
+  return createCheck({
+    id: 'base-specs-not-directly-mutated',
+    status: 'fail',
+    path: offenders[0],
+    message: 'AIFHub skills must not directly mutate openspec/specs; archive OpenSpec changes instead.',
+    details: {
+      changed_paths: offenders
+    }
+  });
+}
+
+async function resolveChange(options, rootDir) {
+  const resolveActiveChange = options.resolveActiveChange ?? defaultResolveActiveChange;
+  const result = await resolveActiveChange({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId: options.changeId,
+    getCurrentBranch: options.getCurrentBranch
+  });
+
+  if (!result.ok) {
+    const normalized = options.changeId ? normalizeChangeId(options.changeId) : { ok: false, changeId: null };
+    return {
+      ok: false,
+      changeId: normalized.ok ? normalized.changeId : null,
+      errors: result.errors ?? []
+    };
+  }
+
+  return {
+    ok: true,
+    changeId: result.changeId,
+    changePath: result.changePath
+  };
+}
+
+async function readValidatorConfig(rootDir) {
+  try {
+    const raw = await readFile(path.join(rootDir, DEFAULT_CONFIG_PATH), 'utf8');
+    const parsed = parseSimpleYaml(raw);
+    return {
+      qaDir: parsed.paths?.qa ?? DEFAULT_QA_DIR,
+      requireDesign: Boolean(parsed.aifhub?.openspec?.requireDesign)
+    };
+  } catch {
+    return {
+      qaDir: DEFAULT_QA_DIR,
+      requireDesign: false
+    };
+  }
+}
+
+function parseSimpleYaml(raw) {
+  const root = {};
+  const stack = [{ indent: -1, value: root }];
+
+  for (const rawLine of String(raw ?? '').split(/\r?\n/)) {
+    const withoutComment = rawLine.replace(/\s+#.*$/, '');
+    if (withoutComment.trim().length === 0) {
+      continue;
+    }
+
+    const match = /^(\s*)([^:]+):(?:\s*(.*))?$/.exec(withoutComment);
+    if (!match) {
+      continue;
+    }
+
+    const indent = match[1].length;
+    const key = match[2].trim();
+    const rawValue = match[3]?.trim() ?? '';
+
+    while (stack.length > 1 && stack.at(-1).indent >= indent) {
+      stack.pop();
+    }
+
+    const parent = stack.at(-1).value;
+    if (rawValue.length === 0) {
+      parent[key] = {};
+      stack.push({ indent, value: parent[key] });
+      continue;
+    }
+
+    parent[key] = parseYamlScalar(rawValue);
+  }
+
+  return root;
+}
+
+function parseYamlScalar(value) {
+  const unquoted = value.replace(/^['"]|['"]$/g, '');
+
+  if (/^(true|false)$/i.test(unquoted)) {
+    return unquoted.toLowerCase() === 'true';
+  }
+
+  if (/^-?\d+(?:\.\d+)?$/.test(unquoted)) {
+    return Number(unquoted);
+  }
+
+  return unquoted;
+}
+
+function hasExplicitSkipSpecsReason(content) {
+  const text = String(content ?? '').toLowerCase();
+  const hasSkipSpecs = /\bskip[-_\s]?specs\b/.test(text);
+  const hasDocsToolingScope = /\b(docs?|documentation|tooling)[-_\s/]+only\b/.test(text)
+    || /\bdocs[-_\s/]+tooling[-_\s/]+only\b/.test(text);
+  const hasReason = /\b(reason|because|no behavior|no product|non[-_\s]?runtime|documentation[-_\s]?only)\b/.test(text);
+
+  return (hasSkipSpecs || hasDocsToolingScope) && hasReason;
+}
+
+function isRuntimeOrEvidenceFile(relativePath) {
+  const posixPath = toPosix(relativePath);
+  const parts = posixPath.split('/');
+  const fileName = parts.at(-1);
+
+  if (['proposal.md', 'design.md', 'tasks.md'].includes(posixPath)) {
+    return false;
+  }
+
+  if (/^specs\/.+\/spec\.md$/.test(posixPath)) {
+    return false;
+  }
+
+  if (RUNTIME_FILE_NAMES.has(fileName)) {
+    return true;
+  }
+
+  if (/^openspec-(base|change-|merged-).+\.md$/.test(fileName)) {
+    return true;
+  }
+
+  return parts.some((part) => RUNTIME_DIR_NAMES.has(part));
+}
+
+async function collectFiles(rootDir, directoryPath) {
+  if (!await isDirectory(directoryPath)) {
+    return [];
+  }
+
+  const results = [];
+  await collectFilesRecursive(rootDir, directoryPath, directoryPath, results);
+  return results.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function collectFilesRecursive(rootDir, basePath, directoryPath, results) {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const sorted = entries.sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of sorted) {
+    const childPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      await collectFilesRecursive(rootDir, basePath, childPath, results);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      results.push({
+        path: toPosix(path.relative(basePath, childPath)),
+        repoPath: toPosix(path.relative(rootDir, childPath))
+      });
+    }
+  }
+}
+
+async function isDirectory(targetPath) {
+  try {
+    return (await stat(targetPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createResult({ changeId, checks, suggestedNext }) {
+  const status = checks.some((check) => check.status === 'fail')
+    ? 'fail'
+    : checks.some((check) => check.status === 'warn') ? 'warn' : 'pass';
+
+  return {
+    schema_version: ARTIFACT_CONTRACT_SCHEMA_VERSION,
+    validator: ARTIFACT_CONTRACT_VALIDATOR,
+    change_id: changeId ?? null,
+    status,
+    blocking: status === 'fail',
+    checks,
+    suggested_next: suggestedNext ?? null
+  };
+}
+
+function isUnresolvedChangeResult(result) {
+  return (result.checks ?? []).some((check) => check.id === 'active-change-resolved' && check.status === 'fail');
+}
+
+function createCheck({ id, status, path: checkPath, message, details }) {
+  const check = {
+    id,
+    status,
+    path: checkPath ?? null,
+    message
+  };
+
+  if (details !== undefined) {
+    check.details = details;
+  }
+
+  return check;
+}
+
+function chooseSuggestedNext(changeId, checks) {
+  const failing = checks.find((check) => check.status === 'fail');
+
+  if (failing?.id === 'generated-rules-current') {
+    return {
+      command: `/aif-mode sync --change ${changeId}`,
+      reason: 'generated rules are stale or missing'
+    };
+  }
+
+  if (failing?.id === 'qa-verify-evidence' || failing?.id === 'qa-openspec-validation-present' || failing?.id === 'qa-verify-gate') {
+    return {
+      command: `/aif-verify ${changeId}`,
+      reason: 'verification evidence is required before finalization'
+    };
+  }
+
+  if (failing?.id === 'delta-specs-present') {
+    return {
+      command: `/aif-mode sync --change ${changeId}`,
+      reason: 'add delta specs or document an explicit docs/tooling-only skip-specs reason before syncing again'
+    };
+  }
+
+  if (failing?.id === 'runtime-files-outside-change') {
+    return {
+      command: `/aif-mode sync --change ${changeId}`,
+      reason: 'move runtime evidence out of openspec/changes before continuing'
+    };
+  }
+
+  if (failing?.id === 'base-specs-not-directly-mutated') {
+    return {
+      command: `/aif-done ${changeId}`,
+      reason: 'archive through OpenSpec instead of directly mutating openspec/specs'
+    };
+  }
+
+  const generatedWarning = checks.find((check) => check.id === 'generated-rules-current' && check.status === 'warn');
+  if (generatedWarning) {
+    return {
+      command: `/aif-mode sync --change ${changeId}`,
+      reason: 'generated rules are stale'
+    };
+  }
+
+  return null;
+}
+
+function renderCheckLine(check) {
+  const suffix = check.path ? ` (${check.path})` : '';
+  return `- ${check.status.toUpperCase()} ${check.id}${suffix}: ${check.message}`;
+}
+
+function invalidArgs(error) {
+  return {
+    ok: false,
+    error
+  };
+}
+
+function resolveRootDir(options = {}) {
+  return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const result = await runArtifactValidatorCommand(process.argv.slice(2));
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  process.exitCode = result.exitCode;
+}

--- a/scripts/openspec-artifact-validator.test.mjs
+++ b/scripts/openspec-artifact-validator.test.mjs
@@ -1,0 +1,304 @@
+// openspec-artifact-validator.test.mjs - OpenSpec artifact contract validator tests
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  runArtifactValidatorCommand,
+  validateOpenSpecArtifactContract
+} from './openspec-artifact-validator.mjs';
+import {
+  compileOpenSpecRules
+} from './openspec-rules-compiler.mjs';
+import {
+  createGateResult,
+  renderGateResultBlock
+} from './aif-gate-result.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-artifact-validator-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createValidChange(rootDir, changeId = 'add-oauth') {
+  await writeFixture(rootDir, '.ai-factory/config.yaml', [
+    'aifhub:',
+    '  artifactProtocol: openspec',
+    '  openspec:',
+    '    requireDesign: true',
+    'paths:',
+    '  qa: .ai-factory/qa',
+    '  generated_rules: .ai-factory/rules/generated',
+    ''
+  ].join('\n'));
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, [
+    '# Proposal',
+    '',
+    '## Why',
+    '',
+    'Add OAuth login.',
+    ''
+  ].join('\n'));
+  await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, '# Tasks\n\n- [ ] Implement OAuth\n');
+  await writeFixture(rootDir, 'openspec/specs/auth/spec.md', [
+    '# Auth Base',
+    '',
+    '## Requirements',
+    '',
+    '### Requirement: Password login',
+    '',
+    'Users MUST be able to sign in with a password.',
+    ''
+  ].join('\n'));
+  await writeFixture(rootDir, `openspec/changes/${changeId}/specs/auth/spec.md`, [
+    '# Auth Delta',
+    '',
+    '## ADDED Requirements',
+    '',
+    '### Requirement: OAuth login',
+    '',
+    'Users MUST be able to sign in with OAuth.',
+    '',
+    '#### Scenario: sign in with OAuth',
+    '',
+    '- GIVEN a user has an OAuth provider account',
+    '- WHEN they sign in through that provider',
+    '- THEN an authenticated session is created.',
+    ''
+  ].join('\n'));
+  await compileOpenSpecRules(changeId, { rootDir });
+}
+
+async function writeVerificationEvidence(rootDir, changeId = 'add-oauth', options = {}) {
+  await writeFixture(rootDir, `.ai-factory/qa/${changeId}/openspec-validation.json`, `${JSON.stringify({
+    changeId,
+    ok: options.validationOk ?? true,
+    skipped: false
+  }, null, 2)}\n`);
+  await writeFixture(rootDir, `.ai-factory/qa/${changeId}/verify.md`, options.verifyContent ?? [
+    `# Verify: ${changeId}`,
+    '',
+    'Verdict: PASS',
+    '',
+    renderGateResultBlock(createGateResult({
+      gate: 'verify',
+      status: 'pass',
+      blockers: [],
+      affectedFiles: [],
+      suggestedNext: null
+    })),
+    ''
+  ].join('\n'));
+}
+
+async function snapshotFiles(rootDir) {
+  const files = await collectFiles(rootDir, rootDir);
+  const snapshot = {};
+
+  for (const filePath of files) {
+    const relativePath = toPosix(path.relative(rootDir, filePath));
+    snapshot[relativePath] = await readFile(filePath, 'utf8');
+  }
+
+  return snapshot;
+}
+
+async function collectFiles(rootDir, directoryPath) {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const childPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...await collectFiles(rootDir, childPath));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(childPath);
+    }
+  }
+
+  return files;
+}
+
+function getCheck(result, id) {
+  return result.checks.find((check) => check.id === id);
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec artifact contract validator', () => {
+  it('passes a valid change without requiring verify evidence', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.equal(result.validator, 'aifhub-openspec-artifact-contract');
+    assert.equal(result.status, 'pass');
+    assert.equal(result.blocking, false);
+    assert.equal(getCheck(result, 'delta-specs-present').status, 'pass');
+  });
+
+  it('fails when delta specs are missing without an explicit skip-specs reason', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await rm(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'specs'), {
+      recursive: true,
+      force: true
+    });
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.equal(result.status, 'fail');
+    assert.equal(getCheck(result, 'delta-specs-present').status, 'fail');
+  });
+
+  it('warns when generated rules are stale and suggests sync', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await writeFixture(rootDir, 'openspec/specs/auth/spec.md', '# Auth Base\n\nChanged after rule sync.\n');
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.equal(result.status, 'warn');
+    assert.equal(result.suggested_next.command, '/aif-mode sync --change add-oauth');
+    assert.ok(result.checks.some((check) => check.id === 'generated-rules-current' && check.status === 'warn'));
+  });
+
+  it('fails when runtime evidence is placed inside openspec/changes', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/openspec-validation.json', '{}\n');
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.equal(result.status, 'fail');
+    assert.ok(result.checks.some((check) => check.id === 'runtime-files-outside-change' && check.status === 'fail'));
+  });
+
+  it('fails missing verify gate when verification evidence is required', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await writeVerificationEvidence(rootDir, 'add-oauth', {
+      verifyContent: '# Verify: add-oauth\n\nVerdict: PASS\n'
+    });
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth',
+      requireVerificationEvidence: true
+    });
+
+    assert.equal(result.status, 'fail');
+    assert.equal(getCheck(result, 'qa-verify-gate').status, 'fail');
+  });
+
+  it('fails direct openspec/specs mutation supplied by changedPaths', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth',
+      changedPaths: ['openspec/specs/auth/spec.md']
+    });
+
+    assert.equal(result.status, 'fail');
+    assert.equal(getCheck(result, 'base-specs-not-directly-mutated').status, 'fail');
+  });
+
+  it('does not write files while validating', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    const before = await snapshotFiles(rootDir);
+
+    await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.deepEqual(await snapshotFiles(rootDir), before);
+  });
+});
+
+describe('OpenSpec artifact contract CLI', () => {
+  it('emits JSON and exits 0 on pass', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+
+    const result = await runArtifactValidatorCommand(['--change', 'add-oauth', '--json'], { rootDir });
+    const parsed = JSON.parse(result.stdout);
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(parsed.status, 'pass');
+  });
+
+  it('emits human output and exits 0 on warn', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await writeFixture(rootDir, 'openspec/specs/auth/spec.md', '# Auth Base\n\nChanged after rule sync.\n');
+
+    const result = await runArtifactValidatorCommand(['--change', 'add-oauth'], { rootDir });
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /AIFHub OpenSpec artifact contract: WARN/);
+  });
+
+  it('exits 1 on contract failure', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await rm(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'specs'), {
+      recursive: true,
+      force: true
+    });
+
+    const result = await runArtifactValidatorCommand(['--change', 'add-oauth'], { rootDir });
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stdout, /delta-specs-present/);
+  });
+
+  it('exits 2 on invalid args or unresolved changes', async () => {
+    const rootDir = await createTempRoot();
+
+    assert.equal((await runArtifactValidatorCommand(['--bad'], { rootDir })).exitCode, 2);
+    assert.equal((await runArtifactValidatorCommand(['--change', 'missing-change'], { rootDir })).exitCode, 2);
+  });
+});

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -25,6 +25,9 @@ import {
 import {
   getLatestGateResult
 } from './aif-gate-result.mjs';
+import {
+  validateOpenSpecArtifactContract as defaultValidateOpenSpecArtifactContract
+} from './openspec-artifact-validator.mjs';
 
 const execFileAsync = promisify(execFile);
 const MODE = 'openspec-native';
@@ -192,6 +195,13 @@ export async function buildDoneContext(options = {}) {
     rootDir,
     qaPath: layout.qaPath
   });
+  const validateOpenSpecArtifactContract = options.validateOpenSpecArtifactContract ?? defaultValidateOpenSpecArtifactContract;
+  const artifactContract = await validateOpenSpecArtifactContract({
+    ...options,
+    rootDir,
+    changeId: resolverResult.changeId,
+    requireVerificationEvidence: true
+  });
   const runtimeTraces = await collectRuntimeTraces(rootDir, layout.statePath);
   const openspec = await detectOpenSpecCapability(options, rootDir);
   const warnings = dedupeDiagnostics([
@@ -199,6 +209,7 @@ export async function buildDoneContext(options = {}) {
     ...canonical.warnings,
     ...generatedRules.warnings,
     ...verification.warnings,
+    ...artifactContractWarnings(artifactContract),
     ...runtimeTraces.warnings,
     ...openspec.warnings
   ]);
@@ -206,6 +217,7 @@ export async function buildDoneContext(options = {}) {
     ...canonical.errors,
     ...generatedRules.errors,
     ...verification.errors,
+    ...artifactContractErrors(artifactContract),
     ...runtimeTraces.errors,
     ...openspec.errors
   ];
@@ -225,6 +237,7 @@ export async function buildDoneContext(options = {}) {
     canonicalArtifacts: canonical.canonicalArtifacts,
     runtimeTraces: runtimeTraces.runtimeTraces,
     generatedRules: generatedRules.generatedRules,
+    artifactContract,
     warnings,
     errors
   };
@@ -359,6 +372,34 @@ export async function assertVerificationPassed(changeId, options = {}) {
     warnings: evidence.warnings ?? [],
     errors: []
   };
+}
+
+function artifactContractWarnings(result) {
+  if (!result || result.status !== 'warn') {
+    return [];
+  }
+
+  return (result.checks ?? [])
+    .filter((check) => check.status === 'warn')
+    .map((check) => ({
+      code: `artifact-contract-${check.id}`,
+      message: check.message,
+      path: check.path ?? undefined
+    }));
+}
+
+function artifactContractErrors(result) {
+  if (!result || result.status !== 'fail') {
+    return [];
+  }
+
+  return [
+    {
+      code: 'artifact-contract-failed',
+      message: 'Refusing to archive because AIFHub OpenSpec artifact contract validation failed.',
+      checks: (result.checks ?? []).filter((check) => check.status === 'fail')
+    }
+  ];
 }
 
 export async function archiveChangeWithOpenSpec(changeId, options = {}) {

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -529,6 +529,45 @@ describe('OpenSpec done finalizer API', () => {
     ]);
   });
 
+  it('refuses to archive when the OpenSpec artifact contract fails', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await createRuntimeEvidence(rootDir);
+    let archiveCalls = 0;
+
+    const result = await finalizeOpenSpecChange({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => availableCliDetection(),
+      readLatestVerificationEvidence: async () => verificationEvidence(),
+      validateOpenSpecArtifactContract: async () => ({
+        schema_version: 1,
+        validator: 'aifhub-openspec-artifact-contract',
+        change_id: 'add-oauth',
+        status: 'fail',
+        blocking: true,
+        checks: [
+          {
+            id: 'runtime-files-outside-change',
+            status: 'fail',
+            path: 'openspec/changes/add-oauth/openspec-validation.json',
+            message: 'Runtime evidence must stay outside canonical changes.'
+          }
+        ],
+        suggested_next: null
+      }),
+      archiveOpenSpecChange: async () => {
+        archiveCalls += 1;
+        return archiveResult();
+      }
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.archive.archived, false);
+    assert.equal(result.errors[0].code, 'artifact-contract-failed');
+    assert.equal(archiveCalls, 0);
+  });
+
   it('finalizes passing changes, writes done summaries, and stays out of canonical/legacy paths', async () => {
     const rootDir = await createTempRoot();
     await createOpenSpecChange(rootDir);


### PR DESCRIPTION
## Summary

Adds a read-only AIFHub OpenSpec artifact contract validator on top of OpenSpec CLI validation.

## Changes

- Add `scripts/openspec-artifact-validator.mjs` with API and CLI support.
- Validate required OpenSpec change artifacts, delta specs, generated rule freshness, QA evidence, runtime-file placement, and direct `openspec/specs/**` mutation evidence.
- Surface validator output in `/aif-mode doctor --json` as `artifactContract`.
- Gate `/aif-done` archive on a fresh passing artifact contract result.
- Document the validator in `docs/openspec-validation.md` and link it from existing docs.

## Validation

- `npm run validate`
- `npm test`
- `node scripts/openspec-artifact-validator.mjs --change add-openspec-artifact-contract-validator --json`
- `node scripts/openspec-artifact-validator.mjs --change add-openspec-artifact-contract-validator --require-verification-evidence --json` expected fail before `/aif-verify` evidence exists
- `node scripts/aif-mode.mjs doctor --change add-openspec-artifact-contract-validator --json` expected fail before `/aif-verify` evidence exists