### PR TITLE
feat: add generated rules traceability index

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ openspec/
       openspec-base.md
       openspec-change-<change-id>.md
       openspec-merged-<change-id>.md
+      openspec-rules-trace-<change-id>.json
+      index.json
 ```
 
 | Path | Ownership |

--- a/agent-files/claude/aifhub-rules-sidecar.md
+++ b/agent-files/claude/aifhub-rules-sidecar.md
@@ -24,9 +24,12 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Inventory and explicitly read `.ai-factory/rules/generated/*` before selecting applicable generated rules.
 - Apply generated rules first when present: `.ai-factory/rules/generated/openspec-merged-<change-id>.md`, `.ai-factory/rules/generated/openspec-change-<change-id>.md`, and `.ai-factory/rules/generated/openspec-base.md`.
+- Read `.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json` and `.ai-factory/rules/generated/index.json` when present.
+- A generated-rule `FAIL` must cite trace-backed `source.path` and `source.requirement` from the trace JSON.
+- If trace JSON is missing or invalid, cap generated-rule findings at `WARN` and ask for `/aif-mode sync --change <change-id>`.
 - Then read `.ai-factory/RULES.md` and `.ai-factory/rules/base.md` when present.
 - Do not require plan-local rules.
-- Do not regenerate generated rules; return `WARN` when they are missing or stale.
+- Do not regenerate generated rules; return `WARN` when they are missing, stale, or lack valid trace metadata.
 - Do not edit files.
 - Return findings first with active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path `.ai-factory/state/<change-id>/`, and QA evidence path `.ai-factory/qa/<change-id>/`.
 

--- a/agent-files/codex/aifhub-rules-sidecar.toml
+++ b/agent-files/codex/aifhub-rules-sidecar.toml
@@ -18,9 +18,12 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Inventory and explicitly read .ai-factory/rules/generated/* before selecting applicable generated rules.
 - Apply generated rules first when present: .ai-factory/rules/generated/openspec-merged-<change-id>.md, .ai-factory/rules/generated/openspec-change-<change-id>.md, and .ai-factory/rules/generated/openspec-base.md.
+- Read .ai-factory/rules/generated/openspec-rules-trace-<change-id>.json and .ai-factory/rules/generated/index.json when present.
+- A generated-rule FAIL must cite trace-backed source.path and source.requirement from the trace JSON.
+- If trace JSON is missing or invalid, cap generated-rule findings at WARN and ask for /aif-mode sync --change <change-id>.
 - Then read .ai-factory/RULES.md and .ai-factory/rules/base.md when present.
 - Do not require plan-local rules.
-- Do not regenerate generated rules; return WARN when they are missing or stale.
+- Do not regenerate generated rules; return WARN when they are missing, stale, or lack valid trace metadata.
 - Do not edit files.
 - Return findings first with active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path .ai-factory/state/<change-id>/, and QA evidence path .ai-factory/qa/<change-id>/.
 

--- a/docs/claude-agents.md
+++ b/docs/claude-agents.md
@@ -23,7 +23,7 @@
 
 - `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope, возвращают findings-first output без auto-fix, and end with one final machine-readable `aif-gate-result` block. Запускаются в фоне (`background: true`).
 - `aifhub-review-sidecar`, `aifhub-security-sidecar`, and `aifhub-rules-sidecar` use gate values `"review"`, `"security"`, and `"rules"` respectively, with lowercase `status` values `pass`, `warn`, or `fail`.
-- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it uses `aif-rules-check` and reads `.ai-factory/rules/generated/*` in OpenSpec-native mode.
+- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it uses `aif-rules-check` and reads generated markdown plus trace metadata under `.ai-factory/rules/generated/*` in OpenSpec-native mode.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
 - `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, and prepares summary/archive evidence.

--- a/docs/codex-agents.md
+++ b/docs/codex-agents.md
@@ -23,7 +23,7 @@
 
 - `read-only sidecar`: `aifhub-review-sidecar`, `aifhub-security-sidecar`, `aifhub-rules-sidecar`. Эти агенты только читают scope, возвращают findings-first output без auto-fix, and end with one final machine-readable `aif-gate-result` block.
 - `aifhub-review-sidecar`, `aifhub-security-sidecar`, and `aifhub-rules-sidecar` use gate values `"review"`, `"security"`, and `"rules"` respectively, with lowercase `status` values `pass`, `warn`, or `fail`.
-- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it is namespaced for AIFHub and reads `.ai-factory/rules/generated/*` in OpenSpec-native mode.
+- `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it is namespaced for AIFHub and reads generated markdown plus trace metadata under `.ai-factory/rules/generated/*` in OpenSpec-native mode.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
 - `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, prepares summary/archive evidence, and does not bypass owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -66,10 +66,12 @@ They may also load derived/runtime artifacts:
 - `.ai-factory/rules/generated/openspec-base.md`
 - `.ai-factory/rules/generated/openspec-change-<change-id>.md`
 - `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
+- `.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json`
+- `.ai-factory/rules/generated/index.json`
 - `.ai-factory/state/<change-id>/**`
 - `.ai-factory/qa/<change-id>/**`
 
-Generated rules are derived guidance only. If generated rules conflict with canonical OpenSpec artifacts, canonical OpenSpec artifacts win.
+Generated rules and generated trace metadata are derived guidance only. If generated rules conflict with canonical OpenSpec artifacts, canonical OpenSpec artifacts win.
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -97,13 +97,25 @@ Recommended sync points:
 
 `/aif-mode sync` compiles generated rules and requests OpenSpec validation/status when configured and available. Missing OpenSpec CLI is degraded mode for sync validation, not an install failure.
 
-When no active changes exist after archive, `/aif-mode sync` still refreshes `.ai-factory/rules/generated/openspec-base.md` from `openspec/specs/**`, skips change-specific generated rules, skips change validation, writes a sync report, and returns OK.
+When no active changes exist after archive, `/aif-mode sync` still refreshes `.ai-factory/rules/generated/openspec-base.md` and `.ai-factory/rules/generated/index.json` from `openspec/specs/**`, skips change-specific generated rules, skips change validation, writes a sync report, and returns OK.
 
 For `/aif-mode sync --all`, selected active changes without `openspec/changes/<change-id>/specs/**/spec.md` delta specs are reported as `no-delta-specs` warnings and skipped for sync validation. Changes with delta specs are still validated/statused when the CLI is available.
 
 ## Rules Gate
 
 `/aif-rules-check` is read-only. It uses AIFHub generated rules in OpenSpec-native mode and returns a machine-readable `aif-gate-result` with `gate: "rules"`.
+
+Generated rules are compiled as markdown plus provenance JSON:
+
+```text
+.ai-factory/rules/generated/openspec-base.md
+.ai-factory/rules/generated/openspec-change-<change-id>.md
+.ai-factory/rules/generated/openspec-merged-<change-id>.md
+.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json
+.ai-factory/rules/generated/index.json
+```
+
+Generated-rule failures must cite trace-backed `source.path` and `source.requirement`. Missing or invalid trace metadata is warning-only and should be fixed with sync; it is not enough on its own for a generated-rule `FAIL`.
 
 If generated rules are missing or stale, run:
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -115,7 +115,7 @@ Generated rules are compiled as markdown plus provenance JSON:
 .ai-factory/rules/generated/index.json
 ```
 
-Generated-rule failures must cite trace-backed `source.path` and `source.requirement`. Missing or invalid trace metadata is warning-only and should be fixed with sync; it is not enough on its own for a generated-rule `FAIL`.
+Generated-rule failures must cite trace-backed `source.path` and `source.requirement`. The trace also records output hashes for generated markdown so status/doctor can detect manual edits to generated rule text. Missing or invalid trace metadata is warning-only and should be fixed with sync; it is not enough on its own for a generated-rule `FAIL`.
 
 If generated rules are missing or stale, run:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,9 +149,9 @@ Does not write:
 
 Use `--dry-run` for planned switching or sync writes. Use `--all` or `--change <id>` to control change selection. Use `--export-openspec` only for compatibility legacy exports from OpenSpec changes. In OpenSpec mode, sync respects `aifhub.openspec.compileRulesOnSync` and `aifhub.openspec.validateOnSync`.
 
-`/aif-mode sync --change <change-id>` is recommended after `/aif-plan full` or `/aif-improve` and whenever canonical specs or tasks changed during implementation or fixes. It ensures OpenSpec skeleton paths, compiles `.ai-factory/rules/generated/openspec-base.md`, `.ai-factory/rules/generated/openspec-change-<change-id>.md`, and `.ai-factory/rules/generated/openspec-merged-<change-id>.md`, requests OpenSpec validation/status when the CLI is available and `validateOnSync` is enabled, detects legacy plans in OpenSpec mode, and writes a sync report under `.ai-factory/state/mode-switches/`.
+`/aif-mode sync --change <change-id>` is recommended after `/aif-plan full` or `/aif-improve` and whenever canonical specs or tasks changed during implementation or fixes. It ensures OpenSpec skeleton paths, compiles `.ai-factory/rules/generated/openspec-base.md`, `.ai-factory/rules/generated/openspec-change-<change-id>.md`, `.ai-factory/rules/generated/openspec-merged-<change-id>.md`, `.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json`, and `.ai-factory/rules/generated/index.json`, requests OpenSpec validation/status when the CLI is available and `validateOnSync` is enabled, detects legacy plans in OpenSpec mode, and writes a sync report under `.ai-factory/state/mode-switches/`.
 
-`/aif-mode sync` without `--change` is recommended after `/aif-done`. After archive, there may be no active change. Sync still refreshes `.ai-factory/rules/generated/openspec-base.md` from `openspec/specs/**`, skips change-specific generated rules and change validation when no active changes exist, and writes a sync report. OpenSpec skills are not installed.
+`/aif-mode sync` without `--change` is recommended after `/aif-done`. After archive, there may be no active change. Sync still refreshes `.ai-factory/rules/generated/openspec-base.md` and `.ai-factory/rules/generated/index.json` from `openspec/specs/**`, skips change-specific generated rules and change validation when no active changes exist, and writes a sync report. OpenSpec skills are not installed.
 
 `/aif-mode sync --all` is a maintenance sweep. It refreshes generated rules for active changes, validates only selected changes that contain `openspec/changes/<change-id>/specs/**/spec.md` delta specs, and reports selected no-delta changes as `no-delta-specs` warnings instead of failing solely because old or docs-only active changes have no delta specs. `/aif-verify <change-id>` remains the stricter verification gate for a specific change.
 
@@ -338,6 +338,8 @@ Reads:
 - `.ai-factory/rules/generated/openspec-merged-<change-id>.md`
 - `.ai-factory/rules/generated/openspec-change-<change-id>.md`
 - `.ai-factory/rules/generated/openspec-base.md`
+- `.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json`
+- `.ai-factory/rules/generated/index.json`
 - `.ai-factory/RULES.md`
 - `.ai-factory/rules/base.md`
 - optional canonical OpenSpec context under `openspec/specs/**` and `openspec/changes/<change-id>/**`
@@ -346,9 +348,11 @@ Writes:
 
 - none
 
-`/aif-rules-check` is optional after implementation or fixes and useful for strict/high-risk changes. In OpenSpec-native mode it uses generated rules first, returns a final `aif-gate-result` with `gate: "rules"`, and does not regenerate generated rules.
+`/aif-rules-check` is optional after implementation or fixes and useful for strict/high-risk changes. In OpenSpec-native mode it uses generated rules first, loads trace JSON when present, returns a final `aif-gate-result` with `gate: "rules"`, and does not regenerate generated rules.
 
-If generated rules are missing or stale:
+Generated-rule `FAIL` findings must cite trace-backed `source.path` and `source.requirement`. If the generated trace is missing or invalid, generated-rule findings are capped at `WARN`; rerun sync to regenerate trace metadata.
+
+If generated rules or generated trace metadata are missing or stale:
 
 ```text
 /aif-rules-check

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -350,7 +350,7 @@ Writes:
 
 `/aif-rules-check` is optional after implementation or fixes and useful for strict/high-risk changes. In OpenSpec-native mode it uses generated rules first, loads trace JSON when present, returns a final `aif-gate-result` with `gate: "rules"`, and does not regenerate generated rules.
 
-Generated-rule `FAIL` findings must cite trace-backed `source.path` and `source.requirement`. If the generated trace is missing or invalid, generated-rule findings are capped at `WARN`; rerun sync to regenerate trace metadata.
+Generated-rule `FAIL` findings must cite trace-backed `source.path` and `source.requirement`. The generated trace includes output hashes for generated markdown, so status/doctor can warn when generated rule text is manually edited without source-spec changes. If the generated trace is missing or invalid, generated-rule findings are capped at `WARN`; rerun sync to regenerate trace metadata.
 
 If generated rules or generated trace metadata are missing or stale:
 

--- a/injections/core/aif-rules-check-openspec-generated-rules.md
+++ b/injections/core/aif-rules-check-openspec-generated-rules.md
@@ -39,7 +39,22 @@ Load rules in this priority order:
 
 OpenSpec-native mode does not require plan-local `rules.md`. Ignore plan-local `rules.md` unless the run is explicitly in Legacy AI Factory-only mode.
 
-If generated rules are missing or stale, return `WARN`, report which generated rules are present, missing, or stale, and ask the caller to regenerate rules through the compiler-owning workflow: `/aif-mode sync --change <change-id>`, then rerun `/aif-rules-check`. This gate must not regenerate or edit generated rules.
+Load generated trace metadata when present:
+
+- `.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json`
+- `.ai-factory/rules/generated/index.json`
+
+Use trace metadata only as provenance for generated rules. Generated markdown remains the readable rule guidance; canonical OpenSpec artifacts remain the source of truth.
+
+Generated-rule `FAIL` findings require trace-backed source evidence:
+
+- cite `source.path`
+- cite `source.requirement`
+- keep the cited source aligned with `.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json`
+
+If generated rules or generated trace metadata are missing, stale, or invalid, return `WARN`, report which generated rules and trace files are present, missing, stale, or invalid, and ask the caller to regenerate rules through the compiler-owning workflow: `/aif-mode sync --change <change-id>`, then rerun `/aif-rules-check`. This gate must not regenerate or edit generated rules.
+
+When generated trace metadata is missing or invalid, possible generated-rule findings are capped at `WARN`. Do not return final `status: "fail"` solely for a generated-rule finding unless that finding includes trace-backed `source.path` and `source.requirement`.
 
 Runtime state and QA evidence are external context only:
 

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -745,7 +745,12 @@ async function syncGeneratedRules(options = {}) {
   const results = [];
 
   if (changeIds.length === 0) {
-    const result = await compileOpenSpecBaseRules({ ...options, rootDir, dryRun });
+    const result = await compileOpenSpecBaseRules({
+      ...options,
+      rootDir,
+      dryRun,
+      resetIndexChanges: true
+    });
 
     return {
       ok: result.ok,

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -716,6 +716,7 @@ export async function inspectGeneratedRules(options = {}) {
       if (!rule.exists) {
         missing.push(fileName);
       } else if (rule.stale === true) {
+        // Includes source-hash drift and generated markdown output hash drift.
         stale.push(fileName);
       }
     }

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -10,15 +10,16 @@ import {
 } from './active-change-resolver.mjs';
 import {
   compileOpenSpecBaseRules,
-  collectOpenSpecRuleSources,
-  compileOpenSpecRules,
-  renderGeneratedRules
+  compileOpenSpecRules
 } from './openspec-rules-compiler.mjs';
 import {
   detectOpenSpec as defaultDetectOpenSpec,
   getOpenSpecStatus as defaultGetOpenSpecStatus,
   validateOpenSpecChange as defaultValidateOpenSpecChange
 } from './openspec-runner.mjs';
+import {
+  collectGeneratedRules as collectGeneratedRuleContext
+} from './openspec-execution-context.mjs';
 import {
   discoverLegacyPlans,
   migrateAllLegacyPlans
@@ -81,15 +82,18 @@ export async function getModeStatus(options = {}) {
   const detection = await detectOpenSpecCapability(rootDir, options);
   const openSpecChanges = await listOpenSpecChanges({ rootDir });
   const legacy = await discoverLegacyPlans({ rootDir });
-  const generatedRules = await inspectGeneratedRules({
-    ...options,
-    rootDir,
-    changeIds: selectRuleInspectionChanges(openSpecChanges)
-  });
   const activeChange = await inspectActiveChange({
     ...options,
     rootDir,
     changeId: options.changeId
+  });
+  const generatedRuleChangeIds = options.changeId !== undefined && activeChange.state === 'resolved'
+    ? [activeChange.changeId]
+    : selectRuleInspectionChanges(openSpecChanges);
+  const generatedRules = await inspectGeneratedRules({
+    ...options,
+    rootDir,
+    changeIds: generatedRuleChangeIds
   });
 
   return {
@@ -398,6 +402,8 @@ export async function doctorAifMode(options = {}) {
 
   if (status.generatedRules.state === 'ok') {
     diagnostics.push(pass('generated-rules', 'Generated rules are present and current.'));
+  } else if (status.generatedRules.state === 'warn') {
+    diagnostics.push(warn('generated-rules-warning', 'Generated rules have trace warnings.'));
   } else if (status.generatedRules.state === 'stale') {
     diagnostics.push(warn('generated-rules-stale', 'Generated rules are stale.'));
   } else {
@@ -667,11 +673,12 @@ export async function listOpenSpecChanges(options = {}) {
 export async function inspectGeneratedRules(options = {}) {
   const rootDir = resolveRootDir(options);
   const changeIds = Array.from(options.changeIds ?? []).map((item) => typeof item === 'string' ? item : item.id);
-  const expected = new Set(['openspec-base.md']);
+  const expected = new Set(['index.json', 'openspec-base.md']);
 
   for (const changeId of changeIds) {
     expected.add(`openspec-change-${changeId}.md`);
     expected.add(`openspec-merged-${changeId}.md`);
+    expected.add(`openspec-rules-trace-${changeId}.json`);
   }
 
   const missing = [];
@@ -692,7 +699,7 @@ export async function inspectGeneratedRules(options = {}) {
       continue;
     }
 
-    const collected = await collectOpenSpecRuleSources(normalized.changeId, {
+    const collected = await collectGeneratedRuleContext(normalized.changeId, {
       ...options,
       rootDir
     });
@@ -703,27 +710,28 @@ export async function inspectGeneratedRules(options = {}) {
       continue;
     }
 
-    const rendered = renderGeneratedRules(collected.sources, { changeId: normalized.changeId });
-    for (const file of rendered.files) {
-      const target = path.join(rootDir, '.ai-factory', 'rules', 'generated', file.fileName);
-      try {
-        const current = await readFile(target, 'utf8');
-        if (current !== file.content) {
-          stale.push(file.fileName);
-        }
-      } catch {
-        // Already reported as missing.
+    for (const rule of collected.generatedRules ?? []) {
+      const fileName = path.basename(rule.path);
+
+      if (!rule.exists) {
+        missing.push(fileName);
+      } else if (rule.stale === true) {
+        stale.push(fileName);
       }
     }
   }
 
-  const state = stale.length > 0 ? 'stale' : missing.length > 0 ? 'missing' : 'ok';
+  const warningOnly = warnings.some((warning) =>
+    warning.code === 'missing-generated-rules-trace'
+    || warning.code === 'invalid-generated-rules-trace'
+  );
+  const state = stale.length > 0 ? 'stale' : missing.length > 0 ? 'missing' : warningOnly ? 'warn' : 'ok';
 
   return {
     ok: errors.length === 0,
     state,
     expected: [...expected].sort((left, right) => left.localeCompare(right)),
-    missing: missing.sort((left, right) => left.localeCompare(right)),
+    missing: [...new Set(missing)].sort((left, right) => left.localeCompare(right)),
     stale: [...new Set(stale)].sort((left, right) => left.localeCompare(right)),
     warnings: dedupeDiagnostics(warnings),
     errors
@@ -758,36 +766,7 @@ async function syncGeneratedRules(options = {}) {
   }
 
   for (const changeId of changeIds) {
-    if (dryRun) {
-      const collected = await collectOpenSpecRuleSources(changeId, { ...options, rootDir });
-      if (!collected.ok) {
-        results.push({
-          ok: false,
-          changeId,
-          files: [],
-          warnings: collected.warnings,
-          errors: collected.errors
-        });
-        continue;
-      }
-
-      const rendered = renderGeneratedRules(collected.sources, { changeId });
-      results.push({
-        ok: true,
-        dryRun: true,
-        changeId,
-        files: rendered.files.map((file) => ({
-          kind: file.kind,
-          relativePath: `.ai-factory/rules/generated/${file.fileName}`,
-          written: false
-        })),
-        warnings: collected.warnings,
-        errors: []
-      });
-      continue;
-    }
-
-    results.push(await compileOpenSpecRules(changeId, { ...options, rootDir }));
+    results.push(await compileOpenSpecRules(changeId, { ...options, rootDir, dryRun }));
   }
 
   return {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -170,6 +170,67 @@ describe('mode status', () => {
     assert.ok(status.generatedRules.warnings.some((warning) => warning.code === 'missing-generated-rules-trace'));
   });
 
+  it('reports generated rules stale when traced markdown output is edited', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## Requirements',
+      '',
+      '### Requirement: Existing Auth',
+      '',
+      'The system MUST preserve existing authentication.',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/design.md', '# Design\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/tasks.md', '# Tasks\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/specs/auth/spec.md', [
+      '# Auth Delta',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: OAuth Login',
+      '',
+      'The system MUST support OAuth login.',
+      ''
+    ].join('\n'));
+    const sync = await syncOpenSpecArtifacts({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection(),
+      getCurrentBranch: async () => 'feat/add-oauth',
+      timestamp: '2026-04-29T01-00-00-000Z'
+    });
+    assert.equal(sync.ok, true);
+    const mergedPath = '.ai-factory/rules/generated/openspec-merged-add-oauth.md';
+    const merged = await readFixture(rootDir, mergedPath);
+    await writeFixture(rootDir, mergedPath, `${merged}\nManual edit.\n`);
+
+    const status = await getModeStatus({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection(),
+      getCurrentBranch: async () => 'feat/add-oauth'
+    });
+
+    assert.equal(status.generatedRules.state, 'stale');
+    assert.deepEqual(status.generatedRules.stale, ['openspec-merged-add-oauth.md']);
+    assert.ok(status.generatedRules.warnings.some((warning) => warning.code === 'stale-generated-rules'));
+  });
+
   it('limits generated-rule status inspection to an explicit change when provided', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, '.ai-factory/config.yaml', [

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -36,6 +36,10 @@ async function readFixture(rootDir, relativePath) {
   return readFile(path.join(rootDir, ...relativePath.split('/')), 'utf8');
 }
 
+async function readJsonFixture(rootDir, relativePath) {
+  return JSON.parse(await readFixture(rootDir, relativePath));
+}
+
 async function pathExists(rootDir, relativePath) {
   try {
     await access(path.join(rootDir, ...relativePath.split('/')));
@@ -131,6 +135,85 @@ describe('mode status', () => {
 
     assert.equal(status.mode, 'ai-factory');
     assert.equal(status.configMarker, 'ai-factory');
+  });
+
+  it('surfaces missing generated rules trace in status diagnostics', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/design.md', '# Design\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/tasks.md', '# Tasks\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/specs/auth/spec.md', '# Auth\n');
+    await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md', '# Generated\n\n## Source Fingerprints\n');
+    await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-change-add-oauth.md', '# Generated\n\n## Source Fingerprints\n');
+    await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-merged-add-oauth.md', '# Generated\n\n## Source Fingerprints\n');
+    await writeFixture(rootDir, '.ai-factory/rules/generated/index.json', '{"schema_version":1,"changes":[]}\n');
+
+    const status = await getModeStatus({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      getCurrentBranch: async () => 'feat/add-oauth'
+    });
+
+    assert.equal(status.generatedRules.state, 'missing');
+    assert.ok(status.generatedRules.missing.includes('openspec-rules-trace-add-oauth.json'));
+    assert.ok(status.generatedRules.warnings.some((warning) => warning.code === 'missing-generated-rules-trace'));
+  });
+
+  it('limits generated-rule status inspection to an explicit change when provided', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: OAuth',
+      '',
+      'The system MUST support OAuth.',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-passkeys/proposal.md', '# Proposal\n');
+
+    await syncOpenSpecArtifacts({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection(),
+      timestamp: '2026-04-29T03-00-00-000Z'
+    });
+
+    const explicit = await getModeStatus({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => missingCliDetection(),
+      getCurrentBranch: async () => 'feat/add-oauth'
+    });
+
+    assert.equal(explicit.activeChange.changeId, 'add-oauth');
+    assert.equal(explicit.generatedRules.state, 'ok');
+    assert.deepEqual(explicit.generatedRules.missing, []);
   });
 });
 
@@ -244,9 +327,25 @@ describe('artifact sync and export', () => {
     });
 
     assert.equal(result.ok, true);
+    assert.deepEqual(result.generatedRules.files.map((file) => file.kind), ['base', 'change', 'merged', 'trace', 'index']);
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md'), /No base OpenSpec requirements found/);
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-change-add-mfa.md'), /Requirement: Require MFA/);
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-merged-add-mfa.md'), /Requirement: Require MFA/);
+    const trace = await readJsonFixture(rootDir, '.ai-factory/rules/generated/openspec-rules-trace-add-mfa.json');
+    const index = await readJsonFixture(rootDir, '.ai-factory/rules/generated/index.json');
+    assert.equal(trace.schema_version, 1);
+    assert.equal(trace.change_id, 'add-mfa');
+    assert.deepEqual(trace.inputs.map((input) => input.kind), ['delta-spec']);
+    assert.equal(index.base.markdown, '.ai-factory/rules/generated/openspec-base.md');
+    assert.deepEqual(index.changes.map((entry) => entry.change_id), ['add-mfa']);
+    assert.equal(index.changes[0].trace, '.ai-factory/rules/generated/openspec-rules-trace-add-mfa.json');
+
+    const status = await getModeStatus({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      getCurrentBranch: async () => 'feat/add-mfa'
+    });
+    assert.equal(status.generatedRules.state, 'ok');
     assert.equal(result.validation.skipped, true);
     assert.equal(result.validation.reason, 'missing-cli');
     assert.equal(await pathExists(rootDir, '.ai-factory/state/mode-switches/2026-04-29T00-00-00-000Z-sync-openspec.md'), true);
@@ -311,6 +410,8 @@ describe('artifact sync and export', () => {
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md'), /Requirement: Base Auth/);
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-change-add-mfa.md'), /Requirement: Require MFA/);
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-merged-add-passkeys.md'), /Requirement: Support Passkeys/);
+    const index = await readJsonFixture(rootDir, '.ai-factory/rules/generated/index.json');
+    assert.deepEqual(index.changes.map((entry) => entry.change_id), ['add-mfa', 'add-passkeys']);
   });
 
   it('skips sync validation for active changes without delta specs', async () => {
@@ -464,9 +565,13 @@ describe('artifact sync and export', () => {
     assert.deepEqual(result.changes.changeIds, []);
     assert.equal(result.generatedRules.baseOnly, true);
     assert.equal(result.generatedRules.changeSpecificSkipped, true);
+    assert.deepEqual(result.generatedRules.files.map((file) => file.kind), ['base', 'index']);
     assert.equal(result.validation.skipped, true);
     assert.equal(result.validation.reason, 'no-selected-changes');
     assert.match(await readFixture(rootDir, '.ai-factory/rules/generated/openspec-base.md'), /Requirement: Accepted Auth/);
+    const index = await readJsonFixture(rootDir, '.ai-factory/rules/generated/index.json');
+    assert.equal(index.base.markdown, '.ai-factory/rules/generated/openspec-base.md');
+    assert.deepEqual(index.changes, []);
     assert.equal(await pathExists(rootDir, '.ai-factory/rules/generated/openspec-change-accepted-auth.md'), false);
     assert.equal(await pathExists(rootDir, 'openspec/changes/.ai-factory'), false);
     assert.equal(await pathExists(rootDir, '.ai-factory/state/mode-switches/2026-04-29T02-00-00-000Z-sync-openspec.md'), true);

--- a/scripts/aif-gate-result.test.mjs
+++ b/scripts/aif-gate-result.test.mjs
@@ -261,6 +261,11 @@ describe('aif-rules-check gate contract', () => {
       assert.match(asset, /final machine-readable `aif-gate-result` fenced JSON block/i);
       assert.match(asset, /"gate": "rules"/);
       assert.match(asset, /lowercase JSON `status`: `pass`, `warn`, or `fail`/);
+      assert.match(asset, /openspec-rules-trace-<change-id>\.json/);
+      assert.match(asset, /source\.path/);
+      assert.match(asset, /source\.requirement/);
+      assert.match(asset, /capped at `WARN`/i);
+      assert.match(asset, /Do not return final `status: "fail"` solely/i);
     }
   });
 
@@ -284,6 +289,10 @@ describe('aif-rules-check gate contract', () => {
       assert.match(asset, /"gate": "rules"/);
       assert.match(asset, /Verdict: PASS/);
       assert.match(asset, /\.ai-factory\/rules\/generated\/\*/);
+      assert.match(asset, /openspec-rules-trace-<change-id>\.json/);
+      assert.match(asset, /source\.path/);
+      assert.match(asset, /source\.requirement/);
+      assert.match(asset, /cap .*WARN/i);
       assert.match(asset, /upstream .*rules-sidecar/i);
       assert.match(asset, /Do not edit files/);
     }

--- a/scripts/openspec-artifact-validator.mjs
+++ b/scripts/openspec-artifact-validator.mjs
@@ -415,8 +415,12 @@ async function inspectGeneratedRules(changeId, options) {
 
   const missing = generated.generatedRules.filter((rule) => !rule.exists);
   const stale = generated.generatedRules.filter((rule) => rule.stale === true);
+  const traceWarnings = generated.warnings.filter((warning) =>
+    warning.code !== 'missing-generated-rules'
+    && warning.code !== 'stale-generated-rules'
+  );
 
-  if (missing.length === 0 && stale.length === 0) {
+  if (missing.length === 0 && stale.length === 0 && traceWarnings.length === 0) {
     return [
       createCheck({
         id: 'generated-rules-current',
@@ -439,6 +443,13 @@ async function inspectGeneratedRules(changeId, options) {
       status: 'warn',
       path: rule.path,
       message: 'Generated OpenSpec rules are stale.'
+    })),
+    ...traceWarnings.map((warning) => createCheck({
+      id: 'generated-rules-current',
+      status: 'warn',
+      path: warning.path ?? '.ai-factory/rules/generated',
+      message: warning.message,
+      details: warning
     }))
   ];
 }

--- a/scripts/openspec-execution-context.mjs
+++ b/scripts/openspec-execution-context.mjs
@@ -189,19 +189,22 @@ export async function collectGeneratedRules(changeId, options = {}) {
       kind: 'merged',
       fileName: `openspec-merged-${resolvedChangeId}.md`,
       expectedFingerprints: new Map([...fingerprints.base, ...fingerprints.delta]),
-      traceInputKinds: ['base-spec', 'delta-spec']
+      traceInputKinds: ['base-spec', 'delta-spec'],
+      traceOutputKind: 'merged-rules'
     },
     {
       kind: 'change',
       fileName: `openspec-change-${resolvedChangeId}.md`,
       expectedFingerprints: fingerprints.delta,
-      traceInputKinds: ['delta-spec']
+      traceInputKinds: ['delta-spec'],
+      traceOutputKind: 'change-rules'
     },
     {
       kind: 'base',
       fileName: 'openspec-base.md',
       expectedFingerprints: fingerprints.base,
-      traceInputKinds: ['base-spec']
+      traceInputKinds: ['base-spec'],
+      traceOutputKind: 'base-rules'
     }
   ];
   const generatedRules = [];
@@ -215,18 +218,25 @@ export async function collectGeneratedRules(changeId, options = {}) {
     const traceStale = item.exists && trace.exists && trace.valid
       ? determineTraceStaleness(trace.inputs, expectedFile.expectedFingerprints, expectedFile.traceInputKinds)
       : null;
+    const traceOutputStale = item.exists && trace.exists && trace.valid
+      ? determineTraceOutputStaleness(trace.outputs, item, expectedFile.traceOutputKind)
+      : null;
     const markdownStale = item.exists && !(trace.exists && trace.valid)
       ? determineStaleness(item.content, expectedFile.expectedFingerprints)
       : null;
-    const stale = trace.exists && trace.valid ? traceStale : markdownStale;
+    const stale = trace.exists && trace.valid
+      ? combineTraceStaleness(traceStale, traceOutputStale)
+      : markdownStale;
 
     generatedRules.push({
       kind: expectedFile.kind,
       path: item.path,
       exists: item.exists,
       stale,
-      staleSource: trace.exists && trace.valid ? 'trace' : 'markdown',
-      trace: summarizeGeneratedRulesTrace(trace, traceStale),
+      staleSource: trace.exists && trace.valid
+        ? traceOutputStale === null ? 'trace' : 'trace-output'
+        : 'markdown',
+      trace: summarizeGeneratedRulesTrace(trace, stale),
       content: item.content
     });
 
@@ -643,6 +653,7 @@ async function readGeneratedRulesTrace(rootDir, generatedDir, changeId) {
       valid: false,
       stale: null,
       inputs: [],
+      outputs: [],
       content: '',
       error: null
     };
@@ -654,16 +665,28 @@ async function readGeneratedRulesTrace(rootDir, generatedDir, changeId) {
     const inputs = Array.isArray(rawInputs)
       ? rawInputs.map(normalizeTraceInput).filter(Boolean)
       : [];
+    const rawOutputs = parsed?.outputs;
+    const outputs = rawOutputs === undefined
+      ? []
+      : Array.isArray(rawOutputs)
+        ? rawOutputs.map(normalizeTraceOutput).filter(Boolean)
+        : [];
 
-    if (parsed?.schema_version !== 1 || !Array.isArray(rawInputs) || inputs.length !== rawInputs.length) {
+    if (
+      parsed?.schema_version !== 1
+      || !Array.isArray(rawInputs)
+      || inputs.length !== rawInputs.length
+      || rawOutputs !== undefined && (!Array.isArray(rawOutputs) || outputs.length !== rawOutputs.length)
+    ) {
       return {
         path: item.path,
         exists: true,
         valid: false,
         stale: null,
         inputs: [],
+        outputs: [],
         content: item.content,
-        error: 'Trace JSON must have schema_version 1 and valid inputs.'
+        error: 'Trace JSON must have schema_version 1 and valid inputs/outputs.'
       };
     }
 
@@ -673,6 +696,7 @@ async function readGeneratedRulesTrace(rootDir, generatedDir, changeId) {
       valid: true,
       stale: null,
       inputs,
+      outputs,
       content: item.content,
       error: null
     };
@@ -683,6 +707,7 @@ async function readGeneratedRulesTrace(rootDir, generatedDir, changeId) {
       valid: false,
       stale: null,
       inputs: [],
+      outputs: [],
       content: item.content,
       error: err?.message ?? 'Invalid JSON.'
     };
@@ -709,6 +734,40 @@ function normalizeTraceInput(input) {
     sha256,
     kind: input.kind
   };
+}
+
+function normalizeTraceOutput(output) {
+  if (
+    output === null
+    || typeof output !== 'object'
+    || typeof output.path !== 'string'
+    || typeof output.sha256 !== 'string'
+    || typeof output.kind !== 'string'
+  ) {
+    return null;
+  }
+
+  const sha256 = output.sha256.startsWith('sha256:')
+    ? output.sha256
+    : `sha256:${output.sha256}`;
+
+  return {
+    path: toPosix(output.path),
+    sha256,
+    kind: output.kind
+  };
+}
+
+function combineTraceStaleness(inputStale, outputStale) {
+  if (inputStale === true || outputStale === true) {
+    return true;
+  }
+
+  if (inputStale === false && (outputStale === false || outputStale === null)) {
+    return false;
+  }
+
+  return inputStale ?? outputStale;
 }
 
 function determineTraceStaleness(inputs, expectedFingerprints, traceInputKinds) {
@@ -746,12 +805,30 @@ function determineTraceStaleness(inputs, expectedFingerprints, traceInputKinds) 
   return false;
 }
 
+function determineTraceOutputStaleness(outputs, generatedRule, traceOutputKind) {
+  if (!Array.isArray(outputs) || outputs.length === 0) {
+    return null;
+  }
+
+  const output = outputs.find((item) =>
+    item.path === generatedRule.path
+    || item.kind === traceOutputKind
+  );
+
+  if (output === undefined) {
+    return null;
+  }
+
+  return output.sha256 !== createFingerprint(generatedRule.content);
+}
+
 function summarizeGeneratedRulesTrace(trace, stale) {
   return {
     path: trace.path,
     exists: trace.exists,
     valid: trace.valid,
     stale,
+    outputs: trace.outputs.length,
     error: trace.error
   };
 }

--- a/scripts/openspec-execution-context.mjs
+++ b/scripts/openspec-execution-context.mjs
@@ -16,6 +16,7 @@ import {
 
 const MODE = 'openspec-native';
 const GENERATED_DIR = path.join('.ai-factory', 'rules', 'generated');
+const TRACE_FILE_PREFIX = 'openspec-rules-trace-';
 const INSTRUCTIONS_ARTIFACT = 'apply';
 const REQUIRED_CHANGE_ARTIFACTS = ['proposal.md', 'design.md', 'tasks.md'];
 
@@ -182,38 +183,50 @@ export async function collectGeneratedRules(changeId, options = {}) {
   const resolvedChangeId = normalized.changeId;
   const generatedDir = path.join(rootDir, GENERATED_DIR);
   const fingerprints = await collectCurrentSpecFingerprints(rootDir, resolvedChangeId);
+  const trace = await readGeneratedRulesTrace(rootDir, generatedDir, resolvedChangeId);
   const expected = [
     {
       kind: 'merged',
       fileName: `openspec-merged-${resolvedChangeId}.md`,
-      expectedFingerprints: new Map([...fingerprints.base, ...fingerprints.delta])
+      expectedFingerprints: new Map([...fingerprints.base, ...fingerprints.delta]),
+      traceInputKinds: ['base-spec', 'delta-spec']
     },
     {
       kind: 'change',
       fileName: `openspec-change-${resolvedChangeId}.md`,
-      expectedFingerprints: fingerprints.delta
+      expectedFingerprints: fingerprints.delta,
+      traceInputKinds: ['delta-spec']
     },
     {
       kind: 'base',
       fileName: 'openspec-base.md',
-      expectedFingerprints: fingerprints.base
+      expectedFingerprints: fingerprints.base,
+      traceInputKinds: ['base-spec']
     }
   ];
   const generatedRules = [];
   const warnings = [];
+  let generatedMarkdownExists = false;
 
   for (const expectedFile of expected) {
     const filePath = path.join(generatedDir, expectedFile.fileName);
     const item = await readOptionalTextFile(rootDir, filePath);
-    const stale = item.exists
+    generatedMarkdownExists ||= item.exists;
+    const traceStale = item.exists && trace.exists && trace.valid
+      ? determineTraceStaleness(trace.inputs, expectedFile.expectedFingerprints, expectedFile.traceInputKinds)
+      : null;
+    const markdownStale = item.exists && !(trace.exists && trace.valid)
       ? determineStaleness(item.content, expectedFile.expectedFingerprints)
       : null;
+    const stale = trace.exists && trace.valid ? traceStale : markdownStale;
 
     generatedRules.push({
       kind: expectedFile.kind,
       path: item.path,
       exists: item.exists,
       stale,
+      staleSource: trace.exists && trace.valid ? 'trace' : 'markdown',
+      trace: summarizeGeneratedRulesTrace(trace, traceStale),
       content: item.content
     });
 
@@ -233,6 +246,21 @@ export async function collectGeneratedRules(changeId, options = {}) {
         path: item.path
       });
     }
+  }
+
+  if (generatedMarkdownExists && !trace.exists) {
+    warnings.push({
+      code: 'missing-generated-rules-trace',
+      message: `Generated OpenSpec rules trace is missing: ${trace.path}`,
+      path: trace.path
+    });
+  } else if (generatedMarkdownExists && trace.exists && !trace.valid) {
+    warnings.push({
+      code: 'invalid-generated-rules-trace',
+      message: `Generated OpenSpec rules trace is invalid: ${trace.path}`,
+      path: trace.path,
+      detail: trace.error
+    });
   }
 
   return {
@@ -602,6 +630,130 @@ function determineStaleness(content, expectedFingerprints) {
   }
 
   return false;
+}
+
+async function readGeneratedRulesTrace(rootDir, generatedDir, changeId) {
+  const filePath = path.join(generatedDir, `${TRACE_FILE_PREFIX}${changeId}.json`);
+  const item = await readOptionalTextFile(rootDir, filePath);
+
+  if (!item.exists) {
+    return {
+      path: item.path,
+      exists: false,
+      valid: false,
+      stale: null,
+      inputs: [],
+      content: '',
+      error: null
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(item.content);
+    const rawInputs = parsed?.inputs;
+    const inputs = Array.isArray(rawInputs)
+      ? rawInputs.map(normalizeTraceInput).filter(Boolean)
+      : [];
+
+    if (parsed?.schema_version !== 1 || !Array.isArray(rawInputs) || inputs.length !== rawInputs.length) {
+      return {
+        path: item.path,
+        exists: true,
+        valid: false,
+        stale: null,
+        inputs: [],
+        content: item.content,
+        error: 'Trace JSON must have schema_version 1 and valid inputs.'
+      };
+    }
+
+    return {
+      path: item.path,
+      exists: true,
+      valid: true,
+      stale: null,
+      inputs,
+      content: item.content,
+      error: null
+    };
+  } catch (err) {
+    return {
+      path: item.path,
+      exists: true,
+      valid: false,
+      stale: null,
+      inputs: [],
+      content: item.content,
+      error: err?.message ?? 'Invalid JSON.'
+    };
+  }
+}
+
+function normalizeTraceInput(input) {
+  if (
+    input === null
+    || typeof input !== 'object'
+    || typeof input.path !== 'string'
+    || typeof input.sha256 !== 'string'
+    || typeof input.kind !== 'string'
+  ) {
+    return null;
+  }
+
+  const sha256 = input.sha256.startsWith('sha256:')
+    ? input.sha256
+    : `sha256:${input.sha256}`;
+
+  return {
+    path: toPosix(input.path),
+    sha256,
+    kind: input.kind
+  };
+}
+
+function determineTraceStaleness(inputs, expectedFingerprints, traceInputKinds) {
+  const allowedKinds = new Set(traceInputKinds);
+  const actualFingerprints = new Map(
+    inputs
+      .filter((input) => allowedKinds.has(input.kind))
+      .map((input) => [input.path, input.sha256])
+  );
+
+  if (actualFingerprints.size === 0 && expectedFingerprints.size === 0) {
+    return false;
+  }
+
+  if (actualFingerprints.size === 0) {
+    return true;
+  }
+
+  if (actualFingerprints.size !== expectedFingerprints.size) {
+    return true;
+  }
+
+  for (const [relativePath, fingerprint] of expectedFingerprints) {
+    if (actualFingerprints.get(relativePath) !== fingerprint) {
+      return true;
+    }
+  }
+
+  for (const relativePath of actualFingerprints.keys()) {
+    if (!expectedFingerprints.has(relativePath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function summarizeGeneratedRulesTrace(trace, stale) {
+  return {
+    path: trace.path,
+    exists: trace.exists,
+    valid: trace.valid,
+    stale,
+    error: trace.error
+  };
 }
 
 function parseSourceFingerprints(content) {

--- a/scripts/openspec-execution-context.test.mjs
+++ b/scripts/openspec-execution-context.test.mjs
@@ -67,7 +67,7 @@ async function createGeneratedRules(rootDir, changeId = 'add-oauth', options = {
 async function createGeneratedRulesTrace(rootDir, changeId = 'add-oauth', options = {}) {
   const baseFingerprint = options.baseFingerprint ?? fingerprint(baseAuthSpec);
   const changeFingerprint = options.changeFingerprint ?? fingerprint(deltaAuthSpec);
-  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-rules-trace-${changeId}.json`, `${JSON.stringify({
+  const trace = {
     schema_version: 1,
     validator: 'aifhub-generated-rules-trace',
     change_id: changeId,
@@ -85,7 +85,32 @@ async function createGeneratedRulesTrace(rootDir, changeId = 'add-oauth', option
       }
     ],
     rules: []
-  }, null, 2)}\n`);
+  };
+
+  if (options.includeOutputs) {
+    const baseRules = await readFile(path.join(rootDir, '.ai-factory', 'rules', 'generated', 'openspec-base.md'), 'utf8');
+    const changeRules = await readFile(path.join(rootDir, '.ai-factory', 'rules', 'generated', `openspec-change-${changeId}.md`), 'utf8');
+    const mergedRules = await readFile(path.join(rootDir, '.ai-factory', 'rules', 'generated', `openspec-merged-${changeId}.md`), 'utf8');
+    trace.outputs = [
+      {
+        path: '.ai-factory/rules/generated/openspec-base.md',
+        sha256: fingerprint(baseRules),
+        kind: 'base-rules'
+      },
+      {
+        path: `.ai-factory/rules/generated/openspec-change-${changeId}.md`,
+        sha256: fingerprint(changeRules),
+        kind: 'change-rules'
+      },
+      {
+        path: `.ai-factory/rules/generated/openspec-merged-${changeId}.md`,
+        sha256: fingerprint(mergedRules),
+        kind: 'merged-rules'
+      }
+    ];
+  }
+
+  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-rules-trace-${changeId}.json`, `${JSON.stringify(trace, null, 2)}\n`);
 }
 
 async function pathExists(targetPath) {
@@ -300,6 +325,36 @@ describe('OpenSpec execution context API', () => {
     assert.equal(result.generatedRules.every((item) => item.staleSource === 'trace'), true);
     assert.equal(result.generatedRules.every((item) => item.trace.exists && item.trace.valid), true);
     assert.equal(result.warnings.some((warning) => warning.code === 'stale-generated-rules'), false);
+  });
+
+  it('detects generated markdown output drift when trace output hashes are present', async () => {
+    const { collectGeneratedRules } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await createGeneratedRules(rootDir, 'add-oauth', {
+      baseFingerprint: fingerprint(baseAuthSpec),
+      changeFingerprint: fingerprint(deltaAuthSpec)
+    });
+    await createGeneratedRulesTrace(rootDir, 'add-oauth', { includeOutputs: true });
+    await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-merged-add-oauth.md', [
+      generatedRulesContent({
+        title: 'Merged OpenSpec Rules',
+        fingerprints: [
+          `${fingerprint(baseAuthSpec)} openspec/specs/auth/spec.md`,
+          `${fingerprint(deltaAuthSpec)} openspec/changes/add-oauth/specs/auth/spec.md`
+        ]
+      }),
+      'Manual edit that should be detected.'
+    ].join('\n'));
+
+    const result = await collectGeneratedRules('add-oauth', { rootDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'base').stale, false);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'change').stale, false);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'merged').stale, true);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'merged').staleSource, 'trace-output');
+    assert.ok(result.warnings.some((warning) => warning.code === 'stale-generated-rules'));
   });
 
   it('warns when trace is missing while preserving markdown fingerprint fallback', async () => {

--- a/scripts/openspec-execution-context.test.mjs
+++ b/scripts/openspec-execution-context.test.mjs
@@ -1,6 +1,7 @@
 // openspec-execution-context.test.mjs - tests for OpenSpec implement/fix runtime context
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -63,6 +64,30 @@ async function createGeneratedRules(rootDir, changeId = 'add-oauth', options = {
   }));
 }
 
+async function createGeneratedRulesTrace(rootDir, changeId = 'add-oauth', options = {}) {
+  const baseFingerprint = options.baseFingerprint ?? fingerprint(baseAuthSpec);
+  const changeFingerprint = options.changeFingerprint ?? fingerprint(deltaAuthSpec);
+  await writeFixture(rootDir, `.ai-factory/rules/generated/openspec-rules-trace-${changeId}.json`, `${JSON.stringify({
+    schema_version: 1,
+    validator: 'aifhub-generated-rules-trace',
+    change_id: changeId,
+    generated_at: '2026-05-09T00:00:00.000Z',
+    inputs: [
+      {
+        path: 'openspec/specs/auth/spec.md',
+        sha256: baseFingerprint,
+        kind: 'base-spec'
+      },
+      {
+        path: `openspec/changes/${changeId}/specs/auth/spec.md`,
+        sha256: changeFingerprint,
+        kind: 'delta-spec'
+      }
+    ],
+    rules: []
+  }, null, 2)}\n`);
+}
+
 async function pathExists(targetPath) {
   try {
     await access(targetPath);
@@ -109,6 +134,10 @@ function generatedRulesContent({ title, fingerprints }) {
     ...fingerprints.map((fingerprint) => `- ${fingerprint}`),
     ''
   ].join('\n');
+}
+
+function fingerprint(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
 }
 
 const baseAuthSpec = `# Auth
@@ -252,6 +281,86 @@ describe('OpenSpec execution context API', () => {
     ]);
     assert.deepEqual(result.openspecInstructions.json, { steps: ['apply change'] });
     assert.equal(result.openspecInstructions.available, true);
+  });
+
+  it('prefers trace input hashes over markdown fingerprints for generated-rule freshness', async () => {
+    const { collectGeneratedRules } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await createGeneratedRules(rootDir, 'add-oauth', {
+      baseFingerprint: 'sha256:stale-markdown-base',
+      changeFingerprint: 'sha256:stale-markdown-change'
+    });
+    await createGeneratedRulesTrace(rootDir, 'add-oauth');
+
+    const result = await collectGeneratedRules('add-oauth', { rootDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.generatedRules.every((item) => item.stale === false), true);
+    assert.equal(result.generatedRules.every((item) => item.staleSource === 'trace'), true);
+    assert.equal(result.generatedRules.every((item) => item.trace.exists && item.trace.valid), true);
+    assert.equal(result.warnings.some((warning) => warning.code === 'stale-generated-rules'), false);
+  });
+
+  it('warns when trace is missing while preserving markdown fingerprint fallback', async () => {
+    const { collectGeneratedRules } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await createGeneratedRules(rootDir, 'add-oauth', {
+      baseFingerprint: fingerprint(baseAuthSpec),
+      changeFingerprint: fingerprint(deltaAuthSpec)
+    });
+
+    const result = await collectGeneratedRules('add-oauth', { rootDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.generatedRules.every((item) => item.stale === false), true);
+    assert.equal(result.generatedRules.every((item) => item.staleSource === 'markdown'), true);
+    assert.ok(result.warnings.some((warning) => warning.code === 'missing-generated-rules-trace'));
+    assert.equal(result.warnings.some((warning) => warning.code === 'stale-generated-rules'), false);
+  });
+
+  it('detects stale generated rules from trace input hash drift', async () => {
+    const { collectGeneratedRules } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await createGeneratedRules(rootDir, 'add-oauth', {
+      baseFingerprint: fingerprint(baseAuthSpec),
+      changeFingerprint: fingerprint(deltaAuthSpec)
+    });
+    await createGeneratedRulesTrace(rootDir, 'add-oauth', {
+      baseFingerprint: 'sha256:old-base',
+      changeFingerprint: fingerprint(deltaAuthSpec)
+    });
+
+    const result = await collectGeneratedRules('add-oauth', { rootDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'base').stale, true);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'change').stale, false);
+    assert.equal(result.generatedRules.find((item) => item.kind === 'merged').stale, true);
+    assert.ok(result.warnings.some((warning) => warning.code === 'stale-generated-rules'));
+  });
+
+  it('warns on invalid trace JSON and falls back to markdown fingerprints', async () => {
+    const { collectGeneratedRules } = await loadExecutionContext();
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'add-oauth');
+    await createGeneratedRules(rootDir, 'add-oauth', {
+      baseFingerprint: fingerprint(baseAuthSpec),
+      changeFingerprint: fingerprint(deltaAuthSpec)
+    });
+    await writeFixture(rootDir, '.ai-factory/rules/generated/openspec-rules-trace-add-oauth.json', JSON.stringify({
+      schema_version: 1,
+      change_id: 'add-oauth'
+    }, null, 2));
+
+    const result = await collectGeneratedRules('add-oauth', { rootDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.generatedRules.every((item) => item.stale === false), true);
+    assert.equal(result.generatedRules.every((item) => item.staleSource === 'markdown'), true);
+    assert.ok(result.warnings.some((warning) => warning.code === 'invalid-generated-rules-trace'));
   });
 
   it('skips OpenSpec apply instructions when useInstructionsApply is false', async () => {

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -310,6 +310,10 @@ describe('OpenSpec-native prompt asset contract', () => {
       assert.notEqual(mergedIndex, -1, `${relativePath} missing merged generated rules priority`);
       assert.notEqual(changeIndex, -1, `${relativePath} missing change generated rules priority`);
       assert.notEqual(generatedBaseIndex, -1, `${relativePath} missing base generated rules priority`);
+      assertIncludes(openspec, '.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json', `${relativePath} OpenSpec-native mode`);
+      assertIncludes(openspec, '.ai-factory/rules/generated/index.json', `${relativePath} OpenSpec-native mode`);
+      assertIncludes(openspec, 'source.path', `${relativePath} OpenSpec-native mode`);
+      assertIncludes(openspec, 'source.requirement', `${relativePath} OpenSpec-native mode`);
       assert.ok(mergedIndex < changeIndex, `${relativePath} merged generated rules should be highest priority`);
       assert.ok(changeIndex < generatedBaseIndex, `${relativePath} change generated rules should precede base generated rules`);
       assert.ok(generatedBaseIndex < projectRulesIndex, `${relativePath} generated rules should precede project rules`);

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -9,6 +9,8 @@ import { normalizeChangeId, resolveActiveChange } from './active-change-resolver
 
 const GENERATED_DIR = path.join('.ai-factory', 'rules', 'generated');
 const BASE_FILE = 'openspec-base.md';
+const INDEX_FILE = 'index.json';
+const TRACE_FILE_PREFIX = 'openspec-rules-trace-';
 const SECTION_ORDER = new Map([
   ['Requirements', 0],
   ['ADDED Requirements', 1],
@@ -178,7 +180,9 @@ export async function compileOpenSpecBaseRules(options = {}) {
   });
   const written = await writeGeneratedBaseRules(rendered, {
     ...options,
-    rootDir
+    rootDir,
+    generatedAt: resolveGeneratedAt(options),
+    indexBase: renderIndexBaseEntry(sortSources(collected.sources))
   });
 
   if (!written.ok) {
@@ -237,6 +241,7 @@ async function collectOpenSpecBaseRuleSources(options = {}) {
 export function renderGeneratedRules(sources, options = {}) {
   const normalized = normalizeChangeId(options.changeId);
   const changeId = normalized.ok ? normalized.changeId : options.changeId;
+  const generatedAt = resolveGeneratedAt(options);
   const sortedSources = sortSources(Array.from(sources ?? []));
   const baseSources = sortedSources.filter((source) => source.kind === 'base');
   const changeSources = sortedSources.filter((source) => source.kind === 'change');
@@ -261,11 +266,19 @@ export function renderGeneratedRules(sources, options = {}) {
     sources: sortedSources,
     emptyMessage: 'No OpenSpec requirements found.'
   });
+  const traceFileName = `${TRACE_FILE_PREFIX}${changeId}.json`;
+  const traceContent = renderTraceDocument(sortedSources, {
+    changeId,
+    generatedAt
+  });
 
   return {
     ok: true,
     changeId,
+    generatedAt,
     warnings: [],
+    indexBase: renderIndexBaseEntry(baseSources),
+    indexEntry: renderIndexChangeEntry(changeId, traceFileName, generatedAt),
     files: [
       {
         kind: 'base',
@@ -281,6 +294,11 @@ export function renderGeneratedRules(sources, options = {}) {
         kind: 'merged',
         fileName: `openspec-merged-${changeId}.md`,
         content: mergedContent
+      },
+      {
+        kind: 'trace',
+        fileName: traceFileName,
+        content: traceContent
       }
     ]
   };
@@ -302,7 +320,8 @@ export async function writeGeneratedRules(changeId, rendered, options = {}) {
   const expectedNames = new Set([
     BASE_FILE,
     `openspec-change-${normalized.changeId}.md`,
-    `openspec-merged-${normalized.changeId}.md`
+    `openspec-merged-${normalized.changeId}.md`,
+    `${TRACE_FILE_PREFIX}${normalized.changeId}.json`
   ]);
   const renderedNames = renderedFiles.map((file) => file.fileName);
   const renderedNameSet = new Set(renderedNames);
@@ -318,13 +337,15 @@ export async function writeGeneratedRules(changeId, rendered, options = {}) {
       errors: [
         {
           code: 'invalid-rendered-files',
-          message: 'Rendered rules must contain exactly the base, change, and merged generated files.'
+          message: 'Rendered rules must contain exactly the base, change, merged, and trace generated files.'
         }
       ]
     });
   }
 
-  await mkdir(generatedDir, { recursive: true });
+  if (!options.dryRun) {
+    await mkdir(generatedDir, { recursive: true });
+  }
 
   for (const renderedFile of renderedFiles) {
     const targetPath = path.resolve(generatedDir, renderedFile.fileName);
@@ -342,18 +363,36 @@ export async function writeGeneratedRules(changeId, rendered, options = {}) {
       });
     }
 
-    await writeFile(targetPath, renderedFile.content, 'utf8');
-    files.push({
+    if (!options.dryRun) {
+      await writeFile(targetPath, renderedFile.content, 'utf8');
+    }
+    files.push(createGeneratedFileResult({
       kind: renderedFile.kind,
-      path: targetPath,
-      relativePath: toPosix(path.relative(rootDir, targetPath)),
-      written: true
-    });
+      rootDir,
+      targetPath,
+      written: !options.dryRun
+    }));
   }
+
+  const index = await writeGeneratedIndex({
+    rootDir,
+    generatedDir,
+    generatedAt: rendered?.generatedAt ?? resolveGeneratedAt(options),
+    base: rendered?.indexBase ?? renderIndexBaseEntry([]),
+    changeEntry: rendered?.indexEntry ?? renderIndexChangeEntry(
+      normalized.changeId,
+      `${TRACE_FILE_PREFIX}${normalized.changeId}.json`,
+      rendered?.generatedAt ?? resolveGeneratedAt(options)
+    ),
+    dryRun: Boolean(options.dryRun),
+    resetChanges: false
+  });
+  files.push(...index.files);
 
   return createWriteResult({
     ok: true,
-    files
+    files,
+    warnings: index.warnings
   });
 }
 
@@ -361,7 +400,6 @@ async function writeGeneratedBaseRules(content, options = {}) {
   const rootDir = path.resolve(options.rootDir ?? process.cwd());
   const generatedDir = path.resolve(rootDir, GENERATED_DIR);
   const targetPath = path.resolve(generatedDir, BASE_FILE);
-  const relativePath = toPosix(path.relative(rootDir, targetPath));
 
   if (!isWithinDirectory(targetPath, generatedDir)) {
     return createWriteResult({
@@ -378,30 +416,266 @@ async function writeGeneratedBaseRules(content, options = {}) {
     return createWriteResult({
       ok: true,
       files: [
-        {
+        createGeneratedFileResult({
           kind: 'base',
-          path: targetPath,
-          relativePath,
+          rootDir,
+          targetPath,
           written: false
-        }
+        }),
+        createGeneratedFileResult({
+          kind: 'index',
+          rootDir,
+          targetPath: path.resolve(generatedDir, INDEX_FILE),
+          written: false
+        })
       ]
     });
   }
 
   await mkdir(generatedDir, { recursive: true });
   await writeFile(targetPath, content, 'utf8');
+  const index = await writeGeneratedIndex({
+    rootDir,
+    generatedDir,
+    generatedAt: options.generatedAt ?? resolveGeneratedAt(options),
+    base: options.indexBase ?? renderIndexBaseEntry([]),
+    dryRun: false,
+    resetChanges: true
+  });
 
   return createWriteResult({
     ok: true,
     files: [
-      {
+      createGeneratedFileResult({
         kind: 'base',
-        path: targetPath,
-        relativePath,
+        rootDir,
+        targetPath,
         written: true
-      }
-    ]
+      }),
+      ...index.files
+    ],
+    warnings: index.warnings
   });
+}
+
+async function writeGeneratedIndex({
+  rootDir,
+  generatedDir,
+  generatedAt,
+  base,
+  changeEntry = null,
+  dryRun = false,
+  resetChanges = false
+}) {
+  const targetPath = path.resolve(generatedDir, INDEX_FILE);
+
+  if (!isWithinDirectory(targetPath, generatedDir)) {
+    return createWriteResult({
+      errors: [
+        {
+          code: 'unsafe-generated-path',
+          message: `Generated output path escapes '${GENERATED_DIR}': ${INDEX_FILE}`
+        }
+      ]
+    });
+  }
+
+  const files = [
+    createGeneratedFileResult({
+      kind: 'index',
+      rootDir,
+      targetPath,
+      written: !dryRun
+    })
+  ];
+
+  if (dryRun) {
+    return createWriteResult({
+      ok: true,
+      files
+    });
+  }
+
+  const existing = resetChanges ? createEmptyGeneratedIndex(generatedAt) : await readGeneratedIndex(targetPath, generatedAt);
+  const changes = resetChanges
+    ? []
+    : Array.from(existing.changes ?? []).filter((entry) => entry?.change_id !== changeEntry?.change_id);
+
+  if (changeEntry !== null) {
+    changes.push(changeEntry);
+  }
+
+  const index = {
+    schema_version: 1,
+    generated_at: generatedAt,
+    base,
+    changes: changes
+      .filter((entry) => typeof entry?.change_id === 'string' && entry.change_id.length > 0)
+      .sort((left, right) => left.change_id.localeCompare(right.change_id))
+  };
+
+  await writeFile(targetPath, `${JSON.stringify(index, null, 2)}\n`, 'utf8');
+
+  return createWriteResult({
+    ok: true,
+    files
+  });
+}
+
+async function readGeneratedIndex(targetPath, generatedAt) {
+  try {
+    const parsed = JSON.parse(await readFile(targetPath, 'utf8'));
+
+    if (parsed?.schema_version !== 1 || !Array.isArray(parsed.changes)) {
+      return createEmptyGeneratedIndex(generatedAt);
+    }
+
+    return {
+      schema_version: 1,
+      generated_at: parsed.generated_at ?? generatedAt,
+      base: parsed.base ?? null,
+      changes: parsed.changes
+    };
+  } catch {
+    return createEmptyGeneratedIndex(generatedAt);
+  }
+}
+
+function createEmptyGeneratedIndex(generatedAt) {
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    base: null,
+    changes: []
+  };
+}
+
+function createGeneratedFileResult({ kind, rootDir, targetPath, written }) {
+  return {
+    kind,
+    path: targetPath,
+    relativePath: toPosix(path.relative(rootDir, targetPath)),
+    written
+  };
+}
+
+function renderTraceDocument(sources, { changeId, generatedAt }) {
+  const inputs = renderTraceInputs(sources);
+  const rules = renderTraceRules(sources);
+
+  return `${JSON.stringify({
+    schema_version: 1,
+    validator: 'aifhub-generated-rules-trace',
+    change_id: changeId,
+    generated_at: generatedAt,
+    inputs,
+    rules
+  }, null, 2)}\n`;
+}
+
+function renderTraceInputs(sources) {
+  return sortSources(sources).map((source) => ({
+    path: source.relativePath,
+    sha256: source.fingerprint,
+    kind: source.kind === 'base' ? 'base-spec' : 'delta-spec'
+  }));
+}
+
+function renderTraceRules(sources) {
+  return flattenRequirements(sources).map((requirement) => ({
+    id: createTraceRuleId(requirement),
+    severity: inferRuleSeverity(requirement),
+    source: {
+      path: requirement.relativePath,
+      requirement: requirement.title
+    },
+    rule_text: createRuleText(requirement)
+  }));
+}
+
+function renderIndexBaseEntry(baseSources) {
+  return {
+    markdown: `${GENERATED_DIR.replaceAll(path.sep, '/')}/${BASE_FILE}`,
+    inputs: renderTraceInputs(baseSources)
+  };
+}
+
+function renderIndexChangeEntry(changeId, traceFileName, generatedAt) {
+  return {
+    change_id: changeId,
+    generated_at: generatedAt,
+    trace: `${GENERATED_DIR.replaceAll(path.sep, '/')}/${traceFileName}`,
+    markdown: {
+      base: `${GENERATED_DIR.replaceAll(path.sep, '/')}/${BASE_FILE}`,
+      change: `${GENERATED_DIR.replaceAll(path.sep, '/')}/openspec-change-${changeId}.md`,
+      merged: `${GENERATED_DIR.replaceAll(path.sep, '/')}/openspec-merged-${changeId}.md`
+    }
+  };
+}
+
+function createTraceRuleId(requirement) {
+  const prefix = requirement.kind === 'base' ? 'base' : 'delta';
+  const capability = slugify(requirement.capability || 'root');
+  const title = slugify(requirement.title || 'requirement');
+  const hash = createHash('sha256')
+    .update([
+      requirement.kind,
+      requirement.relativePath,
+      requirement.section,
+      requirement.title,
+      ...requirement.body,
+      ...requirement.scenarios.flatMap((scenario) => [scenario.title, ...scenario.steps])
+    ].join('\n'))
+    .digest('hex')
+    .slice(0, 8);
+  const stable = `${prefix}-${capability}-${title}`.replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+  return `${stable.slice(0, 80).replace(/-$/g, '')}-${hash}`;
+}
+
+function inferRuleSeverity(requirement) {
+  const text = [
+    requirement.title,
+    ...requirement.body,
+    ...requirement.scenarios.flatMap((scenario) => [scenario.title, ...scenario.steps])
+  ].join('\n').toUpperCase();
+
+  if (/\b(MUST|MUST NOT|SHALL|REQUIRED)\b/.test(text)) {
+    return 'must';
+  }
+
+  if (/\b(SHOULD|RECOMMENDED)\b/.test(text)) {
+    return 'should';
+  }
+
+  if (/\b(MAY|OPTIONAL)\b/.test(text)) {
+    return 'may';
+  }
+
+  return 'should';
+}
+
+function createRuleText(requirement) {
+  const body = requirement.body.join(' ').trim();
+
+  if (body.length > 0) {
+    return body;
+  }
+
+  const scenarioSteps = requirement.scenarios.flatMap((scenario) => scenario.steps).join(' ').trim();
+
+  if (scenarioSteps.length > 0) {
+    return scenarioSteps;
+  }
+
+  return `Requirement "${requirement.title}" from ${requirement.relativePath}.`;
+}
+
+function slugify(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'item';
 }
 
 export function parseSpecMarkdownFallback(markdown, options = {}) {
@@ -1043,6 +1317,17 @@ function normalizeDetectionWarnings(detection) {
       message: 'OpenSpec CLI is unavailable or unsupported; using filesystem fallback.'
     }
   ];
+}
+
+function resolveGeneratedAt(options = {}) {
+  if (typeof options.generatedAt === 'string' && options.generatedAt.trim().length > 0) {
+    return options.generatedAt;
+  }
+
+  const value = options.now ?? Date.now();
+  const date = value instanceof Date ? value : new Date(value);
+
+  return date.toISOString();
 }
 
 function createCompilerResult(overrides = {}) {

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -267,9 +267,27 @@ export function renderGeneratedRules(sources, options = {}) {
     emptyMessage: 'No OpenSpec requirements found.'
   });
   const traceFileName = `${TRACE_FILE_PREFIX}${changeId}.json`;
+  const markdownFiles = [
+    {
+      kind: 'base',
+      fileName: BASE_FILE,
+      content: baseContent
+    },
+    {
+      kind: 'change',
+      fileName: `openspec-change-${changeId}.md`,
+      content: changeContent
+    },
+    {
+      kind: 'merged',
+      fileName: `openspec-merged-${changeId}.md`,
+      content: mergedContent
+    }
+  ];
   const traceContent = renderTraceDocument(sortedSources, {
     changeId,
-    generatedAt
+    generatedAt,
+    outputs: renderTraceOutputs(markdownFiles)
   });
 
   return {
@@ -280,21 +298,7 @@ export function renderGeneratedRules(sources, options = {}) {
     indexBase: renderIndexBaseEntry(baseSources),
     indexEntry: renderIndexChangeEntry(changeId, traceFileName, generatedAt),
     files: [
-      {
-        kind: 'base',
-        fileName: BASE_FILE,
-        content: baseContent
-      },
-      {
-        kind: 'change',
-        fileName: `openspec-change-${changeId}.md`,
-        content: changeContent
-      },
-      {
-        kind: 'merged',
-        fileName: `openspec-merged-${changeId}.md`,
-        content: mergedContent
-      },
+      ...markdownFiles,
       {
         kind: 'trace',
         fileName: traceFileName,
@@ -440,7 +444,7 @@ async function writeGeneratedBaseRules(content, options = {}) {
     generatedAt: options.generatedAt ?? resolveGeneratedAt(options),
     base: options.indexBase ?? renderIndexBaseEntry([]),
     dryRun: false,
-    resetChanges: true
+    resetChanges: Boolean(options.resetIndexChanges)
   });
 
   return createWriteResult({
@@ -559,7 +563,7 @@ function createGeneratedFileResult({ kind, rootDir, targetPath, written }) {
   };
 }
 
-function renderTraceDocument(sources, { changeId, generatedAt }) {
+function renderTraceDocument(sources, { changeId, generatedAt, outputs = [] }) {
   const inputs = renderTraceInputs(sources);
   const rules = renderTraceRules(sources);
 
@@ -569,6 +573,7 @@ function renderTraceDocument(sources, { changeId, generatedAt }) {
     change_id: changeId,
     generated_at: generatedAt,
     inputs,
+    outputs,
     rules
   }, null, 2)}\n`;
 }
@@ -591,6 +596,18 @@ function renderTraceRules(sources) {
     },
     rule_text: createRuleText(requirement)
   }));
+}
+
+function renderTraceOutputs(files) {
+  return files.map((file) => ({
+    path: `${GENERATED_DIR.replaceAll(path.sep, '/')}/${file.fileName}`,
+    sha256: createFingerprint(file.content),
+    kind: `${file.kind}-rules`
+  }));
+}
+
+function createFingerprint(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
 }
 
 function renderIndexBaseEntry(baseSources) {

--- a/scripts/openspec-rules-compiler.test.mjs
+++ b/scripts/openspec-rules-compiler.test.mjs
@@ -1,6 +1,7 @@
 // openspec-rules-compiler.test.mjs - tests for OpenSpec generated rules compiler
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -47,6 +48,10 @@ async function readGenerated(rootDir, fileName) {
 
 async function readGeneratedJson(rootDir, fileName) {
   return JSON.parse(await readGenerated(rootDir, fileName));
+}
+
+function fingerprint(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
 }
 
 function missingCliDetection() {
@@ -186,6 +191,10 @@ describe('compileOpenSpecRules filesystem fallback', () => {
         kind: 'base-spec'
       }
     ]);
+    assert.deepEqual(trace.outputs.map((output) => output.kind), ['base-rules', 'change-rules', 'merged-rules']);
+    assert.equal(trace.outputs.find((output) => output.kind === 'base-rules').sha256, fingerprint(baseRules));
+    assert.equal(trace.outputs.find((output) => output.kind === 'change-rules').sha256, fingerprint(changeRules));
+    assert.equal(trace.outputs.find((output) => output.kind === 'merged-rules').sha256, fingerprint(mergedRules));
     assert.equal(trace.rules.length, 1);
     assert.match(trace.rules[0].id, /^base-billing-track-usage-[a-f0-9]{8}$/);
     assert.equal(trace.rules[0].severity, 'must');
@@ -223,6 +232,39 @@ describe('compileOpenSpecRules filesystem fallback', () => {
     assert.equal(index.base.markdown, '.ai-factory/rules/generated/openspec-base.md');
     assert.deepEqual(index.changes, []);
     assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'rules', 'generated', 'openspec-rules-trace-add-generated-rules.json')), false);
+  });
+
+  it('preserves change trace index entries during direct base-only refresh by default', async () => {
+    const { compileOpenSpecBaseRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, 'openspec/specs/billing/spec.md', baseBillingSpec);
+    await writeFixture(rootDir, '.ai-factory/rules/generated/index.json', `${JSON.stringify({
+      schema_version: 1,
+      generated_at: '2026-05-09T00:00:00.000Z',
+      base: null,
+      changes: [
+        {
+          change_id: 'add-existing',
+          generated_at: '2026-05-09T00:00:00.000Z',
+          trace: '.ai-factory/rules/generated/openspec-rules-trace-add-existing.json',
+          markdown: {
+            base: '.ai-factory/rules/generated/openspec-base.md',
+            change: '.ai-factory/rules/generated/openspec-change-add-existing.md',
+            merged: '.ai-factory/rules/generated/openspec-merged-add-existing.md'
+          }
+        }
+      ]
+    }, null, 2)}\n`);
+
+    const result = await compileOpenSpecBaseRules(compilerOptions(rootDir, {
+      now: new Date('2026-05-09T02:00:00.000Z')
+    }));
+
+    assert.equal(result.ok, true);
+    const index = await readGeneratedJson(rootDir, 'index.json');
+    assert.equal(index.generated_at, '2026-05-09T02:00:00.000Z');
+    assert.equal(index.base.markdown, '.ai-factory/rules/generated/openspec-base.md');
+    assert.deepEqual(index.changes.map((entry) => entry.change_id), ['add-existing']);
   });
 
   it('compiles delta specs only and includes change metadata in change and merged output', async () => {

--- a/scripts/openspec-rules-compiler.test.mjs
+++ b/scripts/openspec-rules-compiler.test.mjs
@@ -45,6 +45,10 @@ async function readGenerated(rootDir, fileName) {
   return readFile(path.join(rootDir, '.ai-factory', 'rules', 'generated', fileName), 'utf8');
 }
 
+async function readGeneratedJson(rootDir, fileName) {
+  return JSON.parse(await readGenerated(rootDir, fileName));
+}
+
 function missingCliDetection() {
   return {
     available: false,
@@ -118,6 +122,7 @@ describe('OpenSpec rules compiler API', () => {
     const {
       collectOpenSpecRuleSources,
       compileOpenSpecRules,
+      compileOpenSpecBaseRules,
       extractRequirementsFromShowJson,
       parseSpecMarkdownFallback,
       renderGeneratedRules,
@@ -125,6 +130,7 @@ describe('OpenSpec rules compiler API', () => {
     } = await loadCompiler();
 
     assert.equal(typeof compileOpenSpecRules, 'function');
+    assert.equal(typeof compileOpenSpecBaseRules, 'function');
     assert.equal(typeof collectOpenSpecRuleSources, 'function');
     assert.equal(typeof renderGeneratedRules, 'function');
     assert.equal(typeof writeGeneratedRules, 'function');
@@ -140,13 +146,16 @@ describe('compileOpenSpecRules filesystem fallback', () => {
     await createChange(rootDir, 'add-generated-rules');
     const specPath = await writeFixture(rootDir, 'openspec/specs/billing/spec.md', baseBillingSpec);
 
-    const result = await compileOpenSpecRules('add-generated-rules', compilerOptions(rootDir));
+    const result = await compileOpenSpecRules('add-generated-rules', compilerOptions(rootDir, {
+      now: new Date('2026-05-09T00:00:00.000Z')
+    }));
 
     assert.equal(result.ok, true);
     assert.equal(result.changeId, 'add-generated-rules');
     assert.equal(result.mode, 'filesystem-fallback');
     assert.deepEqual(result.errors, []);
-    assert.equal(result.files.length, 3);
+    assert.equal(result.files.length, 5);
+    assert.deepEqual(result.files.map((file) => file.kind), ['base', 'change', 'merged', 'trace', 'index']);
     assert.equal(result.files.every((file) => path.isAbsolute(file.path) && file.written), true);
     assert.equal(result.sources.some((source) => source.kind === 'base' && source.relativePath === 'openspec/specs/billing/spec.md'), true);
     assert.equal(result.warnings.some((warning) => warning.code === 'missing-cli'), true);
@@ -154,6 +163,8 @@ describe('compileOpenSpecRules filesystem fallback', () => {
     const baseRules = await readGenerated(rootDir, 'openspec-base.md');
     const changeRules = await readGenerated(rootDir, 'openspec-change-add-generated-rules.md');
     const mergedRules = await readGenerated(rootDir, 'openspec-merged-add-generated-rules.md');
+    const trace = await readGeneratedJson(rootDir, 'openspec-rules-trace-add-generated-rules.json');
+    const index = await readGeneratedJson(rootDir, 'index.json');
 
     assert.match(baseRules, /^# Generated OpenSpec Rules/m);
     assert.match(baseRules, /openspec\/specs\/billing\/spec\.md/);
@@ -164,8 +175,54 @@ describe('compileOpenSpecRules filesystem fallback', () => {
     assert.doesNotMatch(baseRules, /\d{4}-\d{2}-\d{2}T/);
     assert.match(changeRules, /No OpenSpec change requirements found/);
     assert.match(mergedRules, /Requirement: Track Usage/);
+    assert.equal(trace.schema_version, 1);
+    assert.equal(trace.validator, 'aifhub-generated-rules-trace');
+    assert.equal(trace.change_id, 'add-generated-rules');
+    assert.equal(trace.generated_at, '2026-05-09T00:00:00.000Z');
+    assert.deepEqual(trace.inputs, [
+      {
+        path: 'openspec/specs/billing/spec.md',
+        sha256: result.sources[0].fingerprint,
+        kind: 'base-spec'
+      }
+    ]);
+    assert.equal(trace.rules.length, 1);
+    assert.match(trace.rules[0].id, /^base-billing-track-usage-[a-f0-9]{8}$/);
+    assert.equal(trace.rules[0].severity, 'must');
+    assert.deepEqual(trace.rules[0].source, {
+      path: 'openspec/specs/billing/spec.md',
+      requirement: 'Track Usage'
+    });
+    assert.match(trace.rules[0].rule_text, /MUST track customer usage/);
+    assert.equal(index.schema_version, 1);
+    assert.equal(index.generated_at, '2026-05-09T00:00:00.000Z');
+    assert.deepEqual(index.base.inputs, trace.inputs);
+    assert.deepEqual(index.changes.map((entry) => entry.change_id), ['add-generated-rules']);
+    assert.equal(index.changes[0].trace, '.ai-factory/rules/generated/openspec-rules-trace-add-generated-rules.json');
+    assert.equal(index.changes[0].markdown.merged, '.ai-factory/rules/generated/openspec-merged-add-generated-rules.md');
     assert.equal(await readFile(specPath, 'utf8'), baseBillingSpec);
     assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-generated-rules', '.ai-factory')), false);
+  });
+
+  it('refreshes base-only generated rules and index without requiring a change trace', async () => {
+    const { compileOpenSpecBaseRules } = await loadCompiler();
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, 'openspec/specs/billing/spec.md', baseBillingSpec);
+
+    const result = await compileOpenSpecBaseRules(compilerOptions(rootDir, {
+      now: new Date('2026-05-09T01:00:00.000Z')
+    }));
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changeId, null);
+    assert.deepEqual(result.files.map((file) => file.kind), ['base', 'index']);
+    assert.match(await readGenerated(rootDir, 'openspec-base.md'), /Requirement: Track Usage/);
+
+    const index = await readGeneratedJson(rootDir, 'index.json');
+    assert.equal(index.generated_at, '2026-05-09T01:00:00.000Z');
+    assert.equal(index.base.markdown, '.ai-factory/rules/generated/openspec-base.md');
+    assert.deepEqual(index.changes, []);
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'rules', 'generated', 'openspec-rules-trace-add-generated-rules.json')), false);
   });
 
   it('compiles delta specs only and includes change metadata in change and merged output', async () => {

--- a/scripts/openspec-v1-integration.test.mjs
+++ b/scripts/openspec-v1-integration.test.mjs
@@ -351,23 +351,29 @@ describe('Generated rules integration', () => {
     ];
     const first = await compileOpenSpecRules('add-oauth', {
       rootDir,
+      now: new Date('2026-05-09T00:00:00.000Z'),
       detectOpenSpec: async () => missingCliDetection(),
       getCurrentBranch: async () => 'feat/add-oauth'
     });
     const outputsAfterFirst = {
       base: await readText(rootDir, '.ai-factory/rules/generated/openspec-base.md'),
       change: await readText(rootDir, '.ai-factory/rules/generated/openspec-change-add-oauth.md'),
-      merged: await readText(rootDir, '.ai-factory/rules/generated/openspec-merged-add-oauth.md')
+      merged: await readText(rootDir, '.ai-factory/rules/generated/openspec-merged-add-oauth.md'),
+      trace: await readText(rootDir, '.ai-factory/rules/generated/openspec-rules-trace-add-oauth.json'),
+      index: await readText(rootDir, '.ai-factory/rules/generated/index.json')
     };
     const second = await compileOpenSpecRules('add-oauth', {
       rootDir,
+      now: new Date('2026-05-09T00:00:00.000Z'),
       detectOpenSpec: async () => missingCliDetection(),
       getCurrentBranch: async () => 'feat/add-oauth'
     });
     const outputsAfterSecond = {
       base: await readText(rootDir, '.ai-factory/rules/generated/openspec-base.md'),
       change: await readText(rootDir, '.ai-factory/rules/generated/openspec-change-add-oauth.md'),
-      merged: await readText(rootDir, '.ai-factory/rules/generated/openspec-merged-add-oauth.md')
+      merged: await readText(rootDir, '.ai-factory/rules/generated/openspec-merged-add-oauth.md'),
+      trace: await readText(rootDir, '.ai-factory/rules/generated/openspec-rules-trace-add-oauth.json'),
+      index: await readText(rootDir, '.ai-factory/rules/generated/index.json')
     };
     const afterCanonical = [
       ...await listFiles(rootDir, 'openspec/specs'),
@@ -379,7 +385,9 @@ describe('Generated rules integration', () => {
     assert.deepEqual(first.files.map((file) => path.relative(rootDir, file.path).replaceAll('\\', '/')), [
       '.ai-factory/rules/generated/openspec-base.md',
       '.ai-factory/rules/generated/openspec-change-add-oauth.md',
-      '.ai-factory/rules/generated/openspec-merged-add-oauth.md'
+      '.ai-factory/rules/generated/openspec-merged-add-oauth.md',
+      '.ai-factory/rules/generated/openspec-rules-trace-add-oauth.json',
+      '.ai-factory/rules/generated/index.json'
     ]);
     assert.deepEqual(outputsAfterSecond, outputsAfterFirst);
     assert.deepEqual(afterCanonical, beforeCanonical);
@@ -389,6 +397,11 @@ describe('Generated rules integration', () => {
     assert.match(outputsAfterFirst.merged, /openspec\/specs\/auth\/spec\.md/);
     assert.match(outputsAfterFirst.merged, /openspec\/changes\/add-oauth\/specs\/auth\/spec\.md/);
     assert.doesNotMatch(outputsAfterFirst.merged, /\b\d{4}-\d{2}-\d{2}T\d{2}:/);
+    const trace = JSON.parse(outputsAfterFirst.trace);
+    const index = JSON.parse(outputsAfterFirst.index);
+    assert.equal(trace.generated_at, '2026-05-09T00:00:00.000Z');
+    assert.deepEqual(trace.inputs.map((input) => input.kind), ['base-spec', 'delta-spec']);
+    assert.deepEqual(index.changes.map((entry) => entry.change_id), ['add-oauth']);
   });
 });
 

--- a/scripts/validate-artifact-boundaries.test.mjs
+++ b/scripts/validate-artifact-boundaries.test.mjs
@@ -9,6 +9,8 @@ describe('findArtifactBoundaryViolations', () => {
     const violations = findArtifactBoundaryViolations([
       'openspec/specs/foo/spec.md',
       '.ai-factory/rules/generated/openspec-base.md',
+      '.ai-factory/rules/generated/index.json',
+      '.ai-factory/rules/generated/openspec-rules-trace-add-oauth.json',
       '.ai-factory/state/foo/trace.md',
       '.ai-factory/qa/foo/verify.md',
       '.ai-factory/plans/foo/task.md'
@@ -17,6 +19,8 @@ describe('findArtifactBoundaryViolations', () => {
     assert.deepEqual(violations, [
       'openspec/specs/foo/spec.md',
       '.ai-factory/rules/generated/openspec-base.md',
+      '.ai-factory/rules/generated/index.json',
+      '.ai-factory/rules/generated/openspec-rules-trace-add-oauth.json',
       '.ai-factory/state/foo/trace.md',
       '.ai-factory/qa/foo/verify.md',
       '.ai-factory/plans/foo/task.md'
@@ -27,6 +31,8 @@ describe('findArtifactBoundaryViolations', () => {
     const violations = findArtifactBoundaryViolations([
       'test/fixtures/openspec-native/openspec/specs/foo/spec.md',
       'test/fixtures/generated-rules/openspec-base.md',
+      'test/fixtures/generated-rules/index.json',
+      'scripts/fixtures/generated-rules/openspec-rules-trace-add-oauth.json',
       'scripts/fixtures/openspec/specs/foo/spec.md'
     ]);
 

--- a/skills/aif-mode/references/ARTIFACT-SYNC.md
+++ b/skills/aif-mode/references/ARTIFACT-SYNC.md
@@ -27,7 +27,7 @@ Generated rules are derived artifacts:
 .ai-factory/rules/generated/index.json
 ```
 
-They may be overwritten by sync, but canonical OpenSpec artifacts must remain unchanged. Missing or invalid generated trace metadata is warning-only for rules gates; rerun `/aif-mode sync --change <change-id>` to refresh it.
+They may be overwritten by sync, but canonical OpenSpec artifacts must remain unchanged. Trace metadata records source input hashes and generated markdown output hashes, so status/doctor can detect both stale specs and manual edits to generated rule text. Missing or invalid generated trace metadata is warning-only for rules gates; rerun `/aif-mode sync --change <change-id>` to refresh it.
 
 OpenSpec CLI use is adapter-only. Do not call OpenSpec slash commands or install OpenSpec command layers; `/aif-mode` stays the orchestration surface.
 

--- a/skills/aif-mode/references/ARTIFACT-SYNC.md
+++ b/skills/aif-mode/references/ARTIFACT-SYNC.md
@@ -11,7 +11,7 @@ OpenSpec sync performs these actions without changing mode:
 5. Detect legacy plans that may need migration.
 6. Write a sync report under `.ai-factory/state/mode-switches/`.
 
-When no active changes are selected, base-only sync still refreshes `.ai-factory/rules/generated/openspec-base.md`, skips change-specific generated rules, skips change validation with `no-selected-changes`, writes a report, and returns OK.
+When no active changes are selected, base-only sync still refreshes `.ai-factory/rules/generated/openspec-base.md` and `.ai-factory/rules/generated/index.json`, skips change-specific generated rules, skips change validation with `no-selected-changes`, writes a report, and returns OK.
 
 When `--all` selects active changes that have no `openspec/changes/<change-id>/specs/**/spec.md` delta specs, sync reports `no-delta-specs` warnings and skips validation/status for those changes. This keeps maintenance sync usable for old migrated or docs-only active changes while preserving stricter per-change verification in `/aif-verify <change-id>`.
 
@@ -23,9 +23,11 @@ Generated rules are derived artifacts:
 .ai-factory/rules/generated/openspec-base.md
 .ai-factory/rules/generated/openspec-change-<change-id>.md
 .ai-factory/rules/generated/openspec-merged-<change-id>.md
+.ai-factory/rules/generated/openspec-rules-trace-<change-id>.json
+.ai-factory/rules/generated/index.json
 ```
 
-They may be overwritten by sync, but canonical OpenSpec artifacts must remain unchanged.
+They may be overwritten by sync, but canonical OpenSpec artifacts must remain unchanged. Missing or invalid generated trace metadata is warning-only for rules gates; rerun `/aif-mode sync --change <change-id>` to refresh it.
 
 OpenSpec CLI use is adapter-only. Do not call OpenSpec slash commands or install OpenSpec command layers; `/aif-mode` stays the orchestration surface.
 


### PR DESCRIPTION
## Summary

- Add generated rules traceability metadata with `.ai-factory/rules/generated/index.json` and per-change `openspec-rules-trace-<change-id>.json` output.
- Teach generated-rules consumers to use trace input hashes for stale detection while keeping missing or invalid trace metadata warning-only.
- Update rules-check prompts, Codex/Claude sidecars, docs, and validation tests so generated-rule `FAIL` findings require trace-backed `source.path` and `source.requirement`.

## Validation

- `npm run validate`
- `npm test` (289 passed, 0 failed)
- `/aif-verify add-generated-rules-traceability-index`
- `/aif-done add-generated-rules-traceability-index`

## Notes

- OpenSpec change was archived with `openspec archive add-generated-rules-traceability-index --yes --no-color`.
- Final evidence is under `.ai-factory/qa/add-generated-rules-traceability-index/` and `.ai-factory/state/add-generated-rules-traceability-index/`.