### PR TITLE
Add OpenSpec spec-to-code coverage matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ openspec/
   qa/
     <change-id>/
       verify.md
+      coverage.json
       openspec-validation.json
       openspec-status.json
       openspec-archive.json
@@ -259,6 +260,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | Invalid delta spec | Fix `openspec/changes/<change-id>/specs/**/spec.md`, then rerun `/aif-verify <change-id>`. |
 | Ambiguous active change | Pass an explicit `<change-id>` or update `.ai-factory/state/current.yaml`. |
 | Missing or stale generated rules | Regenerate derived rules from OpenSpec specs before relying on rules guidance. |
+| Missing or stale coverage | Rerun `/aif-verify <change-id>` to refresh `.ai-factory/qa/<change-id>/coverage.json` before `/aif-done`. |
 | Dirty working tree before `/aif-done` | Commit, stash, or explicitly allow the dirty state only when the finalizer supports that path. |
 
 ## Documentation
@@ -270,6 +272,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
 | [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
+| [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |
 | [Active Change Resolver](docs/active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](docs/adr/0001-openspec-native-artifact-protocol.md) | v1 artifact ownership decision |

--- a/agent-files/claude/aifhub-done-finalizer.md
+++ b/agent-files/claude/aifhub-done-finalizer.md
@@ -16,14 +16,14 @@ Read `.ai-factory/config.yaml` before resolving scope. Reject `--force`, force f
 Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 
 - Finalize exactly one verification-passing active OpenSpec change through `scripts/openspec-done-finalizer.mjs`.
-- Read QA evidence from `.ai-factory/qa/<change-id>/` and proceed only when `/aif-verify` clearly passed for this change and the latest final `aif-gate-result` block has `"gate": "verify"` with `status` `pass` or `warn`. Refuse unverified changes, missing/invalid/failed verify gates, and `Code verification: PENDING`.
+- Read QA evidence from `.ai-factory/qa/<change-id>/` and proceed only when `/aif-verify` clearly passed for this change, the latest final `aif-gate-result` block has `"gate": "verify"` with `status` `pass` or `warn`, and `coverage.json` is current with status `pass` or policy-accepted `warn`. Refuse unverified changes, missing/invalid/failed verify gates, missing/stale/failed coverage, and `Code verification: PENDING`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present and runtime state from `.ai-factory/state/<change-id>/` when relevant.
 - Check dirty working tree state before archive; fail or record dirty entries only when explicitly requested.
 - Archive only through `archiveOpenSpecChange` from `scripts/openspec-runner.mjs`: normal archive is `openspec archive <change-id> --yes`, and docs/tooling-only finalization uses `--skip-specs`.
 - `/aif-verify` does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
 - Allowed writes are `.ai-factory/qa/<change-id>/` final evidence and `.ai-factory/state/<change-id>/` final summaries; do not write runtime-only files into `openspec/changes/<change-id>/`.
-- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for `/aif-mode sync`, next-step recommendation for `/aif-commit`, and any `/aif-evolve` recommendation.
+- Return selected active OpenSpec change, verification status, coverage status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for `/aif-mode sync`, next-step recommendation for `/aif-commit`, and any `/aif-evolve` recommendation.
 - After successful finalization, recommend `/aif-mode sync` to refresh derived artifacts after archive, recommend `/aif-commit` as the next AI Factory command, and optionally recommend `/aif-evolve` when durable learning evidence exists.
 
 ## Legacy AI Factory-only mode

--- a/agent-files/claude/aifhub-verifier.md
+++ b/agent-files/claude/aifhub-verifier.md
@@ -25,9 +25,11 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Read runtime state from `.ai-factory/state/<change-id>/` when present.
 - Allowed write scope: QA evidence only under `.ai-factory/qa/<change-id>/`.
 - Record OpenSpec validation/status evidence under `.ai-factory/qa/<change-id>/` before code verification.
+- Build and write `.ai-factory/qa/<change-id>/coverage.json` with `scripts/openspec-coverage-matrix.mjs` when available.
+- Missing requirement coverage fails strict verification and warns in normal verification.
 - Do not archive, never archive from `/aif-verify`, do not write runtime state, and do not create legacy plan artifacts in OpenSpec-native mode.
 - Return findings first, then a gate result: `PASS`, `PASS with notes`, or `FAIL`.
-- Include active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, validation status, `shouldRunCodeVerification`, code verification status, counts for blocking/important/optional findings, and next recommended command.
+- Include active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, validation status, `shouldRunCodeVerification`, coverage summary, code verification status, counts for blocking/important/optional findings, and next recommended command.
 - Recommend `/aif-fix <change-id>` when validation or verification fails, and `/aif-done <change-id>` only after passing verification.
 - Optional read-only gates before or during verification are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
 - End with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase `status`: `pass`, `warn`, or `fail`. Write the same final block into `.ai-factory/qa/<change-id>/verify.md`.

--- a/agent-files/codex/aifhub-done-finalizer.toml
+++ b/agent-files/codex/aifhub-done-finalizer.toml
@@ -13,14 +13,14 @@ Read .ai-factory/config.yaml before resolving scope. Reject --force, force final
 Use this mode when config declares aifhub.artifactProtocol: openspec.
 
 - Finalize exactly one verification-passing active OpenSpec change through scripts/openspec-done-finalizer.mjs.
-- Read QA evidence from .ai-factory/qa/<change-id>/ and proceed only when /aif-verify clearly passed for this change and the latest final aif-gate-result block has "gate": "verify" with status pass or warn. Refuse unverified changes, missing/invalid/failed verify gates, and Code verification: PENDING.
+- Read QA evidence from .ai-factory/qa/<change-id>/ and proceed only when /aif-verify clearly passed for this change, the latest final aif-gate-result block has "gate": "verify" with status pass or warn, and coverage.json is current with status pass or policy-accepted warn. Refuse unverified changes, missing/invalid/failed verify gates, missing/stale/failed coverage, and Code verification: PENDING.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present and runtime state from .ai-factory/state/<change-id>/ when relevant.
 - Check dirty working tree state before archive; fail or record dirty entries only when explicitly requested.
 - Archive only through archiveOpenSpecChange from scripts/openspec-runner.mjs: normal archive is openspec archive <change-id> --yes, and docs/tooling-only finalization uses --skip-specs.
 - /aif-verify does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy .ai-factory/specs archive.
 - Allowed writes are .ai-factory/qa/<change-id>/ final evidence and .ai-factory/state/<change-id>/ final summaries; do not write runtime-only files into openspec/changes/<change-id>/.
-- Return selected active OpenSpec change, verification status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for /aif-mode sync, next-step recommendation for /aif-commit, and any /aif-evolve recommendation.
+- Return selected active OpenSpec change, verification status, coverage status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for /aif-mode sync, next-step recommendation for /aif-commit, and any /aif-evolve recommendation.
 - After successful finalization, recommend /aif-mode sync to refresh derived artifacts after archive, recommend /aif-commit as the next AI Factory command, and optionally recommend /aif-evolve when durable learning evidence exists.
 
 ## Legacy AI Factory-only mode

--- a/agent-files/codex/aifhub-verifier.toml
+++ b/agent-files/codex/aifhub-verifier.toml
@@ -22,9 +22,11 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Read runtime state from .ai-factory/state/<change-id>/ when present.
 - Allowed write scope: QA evidence only under .ai-factory/qa/<change-id>/.
 - Record OpenSpec validation/status evidence under .ai-factory/qa/<change-id>/ before code verification.
+- Build and write .ai-factory/qa/<change-id>/coverage.json with scripts/openspec-coverage-matrix.mjs when available.
+- Missing requirement coverage fails strict verification and warns in normal verification.
 - Do not archive, never archive from /aif-verify, do not write runtime state, and do not create legacy plan artifacts in OpenSpec-native mode.
 - Return findings first, then a gate result: PASS, PASS with notes, or FAIL.
-- Include active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, validation status, shouldRunCodeVerification, code verification status, counts for blocking/important/optional findings, and next recommended command.
+- Include active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, validation status, shouldRunCodeVerification, coverage summary, code verification status, counts for blocking/important/optional findings, and next recommended command.
 - Recommend /aif-fix <change-id> when validation or verification fails, and /aif-done <change-id> only after passing verification.
 - Optional read-only gates before or during verification are /aif-rules-check, /aif-review, and /aif-security-checklist. The authoritative final verification remains /aif-verify <change-id>.
 - End with exactly one final fenced aif-gate-result JSON block using "gate": "verify" and lowercase status pass, warn, or fail. Write the same final block into .ai-factory/qa/<change-id>/verify.md.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,9 +19,10 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 3. [Context Loading Policy](context-loading-policy.md) for consumer context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
 4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, capability flags, and degraded mode.
 5. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
-6. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
-7. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
-8. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+6. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
+7. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
+8. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
+9. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
 
 The remaining runtime-specific guides are supporting references:
 
@@ -39,6 +40,7 @@ The remaining runtime-specific guides are supporting references:
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, sync points, rules gate, version support, and degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator for canonical artifacts, runtime evidence, QA, and generated rules |
+| [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness, and integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
 | [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec and AI Factory runtime state contract |
@@ -57,6 +59,7 @@ This docs set covers:
 - command reads, writes, and forbidden writes
 - optional rules, review, and security gates
 - verification, fix, done, post-archive sync, commit, and evolve handoff
+- OpenSpec requirement coverage evidence and policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence, and generated rules
 - legacy AI Factory-only compatibility and migration
@@ -83,6 +86,7 @@ npm test
 - [Context Loading Policy](context-loading-policy.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
 - [OpenSpec Artifact Validation](openspec-validation.md)
+- [OpenSpec Coverage Matrix](spec-coverage.md)
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [Active Change Resolver](active-change-resolver.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/legacy-plan-migration.md
+++ b/docs/legacy-plan-migration.md
@@ -1,4 +1,4 @@
-[Previous Page](openspec-validation.md) | [Back to Documentation](README.md) | [Next Page](active-change-resolver.md)
+[Previous Page](spec-coverage.md) | [Back to Documentation](README.md) | [Next Page](active-change-resolver.md)
 
 # Legacy Plan Migration
 

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -1,4 +1,4 @@
-[Previous Page](openspec-compatibility.md) | [Back to Documentation](README.md) | [Next Page](legacy-plan-migration.md)
+[Previous Page](openspec-compatibility.md) | [Back to Documentation](README.md) | [Next Page](spec-coverage.md)
 
 # OpenSpec Artifact Validation
 
@@ -86,7 +86,7 @@ Missing verification evidence suggests:
 
 `/aif-done` runs the validator with verification evidence required and refuses to archive when the validator returns `fail`.
 
-`/aif-verify` is unchanged. It still writes validation/status/verify evidence under `.ai-factory/qa/<change-id>/` and does not archive.
+`/aif-verify` still writes validation/status/verify evidence under `.ai-factory/qa/<change-id>/` and does not archive. It also writes the separate OpenSpec coverage matrix described in [OpenSpec Coverage Matrix](spec-coverage.md).
 
 ## Read-Only Boundary
 
@@ -104,5 +104,6 @@ Use `/aif-mode sync --change <change-id>` to regenerate derived rules and `/aif-
 ## See Also
 
 - [OpenSpec Compatibility](openspec-compatibility.md)
+- [OpenSpec Coverage Matrix](spec-coverage.md)
 - [Usage](usage.md)
 - [Active Change Resolver](active-change-resolver.md)

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -1,0 +1,118 @@
+[Previous Page](openspec-validation.md) | [Back to Documentation](README.md) | [Next Page](legacy-plan-migration.md)
+
+# OpenSpec Coverage Matrix
+
+`scripts/openspec-coverage-matrix.mjs` builds a deterministic coverage artifact for OpenSpec-native verification:
+
+```text
+OpenSpec requirement -> task -> implementation evidence -> tests -> rules gate
+```
+
+The matrix is runtime QA evidence. It is written to `.ai-factory/qa/<change-id>/coverage.json` and never into `openspec/changes/<change-id>/`.
+
+## Usage
+
+Build and write coverage for one change:
+
+```bash
+node scripts/openspec-coverage-matrix.mjs --change <change-id> --write --json
+```
+
+Policy can be selected explicitly:
+
+```bash
+node scripts/openspec-coverage-matrix.mjs --change <change-id> --policy strict --write --json
+node scripts/openspec-coverage-matrix.mjs --change <change-id> --policy normal --write --json
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Coverage status is `pass` or `warn` |
+| `1` | Coverage status is `fail` |
+| `2` | Invalid arguments or unresolved change |
+
+## JSON Contract
+
+The output shape is stable:
+
+```json
+{
+  "schema_version": 1,
+  "change_id": "add-oauth-login",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [
+    {
+      "id": "auth.login-success",
+      "source": "openspec/changes/add-oauth-login/specs/auth/spec.md",
+      "status": "covered",
+      "tasks": ["1.1", "1.2"],
+      "implementation_evidence": [
+        "src/auth/login.ts",
+        "src/auth/session.ts"
+      ],
+      "test_evidence": [
+        "tests/auth/login.test.ts"
+      ],
+      "rules_gate": "pass"
+    }
+  ],
+  "summary": {
+    "covered": 1,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [
+    {
+      "path": "openspec/changes/add-oauth-login/specs/auth/spec.md",
+      "sha256": "..."
+    }
+  ],
+  "stale": false
+}
+```
+
+Requirement `status` is one of `covered`, `partial`, `missing`, or `not-applicable`. Top-level `status` is `pass`, `warn`, or `fail`.
+
+## Policy
+
+The default policy follows `workflow.verify_mode` from `.ai-factory/config.yaml`; missing config falls back to `normal`.
+
+| Condition | Strict | Normal |
+|---|---|---|
+| Missing requirement coverage | `fail` | `warn` |
+| Partial requirement coverage | `warn` | `warn` |
+| Rules gate failure | `fail` | `fail` |
+| Stale coverage artifact | finalization failure | finalization failure |
+
+`/aif-verify` writes `coverage.json` and includes the coverage summary in `verify.md`. Missing requirement coverage makes the final verify gate `fail` in strict mode and `warn` in normal mode.
+
+`/aif-mode doctor --change <change-id>` reads the latest coverage artifact and reports missing, stale, failed, warning, or passing coverage diagnostics.
+
+`/aif-done` requires a current coverage artifact. It refuses missing, invalid, stale, or failed coverage. A `warn` coverage matrix is accepted when the policy produced a non-blocking warning.
+
+## Evidence Sources
+
+The matrix uses:
+
+- OpenSpec delta requirements from `openspec/changes/<change-id>/specs/**/spec.md`
+- task checklist entries from `openspec/changes/<change-id>/tasks.md`
+- implementation and fix traces under `.ai-factory/state/<change-id>/`
+- generated rules state from `.ai-factory/rules/generated/`
+- optional existing verification evidence under `.ai-factory/qa/<change-id>/verify.md`
+
+Each material source gets a SHA-256 fingerprint. If any fingerprint changes, the matrix is stale and `/aif-done` requires rerunning `/aif-verify <change-id>`.
+
+## See Also
+
+- [Usage](usage.md)
+- [OpenSpec Artifact Validation](openspec-validation.md)
+- [OpenSpec Compatibility](openspec-compatibility.md)
+- [Active Change Resolver](active-change-resolver.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,7 +155,7 @@ Use `--dry-run` for planned switching or sync writes. Use `--all` or `--change <
 
 `/aif-mode sync --all` is a maintenance sweep. It refreshes generated rules for active changes, validates only selected changes that contain `openspec/changes/<change-id>/specs/**/spec.md` delta specs, and reports selected no-delta changes as `no-delta-specs` warnings instead of failing solely because old or docs-only active changes have no delta specs. `/aif-verify <change-id>` remains the stricter verification gate for a specific change.
 
-`/aif-mode doctor --change <change-id>` includes the read-only AIFHub OpenSpec artifact contract check. It reports the full JSON result as `artifactContract` and treats missing verification evidence as a pre-archive readiness failure. See [OpenSpec Artifact Validation](openspec-validation.md).
+`/aif-mode doctor --change <change-id>` includes the read-only AIFHub OpenSpec artifact contract check and the latest coverage matrix diagnostic. It reports the full JSON result as `artifactContract`, reports coverage as `coverage`, and treats missing verification evidence as a pre-archive readiness failure. See [OpenSpec Artifact Validation](openspec-validation.md) and [OpenSpec Coverage Matrix](spec-coverage.md).
 
 For CLI or IDE runtimes, planning commands may recommend an available planning mode for structured questions, but they must not fabricate unavailable tools or client actions. Codex mode switching remains a user action; see [Codex Plan Mode](codex-plan-mode.md).
 
@@ -398,11 +398,12 @@ Reads:
 Writes:
 
 - `.ai-factory/qa/<change-id>/verify.md`
+- `.ai-factory/qa/<change-id>/coverage.json`
 - `.ai-factory/qa/<change-id>/openspec-validation.json`
 - `.ai-factory/qa/<change-id>/openspec-status.json`
 - `.ai-factory/qa/<change-id>/raw/`
 
-`verify.md` ends with a final fenced `aif-gate-result` JSON block using `"gate": "verify"` and `status` of `pass`, `warn`, or `fail`.
+`coverage.json` records OpenSpec requirement coverage as `requirement -> task -> implementation evidence -> tests -> rules gate`. `verify.md` includes the coverage summary and ends with a final fenced `aif-gate-result` JSON block using `"gate": "verify"` and `status` of `pass`, `warn`, or `fail`.
 
 Does not write:
 
@@ -411,7 +412,7 @@ Does not write:
 - final archive output
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
-Invalid OpenSpec validation is a hard stop before code checks. Missing or unsupported CLI is degraded mode unless `aifhub.openspec.requireCliForVerify` is true. `openspec-status.json` is written when `aifhub.openspec.statusOnVerify` is enabled.
+Invalid OpenSpec validation is a hard stop before code checks. Missing or unsupported CLI is degraded mode unless `aifhub.openspec.requireCliForVerify` is true. `openspec-status.json` is written when `aifhub.openspec.statusOnVerify` is enabled. Missing requirement coverage makes verify `fail` in strict mode and `warn` in normal mode.
 
 ### `/aif-fix`
 
@@ -445,6 +446,7 @@ Reads:
 - `openspec/changes/<change-id>/**`
 - passing verification evidence from `.ai-factory/qa/<change-id>/`
 - the latest valid verify `aif-gate-result` block from `.ai-factory/qa/<change-id>/verify.md`
+- current coverage evidence from `.ai-factory/qa/<change-id>/coverage.json`
 - the read-only AIFHub OpenSpec artifact contract result
 - git working tree state
 
@@ -462,7 +464,7 @@ Does not write:
 - manual file moves from `openspec/changes` to archives
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
-Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` refuses archive when the artifact contract validator returns `fail`.
+Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` refuses archive when the artifact contract validator returns `fail`, or when coverage is missing, stale, invalid, or failed by policy.
 
 Next steps after `/aif-done`:
 
@@ -654,6 +656,7 @@ See [Codex Plan Mode](codex-plan-mode.md) for question-format guidance.
 | Ambiguous active change | More than one active change can be selected. | Pass `<change-id>` explicitly or update `.ai-factory/state/current.yaml`. |
 | Missing generated rules | Derived rules are absent. | Regenerate `.ai-factory/rules/generated/*.md` from OpenSpec specs before relying on rules guidance. |
 | Stale generated rules | Generated rules do not match canonical OpenSpec artifacts. | Regenerate them; do not edit generated rules as source of truth. |
+| Missing or stale coverage | `.ai-factory/qa/<change-id>/coverage.json` is absent or fingerprints no longer match source artifacts. | Rerun `/aif-verify <change-id>` to regenerate coverage before `/aif-done`. |
 | Artifact contract failure | Canonical OpenSpec artifacts, runtime state, QA evidence, or generated rules violate the AIFHub contract. | Fix the reported path or run the suggested command from `artifactContract.suggested_next`. |
 | Dirty working tree before `/aif-done` | Finalization cannot prove archive/summary scope safely. | Commit, stash, or use an explicit supported dirty-state override when available. |
 
@@ -695,6 +698,7 @@ Expected OpenSpec-native artifacts:
 openspec/changes/<change-id>/
 .ai-factory/state/<change-id>/
 .ai-factory/qa/<change-id>/
+.ai-factory/qa/<change-id>/coverage.json
 ```
 
 Legacy `.ai-factory/plans/` artifacts are expected only when the project is intentionally in legacy AI Factory-only mode.
@@ -713,6 +717,7 @@ npm test
 - [Documentation Index](README.md)
 - [Context Loading Policy](context-loading-policy.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
+- [OpenSpec Coverage Matrix](spec-coverage.md)
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [Active Change Resolver](active-change-resolver.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/injections/core/aif-verify-plan-folder.md
+++ b/injections/core/aif-verify-plan-folder.md
@@ -65,6 +65,8 @@ Runtime state and QA evidence boundaries:
 - Read implementation runtime state from `.ai-factory/state/<change-id>/` when present.
 - Write verification findings, verdicts, command results, and review evidence only under `.ai-factory/qa/<change-id>/`.
 - Record OpenSpec validation/status evidence under `.ai-factory/qa/<change-id>/` before code verification.
+- Build and write the OpenSpec coverage matrix at `.ai-factory/qa/<change-id>/coverage.json` using `scripts/openspec-coverage-matrix.mjs` when available.
+- Treat missing requirement coverage as `fail` in strict mode and `warn` in normal mode.
 - Do not write QA evidence or runtime-only files into `openspec/changes/<change-id>/`.
 - Do not archive. `/aif-verify` records verification evidence only; `/aif-done <change-id>` owns OpenSpec archive/finalization.
 - Do not create legacy plan-folder verification artifacts in OpenSpec-native mode.
@@ -75,6 +77,7 @@ Normal verification responses should report:
 - canonical artifacts inspected;
 - generated rules freshness or missing/stale `WARN`;
 - OpenSpec validation status and `shouldRunCodeVerification`;
+- coverage summary and policy result;
 - QA evidence path under `.ai-factory/qa/<change-id>/`;
 - verdict and finding counts;
 - fix guidance `/aif-fix <change-id>` when verification fails;
@@ -82,7 +85,7 @@ Normal verification responses should report:
 
 Optional read-only gates before or during verification are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
 
-End verification output and `.ai-factory/qa/<change-id>/verify.md` with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase JSON `status`: `pass`, `warn`, or `fail`. Use `fail` for blocking OpenSpec validation, test, lint, build, review, security, or rules failures; use `warn` only for non-blocking notes after verification completes.
+End verification output and `.ai-factory/qa/<change-id>/verify.md` with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase JSON `status`: `pass`, `warn`, or `fail`. Use `fail` for blocking OpenSpec validation, coverage, test, lint, build, review, security, or rules failures; use `warn` only for non-blocking notes after verification completes.
 
 Do not install OpenSpec skills or slash commands.
 Do not redirect the user to legacy finalize aliases.

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -30,6 +30,10 @@ import {
 import {
   validateOpenSpecArtifactContract as defaultValidateOpenSpecArtifactContract
 } from './openspec-artifact-validator.mjs';
+import {
+  readOpenSpecCoverageMatrix,
+  summarizeOpenSpecCoverage
+} from './openspec-coverage-matrix.mjs';
 
 export const MODES = {
   openspec: 'openspec',
@@ -369,6 +373,7 @@ export async function doctorAifMode(options = {}) {
   const openspecSettings = getOpenSpecSettings(status.config);
   const diagnostics = [];
   let artifactContract = null;
+  let coverage = null;
 
   diagnostics.push(status.configExists && status.configMarker !== null
     ? pass('config-marker', `Config marker is ${status.configMarker}.`)
@@ -427,6 +432,11 @@ export async function doctorAifMode(options = {}) {
       requireVerificationEvidence: true
     });
     diagnostics.push(renderArtifactContractDiagnostic(artifactContract));
+    coverage = await readOpenSpecCoverageMatrix(status.activeChange.changeId, {
+      ...options,
+      rootDir
+    });
+    diagnostics.push(renderCoverageDiagnostic(coverage));
   }
 
   if (status.mode === MODES.openspec && status.openspecCli.canValidate && status.activeChange.state === 'resolved') {
@@ -457,6 +467,7 @@ export async function doctorAifMode(options = {}) {
     mode: status.mode,
     status,
     artifactContract,
+    coverage,
     diagnostics,
     warnings,
     errors
@@ -1866,6 +1877,31 @@ function renderArtifactContractDiagnostic(result) {
     'aifhub-artifact-contract',
     `AIFHub OpenSpec artifact contract failed${first ? `: ${first.id}` : ''}.`
   );
+}
+
+function renderCoverageDiagnostic(result) {
+  if (!result?.exists) {
+    return warn('openspec-coverage-missing', `${result?.warnings?.[0] ?? 'Coverage matrix is missing.'} Run /aif-verify to regenerate coverage.`);
+  }
+
+  if (!result.ok) {
+    return fail('openspec-coverage-invalid', `${result.errors?.[0] ?? 'Coverage matrix is invalid.'} Run /aif-verify to regenerate coverage.`);
+  }
+
+  if (result.stale) {
+    return warn('openspec-coverage-stale', 'Coverage matrix is stale. Run /aif-verify to regenerate coverage.');
+  }
+
+  const summary = summarizeOpenSpecCoverage(result.coverage).replace(/\n/g, '; ');
+  if (result.coverage?.status === 'fail') {
+    return fail('openspec-coverage-failed', summary);
+  }
+
+  if (result.coverage?.status === 'warn') {
+    return warn('openspec-coverage-warn', summary);
+  }
+
+  return pass('openspec-coverage-pass', summary);
 }
 
 function createSkippedResult(reason) {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -894,6 +894,101 @@ describe('doctor', () => {
     assert.ok(result.diagnostics.some((item) => item.code === 'verify-gate-failed'));
   });
 
+  it('includes coverage matrix diagnostics for the resolved active change', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      '  openspec:',
+      '    archiveOnDone: false',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/changes/beta/proposal.md', '# Beta\n');
+    await writeFixture(rootDir, 'openspec/changes/beta/tasks.md', '# Tasks\n');
+    await writeFixture(rootDir, 'openspec/changes/beta/specs/auth/spec.md', '# Auth\n');
+    await writeFixture(rootDir, '.ai-factory/state/current.yaml', 'change_id: beta\n');
+    await writeFixture(rootDir, '.ai-factory/qa/beta/openspec-validation.json', JSON.stringify({
+      changeId: 'beta',
+      ok: true
+    }, null, 2));
+    await writeFixture(rootDir, '.ai-factory/qa/beta/verify.md', [
+      '# Verify: beta',
+      '',
+      'Verdict: PASS',
+      'Code verification: PASS',
+      '',
+      renderGateResultBlock(createGateResult({
+        gate: 'verify',
+        status: 'pass',
+        blockers: [],
+        affectedFiles: [],
+        suggestedNext: null
+      })),
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, '.ai-factory/qa/beta/coverage.json', JSON.stringify({
+      schema_version: 1,
+      change_id: 'beta',
+      status: 'pass',
+      blocking: false,
+      policy: {
+        mode: 'strict',
+        missing_requirement: 'fail'
+      },
+      requirements: [],
+      summary: {
+        covered: 0,
+        partial: 0,
+        missing: 0,
+        not_applicable: 0
+      },
+      sources: [],
+      stale: false,
+      diagnostics: [],
+      warnings: [],
+      errors: []
+    }, null, 2));
+    await mkdir(path.join(rootDir, 'openspec/specs'), { recursive: true });
+    await mkdir(path.join(rootDir, '.ai-factory/rules/generated'), { recursive: true });
+
+    const result = await doctorAifMode({
+      rootDir,
+      detectOpenSpec: async () => availableCliDetection(),
+      getCurrentBranch: async () => 'feat/unmatched',
+      validateOpenSpecArtifactContract: async (options) => ({
+        schema_version: 1,
+        validator: 'aifhub-openspec-artifact-contract',
+        change_id: options.changeId,
+        status: 'pass',
+        blocking: false,
+        checks: [],
+        suggested_next: null
+      }),
+      validateOpenSpecChange: async () => ({
+        ok: true,
+        stdout: '{"valid":true}',
+        stderr: '',
+        json: { valid: true }
+      }),
+      getOpenSpecStatus: async () => ({
+        ok: true,
+        stdout: '{"ok":true}',
+        stderr: '',
+        json: { ok: true }
+      })
+    });
+
+    assert.equal(result.coverage.coverage.status, 'pass');
+    assert.ok(result.diagnostics.some((item) => item.code === 'openspec-coverage-pass'));
+  });
+
   it('reports unsupported Node for OpenSpec CLI capability', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, '.ai-factory/config.yaml', [

--- a/scripts/openspec-coverage-matrix.mjs
+++ b/scripts/openspec-coverage-matrix.mjs
@@ -1,0 +1,1088 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import {
+  ensureRuntimeLayout as defaultEnsureRuntimeLayout,
+  normalizeChangeId,
+  resolveActiveChange as defaultResolveActiveChange,
+} from './active-change-resolver.mjs';
+import {
+  collectCanonicalChangeArtifacts,
+  collectGeneratedRules,
+} from './openspec-execution-context.mjs';
+import { getLatestGateResult } from './aif-gate-result.mjs';
+
+export const COVERAGE_SCHEMA_VERSION = 1;
+export const COVERAGE_FILE = 'coverage.json';
+const DEFAULT_QA_DIR = '.ai-factory/qa';
+const DEFAULT_STATE_DIR = '.ai-factory/state';
+const DEFAULT_POLICY = 'normal';
+const POLICIES = new Set(['strict', 'normal']);
+const REQUIREMENT_STATUS_ORDER = ['covered', 'partial', 'missing', 'not-applicable'];
+const TEST_PATH_PATTERN = /(^|\/)(test|tests|__tests__)\/|[._-](test|spec)\.[A-Za-z0-9]+$/i;
+const SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$|\.mjs$|\.cjs$|\.py$|\.go$|\.rs$|\.java$|\.kt$|\.cs$|\.php$|\.rb$|\.sh$|\.ps1$/i;
+const DOC_PATH_PATTERN = /(^|\/)(docs|documentation)\//i;
+const INTERNAL_ARTIFACT_PATTERN = /^(openspec|\.ai-factory)\//i;
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'be',
+  'by',
+  'can',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'into',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'shall',
+  'should',
+  'the',
+  'then',
+  'to',
+  'when',
+  'with',
+  'without',
+  'must',
+  'user',
+  'system',
+  'requirement',
+  'scenario',
+]);
+
+export async function buildOpenSpecCoverageMatrix(options = {}) {
+  const rootDir = resolveRootDir(options.rootDir);
+  const warnings = [];
+  const errors = [];
+  const policy = await resolveCoveragePolicy(rootDir, options.policy, warnings);
+  const resolved = await resolveCoverageChange(rootDir, options);
+  const changeId = resolved.changeId ?? options.changeId ?? null;
+
+  if (!resolved.ok) {
+    const matrix = emptyCoverageMatrix(changeId, policy, 'fail', true, warnings, resolved.errors ?? ['Unable to resolve OpenSpec change.']);
+    return matrix;
+  }
+
+  const layout = await resolveRuntimeLayout(rootDir, resolved.changeId, options);
+  const canonical = await collectCanonicalChangeArtifacts(resolved.changeId, {
+    ...options,
+    rootDir,
+  });
+  warnings.push(...(canonical.warnings ?? []));
+  errors.push(...(canonical.errors ?? []));
+  const requirementInputs = parseRequirementsFromCanonical(canonical.canonicalArtifacts?.deltaSpecs ?? []);
+  const taskInputs = parseTasks(canonical.canonicalArtifacts?.tasks?.content ?? '');
+  const fallbackTaskIds = taskInputs.filter((task) => task.id.startsWith('task-')).map((task) => task.id);
+  if (fallbackTaskIds.length > 0) {
+    warnings.push({
+      code: 'coverage-task-id-fallback',
+      message: `Generated fallback task id(s) for unnumbered checklist entries: ${fallbackTaskIds.join(', ')}.`,
+      path: canonical.canonicalArtifacts?.tasks?.path,
+    });
+  }
+  const generatedRules = await resolveGeneratedRulesContext(rootDir, resolved.changeId, options);
+  warnings.push(...(generatedRules.warnings ?? []));
+  errors.push(...(generatedRules.errors ?? []));
+  const traceInputs = await collectRuntimeTraceInputs(layout.statePath, options);
+  const verifyInput = await collectVerifyInput(layout.qaPath, options);
+  const sourceRecords = await buildSourceRecords(rootDir, [
+    ...canonicalSources(canonical.canonicalArtifacts),
+    ...traceInputs.sources,
+    ...verifyInput.sources,
+    ...generatedRuleSources(generatedRules.generatedRules),
+  ]);
+  const evidenceText = [
+    canonical.canonicalArtifacts?.tasks?.content ?? '',
+    ...traceInputs.contents,
+    verifyInput.content ?? '',
+    ...(generatedRules.generatedRules ?? []).map((rule) => rule.content ?? ''),
+  ].join('\n\n');
+  const evidencePaths = classifyEvidencePaths(extractEvidencePaths(evidenceText));
+  const rulesGate = inferRulesGate(generatedRules, verifyInput.gateResult, options.verifyGateResult);
+  const requirements = requirementInputs.map((requirement) => {
+    const matchingTasks = matchTasks(requirement, taskInputs);
+    const implementationEvidence = matchEvidencePaths(requirement, evidencePaths.implementation, matchingTasks);
+    const testEvidence = matchEvidencePaths(requirement, evidencePaths.tests, matchingTasks);
+    const status = classifyRequirementCoverage(requirement, matchingTasks, implementationEvidence, testEvidence, rulesGate);
+
+    return {
+      id: requirement.id,
+      source: requirement.source,
+      status,
+      tasks: matchingTasks.map((task) => task.id),
+      implementation_evidence: implementationEvidence,
+      test_evidence: testEvidence,
+      rules_gate: rulesGate,
+    };
+  });
+  const summary = summarizeRequirements(requirements);
+  const policyResult = evaluateOpenSpecCoveragePolicy({ requirements, summary }, { policy: policy.mode });
+  const buildErrorDiagnostics = errors.map((error, index) => ({
+    severity: 'error',
+    code: error.code ?? `coverage-build-error-${index + 1}`,
+    message: error.message ?? String(error),
+    path: error.path,
+  }));
+  const status = buildErrorDiagnostics.length > 0 ? 'fail' : policyResult.status;
+  const matrix = {
+    schema_version: COVERAGE_SCHEMA_VERSION,
+    change_id: resolved.changeId,
+    status,
+    blocking: status === 'fail',
+    policy: {
+      mode: policy.mode,
+      missing_requirement: policy.mode === 'strict' ? 'fail' : 'warn',
+    },
+    requirements,
+    summary,
+    sources: sourceRecords,
+    stale: false,
+    diagnostics: [...buildErrorDiagnostics, ...policyResult.diagnostics],
+    warnings: [...warnings, ...policyResult.warnings],
+    errors: [...errors, ...policyResult.errors],
+  };
+  return matrix;
+}
+
+export async function writeOpenSpecCoverageMatrix(changeId, matrix, options = {}) {
+  const normalized = normalizeCoverageChangeId(changeId ?? matrix?.change_id);
+  const rootDir = resolveRootDir(options.rootDir);
+  const qaPath = await resolveQaPath(rootDir, normalized.changeId, options);
+  await assertSafeQaPath(rootDir, qaPath);
+  await mkdir(qaPath, { recursive: true });
+  const coveragePath = path.join(qaPath, COVERAGE_FILE);
+  const payload = JSON.stringify({ ...matrix, change_id: normalized.changeId }, null, 2);
+  await writeFile(coveragePath, `${payload}\n`, 'utf8');
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    coveragePath,
+    relativePath: toPosix(path.relative(rootDir, coveragePath)),
+  };
+}
+
+export async function readOpenSpecCoverageMatrix(changeId, options = {}) {
+  const normalized = normalizeCoverageChangeId(changeId);
+  const rootDir = resolveRootDir(options.rootDir);
+  const qaPath = await resolveQaPath(rootDir, normalized.changeId, options);
+  const coveragePath = path.join(qaPath, COVERAGE_FILE);
+  const relativePath = toPosix(path.relative(rootDir, coveragePath));
+
+  try {
+    await access(coveragePath);
+  } catch {
+    return {
+      ok: false,
+      exists: false,
+      stale: null,
+      changeId: normalized.changeId,
+      coveragePath,
+      relativePath,
+      coverage: null,
+      diagnostics: [{
+        severity: 'warning',
+        code: 'coverage-missing',
+        message: `Coverage matrix is missing at ${relativePath}.`,
+      }],
+      warnings: [`Coverage matrix is missing at ${relativePath}.`],
+      errors: [],
+    };
+  }
+
+  let coverage;
+  try {
+    coverage = JSON.parse(await readFile(coveragePath, 'utf8'));
+  } catch (error) {
+    return {
+      ok: false,
+      exists: true,
+      stale: null,
+      changeId: normalized.changeId,
+      coveragePath,
+      relativePath,
+      coverage: null,
+      diagnostics: [{
+        severity: 'error',
+        code: 'coverage-invalid-json',
+        message: `Coverage matrix is not valid JSON: ${error.message}`,
+      }],
+      warnings: [],
+      errors: [`Coverage matrix is not valid JSON: ${error.message}`],
+    };
+  }
+
+  const validation = validateCoverageShape(coverage);
+  const stale = await inspectCoverageStaleness(rootDir, coverage);
+  const diagnostics = [...validation.diagnostics, ...stale.diagnostics];
+  return {
+    ok: validation.ok,
+    exists: true,
+    stale: stale.stale,
+    changeId: normalized.changeId,
+    coveragePath,
+    relativePath,
+    coverage: { ...coverage, stale: stale.stale },
+    diagnostics,
+    warnings: diagnostics.filter((diagnostic) => diagnostic.severity === 'warning').map((diagnostic) => diagnostic.message),
+    errors: diagnostics.filter((diagnostic) => diagnostic.severity === 'error').map((diagnostic) => diagnostic.message),
+  };
+}
+
+export function summarizeOpenSpecCoverage(matrixOrResult, options = {}) {
+  const matrix = matrixOrResult?.coverage ?? matrixOrResult;
+  if (!matrix) {
+    return [
+      'Coverage matrix: MISSING',
+      options.relativePath ? `Coverage artifact: ${options.relativePath}` : null,
+    ].filter(Boolean).join('\n');
+  }
+
+  const summary = matrix.summary ?? summarizeRequirements(matrix.requirements ?? []);
+  const status = String(matrix.status ?? 'unknown').toUpperCase();
+  const lines = [
+    `Coverage matrix: ${status}`,
+    `Requirements: covered ${summary.covered ?? 0}, partial ${summary.partial ?? 0}, missing ${summary.missing ?? 0}, not-applicable ${summary.not_applicable ?? 0}`,
+  ];
+
+  if (matrix.policy?.mode) {
+    lines.push(`Coverage policy: ${matrix.policy.mode}`);
+  }
+
+  if (matrix.stale === true) {
+    lines.push('Coverage staleness: stale');
+  } else if (matrix.stale === false) {
+    lines.push('Coverage staleness: current');
+  }
+
+  const missing = (matrix.requirements ?? []).filter((requirement) => requirement.status === 'missing');
+  if (missing.length > 0) {
+    lines.push(`Missing coverage: ${missing.map((requirement) => requirement.id).join(', ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function evaluateOpenSpecCoveragePolicy(matrixOrSummary, options = {}) {
+  const policy = normalizePolicyValue(options.policy ?? matrixOrSummary?.policy?.mode ?? DEFAULT_POLICY);
+  const requirements = matrixOrSummary?.requirements ?? [];
+  const summary = matrixOrSummary?.summary ?? summarizeRequirements(requirements);
+  const diagnostics = [];
+  const warnings = [];
+  const errors = [];
+  const missing = summary.missing ?? 0;
+  const partial = summary.partial ?? 0;
+  const ruleGateFailures = requirements.filter((requirement) => requirement.rules_gate === 'fail');
+
+  if (ruleGateFailures.length > 0) {
+    const message = `Coverage rules gate failed for ${ruleGateFailures.length} requirement(s).`;
+    diagnostics.push({ severity: 'error', code: 'coverage-rules-gate-failed', message });
+    errors.push(message);
+  }
+
+  if (missing > 0) {
+    const severity = policy === 'strict' ? 'error' : 'warning';
+    const message = `Coverage matrix has ${missing} missing requirement(s).`;
+    diagnostics.push({ severity, code: 'coverage-missing-requirements', message });
+    if (severity === 'error') {
+      errors.push(message);
+    } else {
+      warnings.push(message);
+    }
+  }
+
+  if (partial > 0) {
+    const message = `Coverage matrix has ${partial} partially covered requirement(s).`;
+    diagnostics.push({ severity: 'warning', code: 'coverage-partial-requirements', message });
+    warnings.push(message);
+  }
+
+  const status = errors.length > 0 ? 'fail' : warnings.length > 0 ? 'warn' : 'pass';
+  return {
+    status,
+    blocking: status === 'fail',
+    policy,
+    diagnostics,
+    warnings,
+    errors,
+  };
+}
+
+export async function runCoverageMatrixCommand(argv = process.argv.slice(2), options = {}) {
+  const parsed = parseCoverageMatrixArgs(argv);
+  if (!parsed.ok) {
+    const result = {
+      ok: false,
+      status: 'fail',
+      errors: parsed.errors,
+    };
+    await writeCommandOutput(result, parsed.json);
+    return 2;
+  }
+
+  const matrix = await buildOpenSpecCoverageMatrix({
+    ...options,
+    rootDir: options.rootDir ?? process.cwd(),
+    changeId: parsed.changeId,
+    policy: parsed.policy,
+  });
+
+  let writeResult = null;
+  if (parsed.write && matrix.change_id) {
+    writeResult = await writeOpenSpecCoverageMatrix(matrix.change_id, matrix, {
+      ...options,
+      rootDir: options.rootDir ?? process.cwd(),
+    });
+  }
+
+  const output = writeResult ? { ...matrix, artifact: writeResult.relativePath } : matrix;
+  await writeCommandOutput(output, parsed.json);
+  return matrix.status === 'fail' ? 1 : 0;
+}
+
+export function parseCoverageMatrixArgs(argv = []) {
+  const result = {
+    ok: true,
+    changeId: null,
+    json: false,
+    write: false,
+    policy: null,
+    errors: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--change') {
+      result.changeId = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg === '--json') {
+      result.json = true;
+      continue;
+    }
+    if (arg === '--write') {
+      result.write = true;
+      continue;
+    }
+    if (arg === '--policy') {
+      result.policy = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+      continue;
+    }
+    result.ok = false;
+    result.errors.push(`Unknown argument: ${arg}`);
+  }
+
+  if (result.help) {
+    result.ok = false;
+    result.errors.push(usageText());
+  }
+
+  if (result.policy && !POLICIES.has(result.policy)) {
+    result.ok = false;
+    result.errors.push(`Unsupported coverage policy: ${result.policy}. Expected strict or normal.`);
+  }
+
+  if (result.changeId !== null) {
+    const normalized = normalizeChangeId(result.changeId);
+    if (!normalized.ok) {
+      result.ok = false;
+      result.errors.push(...normalized.errors);
+    } else {
+      result.changeId = normalized.changeId;
+    }
+  }
+
+  return result;
+}
+
+function usageText() {
+  return [
+    'Usage: node scripts/openspec-coverage-matrix.mjs [--change <id>] [--policy strict|normal] [--write] [--json]',
+    'Builds an OpenSpec requirement-to-code coverage matrix.',
+  ].join('\n');
+}
+
+async function writeCommandOutput(output, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    return;
+  }
+
+  if (output?.errors?.length > 0 && !output?.requirements) {
+    process.stderr.write(`${output.errors.join('\n')}\n`);
+    return;
+  }
+
+  process.stdout.write(`${summarizeOpenSpecCoverage(output)}\n`);
+  if (output?.artifact) {
+    process.stdout.write(`Coverage artifact: ${output.artifact}\n`);
+  }
+}
+
+async function resolveCoverageChange(rootDir, options) {
+  if (options.changeId) {
+    const normalized = normalizeChangeId(options.changeId);
+    return normalized.ok
+      ? { ok: true, changeId: normalized.changeId, source: 'explicit', errors: [] }
+      : { ok: false, changeId: null, source: 'explicit', errors: normalized.errors };
+  }
+
+  const resolver = options.resolveActiveChange ?? defaultResolveActiveChange;
+  const resolved = await resolver({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId: null,
+    getCurrentBranch: options.getCurrentBranch,
+  });
+  if (resolved.ok) {
+    return { ok: true, changeId: resolved.changeId, source: resolved.source, errors: [] };
+  }
+  return { ok: false, changeId: null, source: resolved.source, errors: resolved.errors };
+}
+
+async function resolveRuntimeLayout(rootDir, changeId, options) {
+  if (options.qaPath && options.statePath) {
+    return { qaPath: options.qaPath, statePath: options.statePath };
+  }
+
+  const ensureLayout = options.ensureRuntimeLayout ?? defaultEnsureRuntimeLayout;
+  const layout = await ensureLayout(changeId, {
+    rootDir,
+    cwd: options.cwd,
+    stateDir: options.stateDir,
+    qaDir: options.qaDir,
+  });
+  return {
+    qaPath: options.qaPath ?? layout.qaPath,
+    statePath: options.statePath ?? layout.statePath,
+  };
+}
+
+async function resolveGeneratedRulesContext(rootDir, changeId, options) {
+  if (Array.isArray(options.generatedRules)) {
+    return {
+      ok: true,
+      changeId,
+      generatedRules: options.generatedRules,
+      warnings: [],
+      errors: [],
+    };
+  }
+
+  if (options.generatedRules?.generatedRules) {
+    return options.generatedRules;
+  }
+
+  return collectGeneratedRules(changeId, {
+    ...options,
+    rootDir,
+  });
+}
+
+async function resolveQaPath(rootDir, changeId, options) {
+  if (options.qaPath) {
+    return path.resolve(rootDir, options.qaPath);
+  }
+  if (options.qaDir) {
+    return path.resolve(rootDir, options.qaDir, changeId);
+  }
+  return path.resolve(rootDir, DEFAULT_QA_DIR, changeId);
+}
+
+function resolveRootDir(rootDir) {
+  return path.resolve(rootDir ?? process.cwd());
+}
+
+function normalizeCoverageChangeId(changeId) {
+  const normalized = normalizeChangeId(changeId);
+  if (!normalized.ok) {
+    throw new Error(normalized.errors.join('; '));
+  }
+  return normalized;
+}
+
+function emptyCoverageMatrix(changeId, policy, status, blocking, warnings, errors) {
+  return {
+    schema_version: COVERAGE_SCHEMA_VERSION,
+    change_id: changeId,
+    status,
+    blocking,
+    policy: {
+      mode: policy.mode,
+      missing_requirement: policy.mode === 'strict' ? 'fail' : 'warn',
+    },
+    requirements: [],
+    summary: { covered: 0, partial: 0, missing: 0, not_applicable: 0 },
+    sources: [],
+    stale: false,
+    diagnostics: errors.map((message) => ({ severity: 'error', code: 'coverage-build-failed', message })),
+    warnings,
+    errors,
+  };
+}
+
+async function resolveCoveragePolicy(rootDir, explicitPolicy, warnings) {
+  if (explicitPolicy) {
+    return { mode: normalizePolicyValue(explicitPolicy, warnings) };
+  }
+
+  const configPath = path.join(rootDir, '.ai-factory', 'config.yaml');
+  try {
+    const config = await readFile(configPath, 'utf8');
+    const match = config.match(/^\s*verify_mode:\s*["']?([A-Za-z0-9_-]+)["']?\s*$/m);
+    if (match) {
+      return { mode: normalizePolicyValue(match[1], warnings) };
+    }
+  } catch {
+    // Missing config is acceptable for isolated tests and direct CLI use.
+  }
+
+  return { mode: DEFAULT_POLICY };
+}
+
+function normalizePolicyValue(value, warnings = []) {
+  const normalized = String(value ?? DEFAULT_POLICY).trim().toLowerCase();
+  if (POLICIES.has(normalized)) {
+    return normalized;
+  }
+  warnings.push(`Unsupported coverage policy "${value}", using ${DEFAULT_POLICY}.`);
+  return DEFAULT_POLICY;
+}
+
+function parseRequirementsFromCanonical(deltaSpecs) {
+  const requirements = [];
+  for (const spec of deltaSpecs) {
+    requirements.push(...parseRequirements(spec.content ?? '', spec.relativePath ?? spec.path));
+  }
+  return requirements;
+}
+
+function parseRequirements(content, source) {
+  const requirements = [];
+  const lines = String(content ?? '').split(/\r?\n/);
+  let currentSection = null;
+  let currentRequirement = null;
+  let scenarioIndex = 0;
+  let inScenario = false;
+
+  const flush = () => {
+    if (!currentRequirement) {
+      return;
+    }
+    currentRequirement.text = [
+      currentRequirement.title,
+      currentRequirement.body.join('\n'),
+      currentRequirement.scenarios.join('\n'),
+    ].join('\n');
+    currentRequirement.keywords = tokenize(currentRequirement.text);
+    currentRequirement.notApplicable = isNotApplicableRequirement(currentRequirement);
+    delete currentRequirement.body;
+    requirements.push(currentRequirement);
+    currentRequirement = null;
+  };
+
+  for (const line of lines) {
+    const section = line.match(/^##\s+(ADDED|MODIFIED|REMOVED|DEPRECATED)\s+Requirements/i);
+    if (section) {
+      flush();
+      currentSection = section[1].toLowerCase();
+      scenarioIndex = 0;
+      inScenario = false;
+      continue;
+    }
+
+    const requirement = line.match(/^###\s+Requirement:\s+(.+?)\s*$/i);
+    if (requirement) {
+      flush();
+      scenarioIndex = 0;
+      inScenario = false;
+      const title = requirement[1].trim();
+      currentRequirement = {
+        id: requirementId(title, source, requirements.length + 1),
+        title,
+        section: currentSection ?? 'unknown',
+        source,
+        body: [],
+        scenarios: [],
+      };
+      continue;
+    }
+
+    if (!currentRequirement) {
+      continue;
+    }
+
+    const scenario = line.match(/^####\s+Scenario:\s+(.+?)\s*$/i);
+    if (scenario) {
+      scenarioIndex += 1;
+      inScenario = true;
+      currentRequirement.scenarios.push(`Scenario ${scenarioIndex}: ${scenario[1].trim()}`);
+      continue;
+    }
+
+    if (inScenario) {
+      currentRequirement.scenarios.push(line);
+    } else {
+      currentRequirement.body.push(line);
+    }
+  }
+
+  flush();
+  return requirements;
+}
+
+function requirementId(title, source, fallbackIndex) {
+  const specName = path.basename(path.dirname(toPosix(source ?? 'spec/spec.md')));
+  const slug = slugify(title);
+  return `${slugify(specName || 'requirement')}.${slug || `requirement-${fallbackIndex}`}`;
+}
+
+function slugify(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[`'"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function isNotApplicableRequirement(requirement) {
+  const text = `${requirement.title}\n${(requirement.body ?? []).join('\n')}`.toLowerCase();
+  return /\b(not-applicable|no code change|documentation only|docs only|tooling only|non-runtime|no runtime behavior|does not require runtime)\b/.test(text);
+}
+
+function parseTasks(content) {
+  const tasks = [];
+  const lines = String(content ?? '').split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^\s*-\s+\[(?<state>[ xX])\]\s+(?:(?<id>\d+(?:\.\d+)*)\s+)?(?<text>.+?)\s*$/);
+    if (!match) {
+      continue;
+    }
+    const id = match.groups?.id ?? `task-${tasks.length + 1}`;
+    const text = match.groups?.text ?? '';
+    tasks.push({
+      id,
+      text,
+      done: /x/i.test(match.groups?.state ?? ''),
+      keywords: tokenize(text),
+      paths: extractEvidencePaths(text),
+    });
+  }
+  return tasks;
+}
+
+function matchTasks(requirement, tasks) {
+  return tasks
+    .filter((task) => intersects(requirement.keywords, task.keywords) || pathSetMatchesRequirement(requirement, task.paths))
+    .sort((a, b) => naturalCompare(a.id, b.id));
+}
+
+function classifyEvidencePaths(paths) {
+  const implementation = new Set();
+  const tests = new Set();
+
+  for (const evidencePath of paths) {
+    if (TEST_PATH_PATTERN.test(evidencePath)) {
+      tests.add(evidencePath);
+      continue;
+    }
+
+    if (isImplementationEvidencePath(evidencePath)) {
+      implementation.add(evidencePath);
+    }
+  }
+
+  return {
+    implementation: [...implementation].sort(naturalCompare),
+    tests: [...tests].sort(naturalCompare),
+  };
+}
+
+function isImplementationEvidencePath(evidencePath) {
+  if (!SOURCE_FILE_PATTERN.test(evidencePath)) {
+    return false;
+  }
+  if (TEST_PATH_PATTERN.test(evidencePath)) {
+    return false;
+  }
+  if (DOC_PATH_PATTERN.test(evidencePath)) {
+    return false;
+  }
+  if (INTERNAL_ARTIFACT_PATTERN.test(evidencePath)) {
+    return false;
+  }
+  return true;
+}
+
+function matchEvidencePaths(requirement, paths, matchingTasks) {
+  const taskPathMatches = new Set(matchingTasks.flatMap((task) => task.paths));
+  const matched = paths.filter((evidencePath) => {
+    if (taskPathMatches.has(evidencePath)) {
+      return true;
+    }
+    return intersects(requirement.keywords, tokenizePath(evidencePath));
+  });
+  return [...new Set(matched)].sort(naturalCompare);
+}
+
+function pathSetMatchesRequirement(requirement, paths) {
+  return paths.some((evidencePath) => intersects(requirement.keywords, tokenizePath(evidencePath)));
+}
+
+function classifyRequirementCoverage(requirement, tasks, implementationEvidence, testEvidence, rulesGate) {
+  if (requirement.notApplicable) {
+    return 'not-applicable';
+  }
+  if (rulesGate === 'fail') {
+    return 'partial';
+  }
+  if (tasks.length === 0 && implementationEvidence.length === 0) {
+    return 'missing';
+  }
+  if (tasks.length > 0 && implementationEvidence.length > 0 && testEvidence.length > 0) {
+    return 'covered';
+  }
+  return 'partial';
+}
+
+function summarizeRequirements(requirements) {
+  const summary = { covered: 0, partial: 0, missing: 0, not_applicable: 0 };
+  for (const requirement of requirements ?? []) {
+    const status = REQUIREMENT_STATUS_ORDER.includes(requirement.status) ? requirement.status : 'partial';
+    if (status === 'not-applicable') {
+      summary.not_applicable += 1;
+    } else {
+      summary[status] += 1;
+    }
+  }
+  return summary;
+}
+
+function inferRulesGate(generatedRules, verifyGateResult, overrideGateResult) {
+  const gate = overrideGateResult ?? verifyGateResult;
+  const gateStatus = gate?.result?.status ?? gate?.status;
+  if (gateStatus === 'fail') {
+    return 'fail';
+  }
+  const rules = generatedRules?.generatedRules ?? (Array.isArray(generatedRules) ? generatedRules : []);
+  if (rules.some((rule) => rule.stale === true || rule.exists === false)) {
+    return 'warn';
+  }
+  if ((generatedRules?.warnings ?? []).length > 0 || gateStatus === 'warn') {
+    return 'warn';
+  }
+  return 'pass';
+}
+
+async function collectRuntimeTraceInputs(statePath, options) {
+  if (options.traceInputs) {
+    return options.traceInputs;
+  }
+
+  const contents = [];
+  const sources = [];
+  const traceDirs = [
+    path.join(statePath, 'implementation'),
+    path.join(statePath, 'fixes'),
+  ];
+
+  for (const traceDir of traceDirs) {
+    const files = await collectFiles(traceDir, (filePath) => /\.(md|markdown)$/i.test(filePath));
+    for (const filePath of files) {
+      try {
+        const content = await readFile(filePath, 'utf8');
+        contents.push(content);
+        sources.push({
+          path: filePath,
+          relativePath: toPosix(path.relative(options.rootDir ?? process.cwd(), filePath)),
+          content,
+        });
+      } catch {
+        // Ignore unreadable optional traces; missing evidence naturally reduces coverage.
+      }
+    }
+  }
+
+  return { contents, sources };
+}
+
+async function collectVerifyInput(qaPath, options) {
+  if (options.skipVerifyEvidence) {
+    return { content: '', sources: [], gateResult: null };
+  }
+  if (options.verifyContent !== undefined) {
+    return {
+      content: options.verifyContent ?? '',
+      sources: options.verifyPath ? [{ path: options.verifyPath, relativePath: options.verifyRelativePath, content: options.verifyContent ?? '' }] : [],
+      gateResult: options.verifyGateResult ?? null,
+    };
+  }
+
+  const verifyPath = path.join(qaPath, 'verify.md');
+  try {
+    const content = await readFile(verifyPath, 'utf8');
+    return {
+      content,
+      sources: [{ path: verifyPath, content }],
+      gateResult: getLatestGateResult(content),
+    };
+  } catch {
+    return { content: '', sources: [], gateResult: null };
+  }
+}
+
+async function collectFiles(directory, predicate) {
+  const result = [];
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...await collectFiles(filePath, predicate));
+    } else if (entry.isFile() && predicate(filePath)) {
+      result.push(filePath);
+    }
+  }
+
+  return result.sort(naturalCompare);
+}
+
+function canonicalSources(canonicalArtifacts = {}) {
+  const specs = canonicalArtifacts.deltaSpecs ?? [];
+  return [
+    ...specs.map((spec) => ({
+      path: spec.path,
+      relativePath: spec.relativePath ?? spec.path,
+      content: spec.content,
+    })),
+    canonicalArtifacts.tasks ? {
+      path: canonicalArtifacts.tasks.path,
+      relativePath: canonicalArtifacts.tasks.relativePath ?? canonicalArtifacts.tasks.path,
+      content: canonicalArtifacts.tasks.content,
+    } : null,
+  ].filter(Boolean);
+}
+
+function generatedRuleSources(generatedRules = []) {
+  return generatedRules
+    .filter((artifact) => artifact && artifact.exists !== false)
+    .map((artifact) => ({
+      path: artifact.path,
+      relativePath: artifact.relativePath ?? artifact.path,
+      content: artifact.content,
+    }));
+}
+
+async function buildSourceRecords(rootDir, sources) {
+  const records = [];
+  const seen = new Set();
+
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    const relativePath = toPosix(source.relativePath ?? path.relative(rootDir, source.path));
+    if (!relativePath || seen.has(relativePath)) {
+      continue;
+    }
+    seen.add(relativePath);
+    let content = source.content;
+    if (content === undefined && source.path) {
+      try {
+        content = await readFile(source.path, 'utf8');
+      } catch {
+        content = '';
+      }
+    }
+    records.push({
+      path: relativePath,
+      sha256: sha256(content ?? ''),
+    });
+  }
+
+  return records.sort((a, b) => naturalCompare(a.path, b.path));
+}
+
+async function inspectCoverageStaleness(rootDir, coverage) {
+  const diagnostics = [];
+  const sources = Array.isArray(coverage?.sources) ? coverage.sources : [];
+
+  for (const source of sources) {
+    const relativePath = source?.path;
+    if (!relativePath || !source.sha256) {
+      diagnostics.push({
+        severity: 'warning',
+        code: 'coverage-source-invalid',
+        message: `Coverage source entry is missing path or sha256: ${JSON.stringify(source)}`,
+      });
+      continue;
+    }
+
+    const sourcePath = path.resolve(rootDir, relativePath);
+    let content;
+    try {
+      content = await readFile(sourcePath, 'utf8');
+    } catch {
+      diagnostics.push({
+        severity: 'warning',
+        code: 'coverage-source-missing',
+        message: `Coverage source is missing: ${relativePath}`,
+      });
+      continue;
+    }
+
+    const current = sha256(content);
+    if (current !== source.sha256) {
+      diagnostics.push({
+        severity: 'warning',
+        code: 'coverage-source-stale',
+        message: `Coverage source changed since matrix generation: ${relativePath}`,
+      });
+    }
+  }
+
+  return {
+    stale: diagnostics.length > 0,
+    diagnostics,
+  };
+}
+
+function validateCoverageShape(coverage) {
+  const diagnostics = [];
+  if (coverage?.schema_version !== COVERAGE_SCHEMA_VERSION) {
+    diagnostics.push({
+      severity: 'error',
+      code: 'coverage-schema-version',
+      message: `Unsupported coverage schema version: ${coverage?.schema_version}`,
+    });
+  }
+  if (!coverage?.change_id) {
+    diagnostics.push({
+      severity: 'error',
+      code: 'coverage-change-id-missing',
+      message: 'Coverage matrix is missing change_id.',
+    });
+  }
+  if (!Array.isArray(coverage?.requirements)) {
+    diagnostics.push({
+      severity: 'error',
+      code: 'coverage-requirements-invalid',
+      message: 'Coverage matrix requirements must be an array.',
+    });
+  }
+  return {
+    ok: diagnostics.every((diagnostic) => diagnostic.severity !== 'error'),
+    diagnostics,
+  };
+}
+
+async function assertSafeQaPath(rootDir, qaPath) {
+  const root = path.resolve(rootDir);
+  const qa = path.resolve(qaPath);
+
+  if (!isWithinDirectory(qa, root)) {
+    throw new Error(`Refusing to write coverage outside repository root: ${qa}`);
+  }
+
+  for (const forbiddenDir of [
+    path.join(root, 'openspec', 'changes'),
+    path.join(root, '.ai-factory', 'plans'),
+  ]) {
+    if (isWithinDirectory(qa, forbiddenDir)) {
+      throw new Error(`Coverage evidence path must stay outside canonical OpenSpec changes and legacy plan folders: ${qa}`);
+    }
+  }
+}
+
+function isWithinDirectory(targetPath, directoryPath) {
+  const relative = path.relative(path.resolve(directoryPath), path.resolve(targetPath));
+  return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function extractEvidencePaths(text) {
+  const paths = new Set();
+  const source = String(text ?? '');
+  const pathPattern = /(?:^|[\s`"'(])((?:[A-Za-z0-9_.@-]+[\\/])+[A-Za-z0-9_.@()-]+(?:\.[A-Za-z0-9]+)+)(?=$|[\s`"',).:\]])/g;
+  for (const match of source.matchAll(pathPattern)) {
+    const normalized = normalizeEvidencePath(match[1]);
+    if (normalized) {
+      paths.add(normalized);
+    }
+  }
+  return [...paths].sort(naturalCompare);
+}
+
+function normalizeEvidencePath(value) {
+  let normalized = String(value ?? '').trim()
+    .replace(/\\/g, '/')
+    .replace(/^[./]+/, '')
+    .replace(/[.,;:)]+$/g, '');
+  if (!normalized || /^[a-z]+:\/\//i.test(normalized)) {
+    return null;
+  }
+  if (normalized.includes('..')) {
+    return null;
+  }
+  return normalized;
+}
+
+function tokenize(text) {
+  const tokens = String(text ?? '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3 && !STOPWORDS.has(token));
+  return [...new Set(tokens)];
+}
+
+function tokenizePath(evidencePath) {
+  return tokenize(evidencePath.replace(/[./_-]/g, ' '));
+}
+
+function intersects(left, right) {
+  const rightSet = new Set(right);
+  return left.some((token) => rightSet.has(token));
+}
+
+function naturalCompare(left, right) {
+  return String(left).localeCompare(String(right), undefined, { numeric: true, sensitivity: 'base' });
+}
+
+function sha256(content) {
+  return createHash('sha256').update(String(content ?? ''), 'utf8').digest('hex');
+}
+
+function toPosix(filePath) {
+  return String(filePath ?? '').replace(/\\/g, '/');
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isCli) {
+  runCoverageMatrixCommand().then((exitCode) => {
+    process.exitCode = exitCode;
+  }).catch((error) => {
+    process.stderr.write(`${error.stack ?? error.message}\n`);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/openspec-coverage-matrix.mjs
+++ b/scripts/openspec-coverage-matrix.mjs
@@ -402,7 +402,7 @@ export function parseCoverageMatrixArgs(argv = []) {
     const normalized = normalizeChangeId(result.changeId);
     if (!normalized.ok) {
       result.ok = false;
-      result.errors.push(...normalized.errors);
+      result.errors.push(...normalizeChangeIdMessages(normalized));
     } else {
       result.changeId = normalized.changeId;
     }
@@ -440,7 +440,7 @@ async function resolveCoverageChange(rootDir, options) {
     const normalized = normalizeChangeId(options.changeId);
     return normalized.ok
       ? { ok: true, changeId: normalized.changeId, source: 'explicit', errors: [] }
-      : { ok: false, changeId: null, source: 'explicit', errors: normalized.errors };
+      : { ok: false, changeId: null, source: 'explicit', errors: normalizeChangeIdMessages(normalized) };
   }
 
   const resolver = options.resolveActiveChange ?? defaultResolveActiveChange;
@@ -512,9 +512,19 @@ function resolveRootDir(rootDir) {
 function normalizeCoverageChangeId(changeId) {
   const normalized = normalizeChangeId(changeId);
   if (!normalized.ok) {
-    throw new Error(normalized.errors.join('; '));
+    throw new Error(normalizeChangeIdMessages(normalized).join('; '));
   }
   return normalized;
+}
+
+function normalizeChangeIdMessages(normalized) {
+  const errors = Array.isArray(normalized?.errors)
+    ? normalized.errors
+    : normalized?.error
+      ? [normalized.error]
+      : [];
+  const messages = errors.map((error) => error?.message ?? String(error)).filter(Boolean);
+  return messages.length > 0 ? messages : ['Invalid OpenSpec change id.'];
 }
 
 function emptyCoverageMatrix(changeId, policy, status, blocking, warnings, errors) {

--- a/scripts/openspec-coverage-matrix.test.mjs
+++ b/scripts/openspec-coverage-matrix.test.mjs
@@ -1,0 +1,363 @@
+// openspec-coverage-matrix.test.mjs - tests for OpenSpec spec-to-code coverage matrix
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildOpenSpecCoverageMatrix,
+  evaluateOpenSpecCoveragePolicy,
+  parseCoverageMatrixArgs,
+  readOpenSpecCoverageMatrix,
+  runCoverageMatrixCommand,
+  summarizeOpenSpecCoverage,
+  writeOpenSpecCoverageMatrix
+} from './openspec-coverage-matrix.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-openspec-coverage-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createChange(rootDir, changeId = 'add-oauth') {
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, [
+    '# Tasks',
+    '',
+    '- [x] 1.1 Implement OAuth login in src/auth/login.ts and src/auth/session.ts.',
+    '- [x] 1.2 Add regression coverage in tests/auth/login.test.ts.',
+    ''
+  ].join('\n'));
+  await writeFixture(rootDir, `openspec/changes/${changeId}/specs/auth/spec.md`, [
+    '# Auth Delta',
+    '',
+    '## ADDED Requirements',
+    '',
+    '### Requirement: OAuth Login',
+    '',
+    'The system MUST support OAuth login sessions.',
+    '',
+    '#### Scenario: Successful login',
+    '',
+    '- GIVEN a valid OAuth callback',
+    '- WHEN the user signs in',
+    '- THEN a login session is created',
+    ''
+  ].join('\n'));
+  await writeFixture(rootDir, `.ai-factory/state/${changeId}/implementation/run-001.md`, [
+    '# Implementation Trace',
+    '',
+    'Changed files:',
+    '- src/auth/login.ts',
+    '- src/auth/session.ts',
+    '- tests/auth/login.test.ts',
+    ''
+  ].join('\n'));
+}
+
+async function createGeneratedRules(rootDir, changeId = 'add-oauth') {
+  const files = [
+    ['merged', `.ai-factory/rules/generated/openspec-merged-${changeId}.md`, '# Merged Rules\n'],
+    ['change', `.ai-factory/rules/generated/openspec-change-${changeId}.md`, '# Change Rules\n'],
+    ['base', '.ai-factory/rules/generated/openspec-base.md', '# Base Rules\n']
+  ];
+  const rules = [];
+  for (const [kind, relativePath, content] of files) {
+    await writeFixture(rootDir, relativePath, content);
+    rules.push({
+      kind,
+      path: relativePath,
+      exists: true,
+      stale: false,
+      content
+    });
+  }
+  return rules;
+}
+
+async function captureStdout(fn) {
+  const originalWrite = process.stdout.write;
+  const chunks = [];
+  process.stdout.write = (chunk, ...args) => {
+    chunks.push(String(chunk));
+    const callback = args.find((arg) => typeof arg === 'function');
+    if (callback) {
+      callback();
+    }
+    return true;
+  };
+
+  try {
+    return {
+      result: await fn(),
+      stdout: chunks.join('')
+    };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec coverage matrix', () => {
+  it('builds requirement-to-task-to-code coverage and writes a stable QA artifact', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir);
+    const generatedRules = await createGeneratedRules(rootDir);
+
+    const matrix = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules
+    });
+
+    assert.equal(matrix.schema_version, 1);
+    assert.equal(matrix.change_id, 'add-oauth');
+    assert.equal(matrix.status, 'pass');
+    assert.deepEqual(matrix.summary, {
+      covered: 1,
+      partial: 0,
+      missing: 0,
+      not_applicable: 0
+    });
+    assert.deepEqual(matrix.requirements[0], {
+      id: 'auth.oauth-login',
+      source: 'openspec/changes/add-oauth/specs/auth/spec.md',
+      status: 'covered',
+      tasks: ['1.1', '1.2'],
+      implementation_evidence: [
+        'src/auth/login.ts',
+        'src/auth/session.ts'
+      ],
+      test_evidence: [
+        'tests/auth/login.test.ts'
+      ],
+      rules_gate: 'pass'
+    });
+
+    const writeResult = await writeOpenSpecCoverageMatrix('add-oauth', matrix, { rootDir });
+    assert.equal(writeResult.relativePath, '.ai-factory/qa/add-oauth/coverage.json');
+
+    const latest = await readOpenSpecCoverageMatrix('add-oauth', { rootDir });
+    assert.equal(latest.ok, true);
+    assert.equal(latest.exists, true);
+    assert.equal(latest.stale, false);
+    assert.equal(latest.coverage.status, 'pass');
+    assert.match(summarizeOpenSpecCoverage(latest.coverage), /Coverage matrix: PASS/);
+  });
+
+  it('fails missing requirements in strict mode and warns in normal mode', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/design.md', '# Design\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/tasks.md', '# Tasks\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/specs/auth/spec.md', [
+      '# Auth Delta',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: OAuth Login',
+      '',
+      'The system MUST support OAuth login.',
+      ''
+    ].join('\n'));
+
+    const strict = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules: []
+    });
+    const normal = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'normal',
+      generatedRules: []
+    });
+
+    assert.equal(strict.summary.missing, 1);
+    assert.equal(strict.status, 'fail');
+    assert.equal(strict.blocking, true);
+    assert.equal(normal.status, 'warn');
+    assert.equal(normal.blocking, false);
+    assert.deepEqual(
+      evaluateOpenSpecCoveragePolicy(strict, { policy: 'strict' }).errors.map((error) => error),
+      ['Coverage matrix has 1 missing requirement(s).']
+    );
+  });
+
+  it('marks coverage stale when a material source fingerprint changes', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir);
+    const generatedRules = await createGeneratedRules(rootDir);
+    const matrix = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules
+    });
+    await writeOpenSpecCoverageMatrix('add-oauth', matrix, { rootDir });
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/tasks.md', '# Tasks\n\n- [ ] 1.1 Changed task.\n');
+
+    const latest = await readOpenSpecCoverageMatrix('add-oauth', { rootDir });
+
+    assert.equal(latest.exists, true);
+    assert.equal(latest.stale, true);
+    assert.ok(latest.warnings.some((warning) => warning.includes('tasks.md')));
+
+    const rebuiltForSpec = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules
+    });
+    await writeOpenSpecCoverageMatrix('add-oauth', rebuiltForSpec, { rootDir });
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/specs/auth/spec.md', '# Auth Delta\n\n## ADDED Requirements\n\n### Requirement: Changed OAuth Login\n\nThe system MUST support changed OAuth login.\n');
+
+    const specStale = await readOpenSpecCoverageMatrix('add-oauth', { rootDir });
+    assert.equal(specStale.stale, true);
+    assert.ok(specStale.warnings.some((warning) => warning.includes('spec.md')));
+
+    const rebuiltForTrace = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules
+    });
+    await writeOpenSpecCoverageMatrix('add-oauth', rebuiltForTrace, { rootDir });
+    await writeFixture(rootDir, '.ai-factory/state/add-oauth/implementation/run-001.md', '# Implementation Trace\n\nChanged files:\n- src/auth/login.ts\n');
+
+    const traceStale = await readOpenSpecCoverageMatrix('add-oauth', { rootDir });
+    assert.equal(traceStale.stale, true);
+    assert.ok(traceStale.warnings.some((warning) => warning.includes('run-001.md')));
+
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth/verify.md', '# Verify\n\nCode verification: PASS\n');
+    const rebuiltForVerify = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules
+    });
+    await writeOpenSpecCoverageMatrix('add-oauth', rebuiltForVerify, { rootDir });
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth/verify.md', '# Verify\n\nCode verification: PASS\nUpdated.\n');
+
+    const verifyStale = await readOpenSpecCoverageMatrix('add-oauth', { rootDir });
+    assert.equal(verifyStale.stale, true);
+    assert.ok(verifyStale.warnings.some((warning) => warning.includes('verify.md')));
+  });
+
+  it('parses CLI arguments defensively', () => {
+    const parsed = parseCoverageMatrixArgs([
+      '--change',
+      'add-oauth',
+      '--write',
+      '--json',
+      '--policy',
+      'strict'
+    ]);
+
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.changeId, 'add-oauth');
+    assert.equal(parsed.write, true);
+    assert.equal(parsed.json, true);
+    assert.equal(parsed.policy, 'strict');
+
+    const invalid = parseCoverageMatrixArgs(['--policy', 'hard']);
+    assert.equal(invalid.ok, false);
+    assert.match(invalid.errors[0], /Unsupported coverage policy/);
+  });
+
+  it('runs the CLI with deterministic JSON output and exit codes', async () => {
+    const passRoot = await createTempRoot();
+    await createChange(passRoot);
+    const generatedRules = await createGeneratedRules(passRoot);
+
+    const pass = await captureStdout(() => runCoverageMatrixCommand([
+      '--change',
+      'add-oauth',
+      '--write',
+      '--json',
+      '--policy',
+      'strict'
+    ], {
+      rootDir: passRoot,
+      generatedRules
+    }));
+
+    assert.equal(pass.result, 0);
+    assert.equal(JSON.parse(pass.stdout).status, 'pass');
+
+    const failRoot = await createTempRoot();
+    await writeFixture(failRoot, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(failRoot, 'openspec/changes/add-oauth/design.md', '# Design\n');
+    await writeFixture(failRoot, 'openspec/changes/add-oauth/tasks.md', '# Tasks\n');
+    await writeFixture(failRoot, 'openspec/changes/add-oauth/specs/auth/spec.md', [
+      '# Auth Delta',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: OAuth Login',
+      '',
+      'The system MUST support OAuth login.',
+      ''
+    ].join('\n'));
+
+    const fail = await captureStdout(() => runCoverageMatrixCommand([
+      '--change',
+      'add-oauth',
+      '--json',
+      '--policy',
+      'strict'
+    ], {
+      rootDir: failRoot,
+      generatedRules: []
+    }));
+
+    assert.equal(fail.result, 1);
+    assert.equal(JSON.parse(fail.stdout).status, 'fail');
+
+    const invalid = await captureStdout(() => runCoverageMatrixCommand(['--bad', '--json'], {
+      rootDir: failRoot
+    }));
+
+    assert.equal(invalid.result, 2);
+    assert.equal(JSON.parse(invalid.stdout).ok, false);
+  });
+
+  it('persists exact source fingerprints in coverage.json', async () => {
+    const rootDir = await createTempRoot();
+    await createChange(rootDir);
+    const generatedRules = await createGeneratedRules(rootDir);
+    const matrix = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId: 'add-oauth',
+      policy: 'strict',
+      generatedRules
+    });
+    await writeOpenSpecCoverageMatrix('add-oauth', matrix, { rootDir });
+
+    const raw = JSON.parse(await readFile(path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'coverage.json'), 'utf8'));
+
+    assert.ok(raw.sources.some((source) => source.path === 'openspec/changes/add-oauth/specs/auth/spec.md'));
+    assert.ok(raw.sources.some((source) => source.path === 'openspec/changes/add-oauth/tasks.md'));
+    assert.ok(raw.sources.every((source) => /^[a-f0-9]{64}$/.test(source.sha256)));
+  });
+});

--- a/scripts/openspec-coverage-matrix.test.mjs
+++ b/scripts/openspec-coverage-matrix.test.mjs
@@ -283,6 +283,10 @@ describe('OpenSpec coverage matrix', () => {
     const invalid = parseCoverageMatrixArgs(['--policy', 'hard']);
     assert.equal(invalid.ok, false);
     assert.match(invalid.errors[0], /Unsupported coverage policy/);
+
+    const invalidChange = parseCoverageMatrixArgs(['--change', '../bad']);
+    assert.equal(invalidChange.ok, false);
+    assert.match(invalidChange.errors[0], /Invalid OpenSpec change id/);
   });
 
   it('runs the CLI with deterministic JSON output and exit codes', async () => {
@@ -340,6 +344,35 @@ describe('OpenSpec coverage matrix', () => {
 
     assert.equal(invalid.result, 2);
     assert.equal(JSON.parse(invalid.stdout).ok, false);
+
+    const invalidChange = await captureStdout(() => runCoverageMatrixCommand([
+      '--change',
+      '../bad',
+      '--json'
+    ], {
+      rootDir: failRoot
+    }));
+
+    assert.equal(invalidChange.result, 2);
+    assert.match(JSON.parse(invalidChange.stdout).errors[0], /Invalid OpenSpec change id/);
+  });
+
+  it('rejects invalid change ids with meaningful helper errors', async () => {
+    const rootDir = await createTempRoot();
+
+    await assert.rejects(
+      () => readOpenSpecCoverageMatrix('../bad', { rootDir }),
+      /Invalid OpenSpec change id/
+    );
+    await assert.rejects(
+      () => writeOpenSpecCoverageMatrix('../bad', {
+        schema_version: 1,
+        change_id: '../bad',
+        requirements: [],
+        summary: { covered: 0, partial: 0, missing: 0, not_applicable: 0 }
+      }, { rootDir }),
+      /Invalid OpenSpec change id/
+    );
   });
 
   it('persists exact source fingerprints in coverage.json', async () => {

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -28,6 +28,10 @@ import {
 import {
   validateOpenSpecArtifactContract as defaultValidateOpenSpecArtifactContract
 } from './openspec-artifact-validator.mjs';
+import {
+  readOpenSpecCoverageMatrix,
+  summarizeOpenSpecCoverage
+} from './openspec-coverage-matrix.mjs';
 
 const execFileAsync = promisify(execFile);
 const MODE = 'openspec-native';
@@ -195,6 +199,11 @@ export async function buildDoneContext(options = {}) {
     rootDir,
     qaPath: layout.qaPath
   });
+  const coverage = await assertCoverageAcceptable(resolverResult.changeId, {
+    ...options,
+    rootDir,
+    qaPath: layout.qaPath
+  });
   const validateOpenSpecArtifactContract = options.validateOpenSpecArtifactContract ?? defaultValidateOpenSpecArtifactContract;
   const artifactContract = await validateOpenSpecArtifactContract({
     ...options,
@@ -209,6 +218,7 @@ export async function buildDoneContext(options = {}) {
     ...canonical.warnings,
     ...generatedRules.warnings,
     ...verification.warnings,
+    ...coverage.warnings,
     ...artifactContractWarnings(artifactContract),
     ...runtimeTraces.warnings,
     ...openspec.warnings
@@ -217,6 +227,7 @@ export async function buildDoneContext(options = {}) {
     ...canonical.errors,
     ...generatedRules.errors,
     ...verification.errors,
+    ...coverage.errors,
     ...artifactContractErrors(artifactContract),
     ...runtimeTraces.errors,
     ...openspec.errors
@@ -233,6 +244,7 @@ export async function buildDoneContext(options = {}) {
       qa: layout.qaPath
     },
     verification: verification.verification,
+    coverage: coverage.coverage,
     openspec: openspec.openspec,
     canonicalArtifacts: canonical.canonicalArtifacts,
     runtimeTraces: runtimeTraces.runtimeTraces,
@@ -371,6 +383,90 @@ export async function assertVerificationPassed(changeId, options = {}) {
     verification: normalizeVerificationSummary(evidence, true),
     warnings: evidence.warnings ?? [],
     errors: []
+  };
+}
+
+export async function assertCoverageAcceptable(changeId, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId);
+
+  if (!normalized.ok) {
+    return createCoverageFailure({
+      changeId: null,
+      code: normalized.error.code,
+      message: normalized.error.message,
+      coverage: null
+    });
+  }
+
+  const readCoverage = options.readOpenSpecCoverageMatrix ?? readOpenSpecCoverageMatrix;
+  const coverage = await readCoverage(normalized.changeId, {
+    ...options,
+    rootDir
+  });
+
+  if (!coverage?.exists) {
+    return createCoverageFailure({
+      changeId: normalized.changeId,
+      code: 'coverage-evidence-missing',
+      message: `Run /aif-verify ${normalized.changeId} before /aif-done so coverage.json is generated.`,
+      coverage
+    });
+  }
+
+  if (!coverage.ok) {
+    return createCoverageFailure({
+      changeId: normalized.changeId,
+      code: 'coverage-evidence-invalid',
+      message: 'Refusing to archive because coverage evidence is invalid.',
+      coverage
+    });
+  }
+
+  if (coverage.stale) {
+    return createCoverageFailure({
+      changeId: normalized.changeId,
+      code: 'coverage-evidence-stale',
+      message: 'Refusing to archive because coverage evidence is stale. Rerun /aif-verify.',
+      coverage
+    });
+  }
+
+  if (coverage.coverage?.status === 'fail') {
+    return createCoverageFailure({
+      changeId: normalized.changeId,
+      code: 'coverage-policy-failed',
+      message: 'Refusing to archive because OpenSpec coverage policy failed.',
+      coverage
+    });
+  }
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    coverage: coverage.coverage,
+    warnings: coverage.coverage?.status === 'warn'
+      ? [{
+        code: 'coverage-policy-warn',
+        message: 'OpenSpec coverage completed with warnings accepted by policy.'
+      }]
+      : [],
+    errors: []
+  };
+}
+
+function createCoverageFailure({ changeId, code, message, coverage }) {
+  return {
+    ok: false,
+    changeId,
+    coverage: coverage?.coverage ?? null,
+    warnings: coverage?.warnings ?? [],
+    errors: [
+      {
+        code,
+        message
+      }
+    ]
   };
 }
 
@@ -1096,6 +1192,7 @@ function createContextFailure({ changeId, source, candidates = [], warnings = []
         content: ''
       }
     },
+    coverage: null,
     openspec: {
       available: false,
       canArchive: false,
@@ -1129,6 +1226,7 @@ function createCommitMessage(changeId) {
 function createPrSummary({ changeId, context, archive }) {
   const validationState = summarizeValidationState(context?.verification?.validation);
   const codeState = summarizeCodeState(context?.verification?.verify?.content);
+  const coverageState = context?.coverage?.status ? context.coverage.status.toUpperCase() : 'UNKNOWN';
   return [
     '## Summary',
     '',
@@ -1146,9 +1244,11 @@ function createPrSummary({ changeId, context, archive }) {
     '- /aif-verify: PASS',
     `- OpenSpec validation: ${validationState}`,
     `- Code verification: ${codeState}`,
+    `- Coverage matrix: ${coverageState}`,
     '',
     '## Artifacts',
     '',
+    `- .ai-factory/qa/${changeId}/coverage.json`,
     `- .ai-factory/qa/${changeId}/done.md`,
     `- .ai-factory/qa/${changeId}/openspec-archive.json`,
     `- .ai-factory/state/${changeId}/final-summary.md`,
@@ -1162,7 +1262,7 @@ function renderDoneMarkdown(changeId, summary) {
   const verificationGate = context?.verification?.passed ? 'PASS' : 'FAIL';
   const finalizationStatus = summary.status ?? (summary.ok ? 'PASS' : 'FAIL');
   const canonicalPaths = collectCanonicalArtifactPaths(context.canonicalArtifacts);
-  const qaEvidencePaths = collectQaEvidencePaths(changeId, context.verification);
+  const qaEvidencePaths = collectQaEvidencePaths(changeId, context.verification, context.coverage);
   const runtimeTracePaths = Array.isArray(context.runtimeTraces)
     ? context.runtimeTraces.map((trace) => trace.path)
     : [];
@@ -1182,6 +1282,10 @@ function renderDoneMarkdown(changeId, summary) {
     '',
     `Archived: ${archive.archived ? 'yes' : 'no'}`,
     `Skip specs: ${archive.skipSpecs ? 'yes' : 'no'}`,
+    '',
+    '## Coverage matrix',
+    '',
+    ...summarizeOpenSpecCoverage(context.coverage).split('\n'),
     '',
     '## Canonical artifacts finalized',
     '',
@@ -1241,9 +1345,10 @@ function collectCanonicalArtifactPaths(canonicalArtifacts = {}) {
   return paths;
 }
 
-function collectQaEvidencePaths(changeId, verification) {
+function collectQaEvidencePaths(changeId, verification, coverage) {
   const paths = [
     verification?.verify?.path,
+    coverage ? `.ai-factory/qa/${changeId}/coverage.json` : null,
     `.ai-factory/qa/${changeId}/${ARCHIVE_JSON}`,
     `.ai-factory/qa/${changeId}/${DONE_MARKDOWN}`
   ].filter(Boolean);

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 import {
   archiveChangeWithOpenSpec,
+  assertCoverageAcceptable,
   assertVerificationPassed,
   buildDoneContext,
   detectWorkingTreeState,
@@ -180,6 +181,46 @@ function verificationEvidence(overrides = {}) {
   };
 }
 
+function coverageMatrix(overrides = {}) {
+  return {
+    schema_version: 1,
+    change_id: overrides.changeId ?? 'add-oauth',
+    status: overrides.status ?? 'pass',
+    blocking: overrides.status === 'fail',
+    policy: {
+      mode: overrides.policy ?? 'strict',
+      missing_requirement: overrides.policy === 'normal' ? 'warn' : 'fail'
+    },
+    requirements: overrides.requirements ?? [],
+    summary: overrides.summary ?? {
+      covered: 0,
+      partial: 0,
+      missing: 0,
+      not_applicable: 0
+    },
+    sources: overrides.sources ?? [],
+    stale: false,
+    diagnostics: overrides.diagnostics ?? [],
+    warnings: [],
+    errors: []
+  };
+}
+
+function coverageEvidence(overrides = {}) {
+  return {
+    ok: overrides.ok ?? true,
+    exists: overrides.exists ?? true,
+    stale: overrides.stale ?? false,
+    changeId: overrides.changeId ?? 'add-oauth',
+    coveragePath: overrides.coveragePath ?? null,
+    relativePath: overrides.relativePath ?? '.ai-factory/qa/add-oauth/coverage.json',
+    coverage: overrides.coverage ?? coverageMatrix(overrides),
+    diagnostics: overrides.diagnostics ?? [],
+    warnings: overrides.warnings ?? [],
+    errors: overrides.errors ?? []
+  };
+}
+
 afterEach(async () => {
   await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
     recursive: true,
@@ -192,6 +233,7 @@ describe('OpenSpec done finalizer API', () => {
     for (const fn of [
       finalizeOpenSpecChange,
       buildDoneContext,
+      assertCoverageAcceptable,
       assertVerificationPassed,
       archiveChangeWithOpenSpec,
       writeDoneSummary,
@@ -211,7 +253,8 @@ describe('OpenSpec done finalizer API', () => {
       rootDir,
       changeId: 'add-oauth',
       detectOpenSpec: async () => availableCliDetection(),
-      readLatestVerificationEvidence: async () => verificationEvidence()
+      readLatestVerificationEvidence: async () => verificationEvidence(),
+      readOpenSpecCoverageMatrix: async () => coverageEvidence()
     });
 
     assert.equal(context.ok, true);
@@ -267,6 +310,7 @@ describe('OpenSpec done finalizer API', () => {
       })),
       ''
     ].join('\n'));
+    await writeFixture(rootDir, 'custom-qa/add-oauth/coverage.json', JSON.stringify(coverageMatrix(), null, 2));
 
     const context = await buildDoneContext({
       rootDir,
@@ -390,6 +434,51 @@ describe('OpenSpec done finalizer API', () => {
     });
     assert.equal(failedGate.ok, false);
     assert.equal(failedGate.errors[0].code, 'verification-gate-failed');
+  });
+
+  it('requires current coverage evidence before finalization', async () => {
+    const missing = await assertCoverageAcceptable('add-oauth', {
+      readOpenSpecCoverageMatrix: async () => coverageEvidence({
+        ok: false,
+        exists: false,
+        coverage: null,
+        warnings: ['missing']
+      })
+    });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.errors[0].code, 'coverage-evidence-missing');
+
+    const stale = await assertCoverageAcceptable('add-oauth', {
+      readOpenSpecCoverageMatrix: async () => coverageEvidence({
+        stale: true,
+        warnings: ['stale']
+      })
+    });
+    assert.equal(stale.ok, false);
+    assert.equal(stale.errors[0].code, 'coverage-evidence-stale');
+
+    const failed = await assertCoverageAcceptable('add-oauth', {
+      readOpenSpecCoverageMatrix: async () => coverageEvidence({
+        coverage: coverageMatrix({
+          status: 'fail',
+          summary: { covered: 0, partial: 0, missing: 1, not_applicable: 0 }
+        })
+      })
+    });
+    assert.equal(failed.ok, false);
+    assert.equal(failed.errors[0].code, 'coverage-policy-failed');
+
+    const warned = await assertCoverageAcceptable('add-oauth', {
+      readOpenSpecCoverageMatrix: async () => coverageEvidence({
+        coverage: coverageMatrix({
+          status: 'warn',
+          policy: 'normal',
+          summary: { covered: 0, partial: 0, missing: 1, not_applicable: 0 }
+        })
+      })
+    });
+    assert.equal(warned.ok, true);
+    assert.equal(warned.warnings[0].code, 'coverage-policy-warn');
   });
 
   it('detects dirty working tree state and records it only when explicit', async () => {
@@ -540,6 +629,7 @@ describe('OpenSpec done finalizer API', () => {
       changeId: 'add-oauth',
       detectOpenSpec: async () => availableCliDetection(),
       readLatestVerificationEvidence: async () => verificationEvidence(),
+      readOpenSpecCoverageMatrix: async () => coverageEvidence(),
       validateOpenSpecArtifactContract: async () => ({
         schema_version: 1,
         validator: 'aifhub-openspec-artifact-contract',
@@ -580,6 +670,7 @@ describe('OpenSpec done finalizer API', () => {
       getOpenSpecStatus: async () => statusResult(),
       gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
       readLatestVerificationEvidence: async () => verificationEvidence(),
+      readOpenSpecCoverageMatrix: async () => coverageEvidence(),
       archiveOpenSpecChange: async () => archiveResult()
     });
 
@@ -587,6 +678,7 @@ describe('OpenSpec done finalizer API', () => {
     assert.equal(result.archive.archived, true);
     assert.match(result.commitMessage, /^feat: finalize add-oauth$/);
     assert.match(result.prSummary, /## OpenSpec/);
+    assert.match(result.prSummary, /Coverage matrix: PASS/);
     assert.match(summarizeDoneResult(result), /Finalization status: PASS/);
 
     const donePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done.md');
@@ -594,6 +686,7 @@ describe('OpenSpec done finalizer API', () => {
     assert.equal(await pathExists(donePath), true, 'done.md should be written under QA path');
     assert.equal(await pathExists(finalSummaryPath), true, 'final-summary.md should be written under state path');
     assert.match(await readFile(donePath, 'utf8'), /# Done: add-oauth/);
+    assert.match(await readFile(donePath, 'utf8'), /Coverage matrix: PASS/);
     assert.match(await readFile(donePath, 'utf8'), /Archived: yes/);
     assert.match(await readFile(finalSummaryPath, 'utf8'), /## Suggested PR summary/);
     assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'done.md')), false);
@@ -611,6 +704,7 @@ describe('OpenSpec done finalizer API', () => {
       detectOpenSpec: async () => availableCliDetection(),
       gitStatus: async () => ({ exitCode: 0, stdout: ' M README.md\n', stderr: '' }),
       readLatestVerificationEvidence: async () => verificationEvidence(),
+      readOpenSpecCoverageMatrix: async () => coverageEvidence(),
       archiveOpenSpecChange: async () => archiveResult()
     });
 

--- a/scripts/openspec-verification-context.mjs
+++ b/scripts/openspec-verification-context.mjs
@@ -22,6 +22,12 @@ import {
   getLatestGateResult,
   renderGateResultBlock
 } from './aif-gate-result.mjs';
+import {
+  buildOpenSpecCoverageMatrix,
+  readOpenSpecCoverageMatrix,
+  summarizeOpenSpecCoverage,
+  writeOpenSpecCoverageMatrix
+} from './openspec-coverage-matrix.mjs';
 
 const MODE = 'openspec-native';
 const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
@@ -130,7 +136,8 @@ export async function runOpenSpecVerification(changeId, options = {}) {
   }, {
     ...options,
     rootDir,
-    qaPath: layout.qaPath
+    qaPath: layout.qaPath,
+    statePath: layout.statePath
   });
 
   return {
@@ -187,6 +194,22 @@ export async function writeVerificationEvidence(changeId, evidence, options = {}
     files.push(toPosix(path.relative(rootDir, path.join(qaPath, STATUS_FILE))));
   }
 
+  const coverage = evidence.coverage ?? await buildOpenSpecCoverageMatrix({
+    ...options,
+    rootDir,
+    changeId: normalized.changeId,
+    qaPath,
+    generatedRules: evidence.generatedRules ?? [],
+    skipVerifyEvidence: true,
+    policy: evidence.policy ?? options.policy
+  });
+  const coverageEvidence = await writeOpenSpecCoverageMatrix(normalized.changeId, coverage, {
+    ...options,
+    rootDir,
+    qaPath
+  });
+  files.push(coverageEvidence.relativePath);
+
   const summary = summarizeOpenSpecValidation({
     ok: Array.isArray(evidence.errors) ? evidence.errors.length === 0 : validation.ok,
     changeId: normalized.changeId,
@@ -196,10 +219,14 @@ export async function writeVerificationEvidence(changeId, evidence, options = {}
       status
     },
     generatedRules: evidence.generatedRules ?? [],
+    coverage,
     warnings: evidence.warnings ?? [],
     errors: evidence.errors ?? []
   });
-  const gateResult = evidence.gateResult ?? createVerifyGateResult(normalized.changeId, evidence);
+  const gateResult = evidence.gateResult ?? createVerifyGateResult(normalized.changeId, {
+    ...evidence,
+    coverage
+  });
   await writeFile(path.join(qaPath, VERIFY_FILE), `${summary}\n\n${renderGateResultBlock(gateResult)}\n`, 'utf8');
   files.push(toPosix(path.relative(rootDir, path.join(qaPath, VERIFY_FILE))));
 
@@ -248,6 +275,11 @@ export async function readLatestVerificationEvidence(changeId, options = {}) {
   const gateResult = verifyContent.exists
     ? getLatestGateResult(verifyContent.value, { gate: 'verify' })
     : null;
+  const coverage = await readOpenSpecCoverageMatrix(normalized.changeId, {
+    ...options,
+    rootDir,
+    qaPath
+  });
 
   return {
     ok: validation.exists,
@@ -260,6 +292,7 @@ export async function readLatestVerificationEvidence(changeId, options = {}) {
       content: verifyContent.value
     },
     gateResult,
+    coverage,
     warnings: validation.exists ? [] : [
       {
         code: 'verification-evidence-missing',
@@ -274,12 +307,22 @@ function createVerifyGateResult(changeId, evidence) {
   const errors = Array.isArray(evidence.errors) ? evidence.errors : [];
   const warnings = Array.isArray(evidence.warnings) ? evidence.warnings : [];
   const shouldRunCodeVerification = evidence.shouldRunCodeVerification !== false;
-  const failed = errors.length > 0 || !shouldRunCodeVerification;
-  const diagnostics = failed ? errors : warnings;
+  const coverage = evidence.coverage ?? null;
+  const coverageErrors = coverage?.status === 'fail'
+    ? coverageDiagnostics(coverage, 'error')
+    : [];
+  const coverageWarnings = coverage?.status === 'warn'
+    ? coverageDiagnostics(coverage, 'warning')
+    : [];
+  const failed = errors.length > 0 || coverageErrors.length > 0 || !shouldRunCodeVerification;
+  const diagnostics = failed
+    ? [...errors, ...coverageErrors]
+    : [...warnings, ...coverageWarnings];
+  const status = failed ? 'fail' : diagnostics.length > 0 ? 'warn' : 'pass';
 
   return createGateResult({
     gate: 'verify',
-    status: failed ? 'fail' : 'warn',
+    status,
     blockers: diagnostics.map((item, index) => ({
       id: item.code ?? `verify-${index + 1}`,
       severity: failed ? 'error' : 'warning',
@@ -294,6 +337,28 @@ function createVerifyGateResult(changeId, evidence) {
       }
       : null
   });
+}
+
+function coverageDiagnostics(coverage, severity) {
+  const diagnostics = Array.isArray(coverage?.diagnostics) ? coverage.diagnostics : [];
+  const matching = diagnostics
+    .filter((diagnostic) => severity === 'error'
+      ? diagnostic.severity === 'error'
+      : diagnostic.severity !== 'error')
+    .map((diagnostic) => ({
+      code: diagnostic.code,
+      message: diagnostic.message,
+      path: '.ai-factory/qa'
+    }));
+
+  if (matching.length > 0) {
+    return matching;
+  }
+
+  return [{
+    code: `coverage-${coverage?.status ?? 'unknown'}`,
+    message: `OpenSpec coverage matrix status is ${coverage?.status ?? 'unknown'}.`
+  }];
 }
 
 export function summarizeOpenSpecValidation(result, options = {}) {
@@ -319,6 +384,10 @@ export function summarizeOpenSpecValidation(result, options = {}) {
     '## Generated rules',
     '',
     ...renderGeneratedRulesSummary(result?.generatedRules),
+    '',
+    '## Coverage',
+    '',
+    ...summarizeOpenSpecCoverage(result?.coverage).split('\n'),
     '',
     '## Diagnostics',
     '',

--- a/scripts/openspec-verification-context.test.mjs
+++ b/scripts/openspec-verification-context.test.mjs
@@ -181,10 +181,12 @@ describe('OpenSpec verification context API', () => {
 
     const validationEvidencePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'openspec-validation.json');
     const statusEvidencePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'openspec-status.json');
+    const coveragePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'coverage.json');
     const verifyPath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'verify.md');
 
     assert.equal(await pathExists(validationEvidencePath), true, 'validation evidence JSON should be written');
     assert.equal(await pathExists(statusEvidencePath), true, 'status evidence JSON should be written');
+    assert.equal(await pathExists(coveragePath), true, 'coverage matrix JSON should be written');
     assert.equal(await pathExists(verifyPath), true, 'verify.md summary should be written');
     assert.equal(await pathExists(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'verify.md')), false);
     assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'plans', 'add-oauth')), false);
@@ -194,7 +196,12 @@ describe('OpenSpec verification context API', () => {
     assert.deepEqual(validationEvidence.parsedJson, { valid: true });
     assert.equal(validationEvidence.rawStdoutPath, '.ai-factory/qa/add-oauth/raw/openspec-validate.stdout');
     assert.equal(validationEvidence.rawStderrPath, '.ai-factory/qa/add-oauth/raw/openspec-validate.stderr');
-    assert.match(await readFile(verifyPath, 'utf8'), /Code verification: PENDING/);
+    const coverage = await readJson(coveragePath);
+    assert.equal(coverage.schema_version, 1);
+    assert.equal(coverage.change_id, 'add-oauth');
+    const verifySummary = await readFile(verifyPath, 'utf8');
+    assert.match(verifySummary, /Code verification: PENDING/);
+    assert.match(verifySummary, /## Coverage/);
   });
 
   it('uses injected active-change resolver and runtime layout hooks', async () => {
@@ -508,6 +515,48 @@ describe('OpenSpec verification context API', () => {
     assert.equal(latest.validation.changeId, 'add-oauth');
     assert.equal(latest.status, null, 'missing optional status output should not throw');
     assert.equal(latest.verify.exists, true);
+    assert.equal(latest.coverage.exists, true, 'latest verification evidence should include coverage artifact status');
+  });
+
+  it('fails the verify gate when strict coverage has missing requirements', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'workflow:',
+      '  verify_mode: strict',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/design.md', '# Design\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/tasks.md', '# Tasks\n');
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/specs/auth/spec.md', [
+      '# Auth Delta',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: OAuth Login',
+      '',
+      'The system MUST support OAuth login.',
+      ''
+    ].join('\n'));
+
+    await writeVerificationEvidence('add-oauth', {
+      validation: validationResult(),
+      status: null,
+      generatedRules: [],
+      shouldRunCodeVerification: true,
+      warnings: [],
+      errors: []
+    }, {
+      rootDir
+    });
+
+    const latest = await readLatestVerificationEvidence('add-oauth', { rootDir });
+
+    assert.equal(latest.coverage.coverage.status, 'fail');
+    assert.match(latest.verify.content, /Coverage matrix: FAIL/);
+    assert.equal(latest.gateResult.ok, true);
+    assert.equal(latest.gateResult.result.status, 'fail');
+    assert.ok(latest.gateResult.result.blockers.some((blocker) => blocker.id === 'coverage-missing-requirements'));
   });
 
   it('writes and reloads the final verify gate result block', async () => {

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -26,8 +26,10 @@ OpenSpec-native mode finalizes the verified change state through `scripts/opensp
 - Read QA evidence from `.ai-factory/qa/<change-id>/`.
 - Treat verification as passing only when QA evidence clearly records a final PASS or PASS-with-notes for this change.
 - Require the latest final fenced `aif-gate-result` block in `verify.md` to be valid JSON with `"gate": "verify"` and `status` of `pass` or `warn`.
+- Require `.ai-factory/qa/<change-id>/coverage.json` to exist, be current, and have coverage status `pass` or policy-accepted `warn`.
 - If verification has not run or verdict is `fail`, stop and suggest `/aif-verify` or `/aif-fix`.
 - If the verify gate result is missing, invalid, or `fail`, stop and suggest rerunning `/aif-verify <change-id>` or `/aif-fix <change-id>`.
+- If coverage is missing, invalid, stale, or failed by policy, stop and suggest rerunning `/aif-verify <change-id>`.
 - Refuse unverified changes; do not accept `Code verification: PENDING` as final verification.
 - Check dirty working tree state before archive and either fail or record it only when explicit dirty-state recording is requested.
 
@@ -50,7 +52,7 @@ Read generated rules as derived guidance when present:
 Runtime state and QA evidence live outside canonical changes:
 
 - `.ai-factory/state/<change-id>/`
-- `.ai-factory/qa/<change-id>/`
+- `.ai-factory/qa/<change-id>/`, including `verify.md` and `coverage.json`
 
 ### Archive Policy
 
@@ -176,7 +178,7 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 | Artifact | Owner | This Skill |
 |----------|-------|------------|
 | `openspec/changes/<change-id>/` | OpenSpec-native workflow | Reads before archive; OpenSpec CLI owns lifecycle mutation |
-| `.ai-factory/qa/<change-id>/` | `/aif-verify` and **aif-done** | Reads verification evidence; writes `done.md`, `openspec-archive.json`, and raw archive output |
+| `.ai-factory/qa/<change-id>/` | `/aif-verify` and **aif-done** | Reads verification and coverage evidence; writes `done.md`, `openspec-archive.json`, and raw archive output |
 | `.ai-factory/state/<change-id>/` | OpenSpec-native runtime and **aif-done** | Reads traces; writes `final-summary.md` |
 | `.ai-factory/specs/<plan-id>/` | **aif-done** legacy mode only | Creates or refreshes on legacy finalization |
 | `.ai-factory/specs/index.yaml` | **aif-done** | Updates |
@@ -190,6 +192,7 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 
 - Never finalize a plan that has not passed verification.
 - In OpenSpec-native mode, never finalize an unverified change.
+- In OpenSpec-native mode, never finalize a change with missing, stale, invalid, or failed `coverage.json`.
 - In OpenSpec-native mode, archive only through `archiveOpenSpecChange`; never use custom OpenSpec archive logic.
 - In OpenSpec-native mode, never silently archive through legacy `.ai-factory/specs`.
 - Never invent governance changes without evidence from the verified plan.

--- a/skills/aif-done/references/finalization-contract.md
+++ b/skills/aif-done/references/finalization-contract.md
@@ -11,8 +11,10 @@ Reference for the `aif-done` skill and `aifhub-done-finalizer` agents.
 - QA evidence exists under `.ai-factory/qa/<change-id>/`.
 - Verification evidence clearly records final PASS or PASS-with-notes for this change.
 - The latest final fenced `aif-gate-result` block in `verify.md` is valid JSON with `"gate": "verify"` and `status` of `pass` or `warn`.
+- `.ai-factory/qa/<change-id>/coverage.json` exists, is current, and has coverage status `pass` or policy-accepted `warn`.
 - OpenSpec-native `/aif-done` refuses unverified changes.
 - Missing, invalid, or failed verify gate results refuse finalization and require `/aif-verify` or `/aif-fix`.
+- Missing, invalid, stale, or failed coverage refuses finalization and requires `/aif-verify`.
 - `Code verification: PENDING` is ambiguous and must refuse finalization.
 - Dirty working tree state is empty, or explicit dirty-state recording is enabled.
 
@@ -31,6 +33,7 @@ openspec/changes/<change-id>/specs/**/spec.md
 .ai-factory/rules/generated/openspec-base.md
 .ai-factory/state/<change-id>/
 .ai-factory/qa/<change-id>/
+.ai-factory/qa/<change-id>/coverage.json
 ```
 
 ### Archive Policy
@@ -69,7 +72,7 @@ Do not write runtime-only files into `openspec/changes/<change-id>/`.
 
 ### Output
 
-Report selected `change-id`, verification status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, `--skip-specs` state, commit draft, PR draft, and next steps: `/aif-mode sync`, `/aif-commit`, and optional `/aif-evolve`.
+Report selected `change-id`, verification status, coverage matrix status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, `--skip-specs` state, commit draft, PR draft, and next steps: `/aif-mode sync`, `/aif-commit`, and optional `/aif-evolve`.
 
 After successful finalization:
 
@@ -184,6 +187,7 @@ finalization:
 | No active plan found | Stop with guidance to select a plan |
 | Verification not run / verdict missing | Stop, suggest `/aif-verify` |
 | Verification failed (`fail`) | Stop, suggest `/aif-fix` then `/aif-verify` |
+| Coverage missing, stale, invalid, or failed | Stop, suggest `/aif-verify` |
 | Workspace dirty outside plan scope | Stop, ask user to confirm |
 | Archive already exists | Refresh archive/spec/index outputs; do not fail |
 | `gh` not available | Output manual PR instructions instead of failing |

--- a/skills/aif-mode/SKILL.md
+++ b/skills/aif-mode/SKILL.md
@@ -97,7 +97,7 @@ Refresh derived or compatibility artifacts without changing mode.
 
 ### `doctor`
 
-Read-only diagnostics for config marker, configured paths, OpenSpec CLI capability, Node compatibility, active change ambiguity, generated rules, legacy artifacts in OpenSpec-native mode, OpenSpec validation when available, and archive readiness for `/aif-done`.
+Read-only diagnostics for config marker, configured paths, OpenSpec CLI capability, Node compatibility, active change ambiguity, generated rules, coverage matrix status, legacy artifacts in OpenSpec-native mode, OpenSpec validation when available, and archive readiness for `/aif-done`.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Adds a deterministic OpenSpec coverage matrix helper that maps delta requirements to tasks, implementation evidence, test evidence, and rules-gate state.
- Writes coverage evidence to `.ai-factory/qa/<change-id>/coverage.json` and folds coverage status into `/aif-verify`, `/aif-mode doctor --change`, and `/aif-done`.
- Updates docs and agent/prompt contracts to describe coverage policy, stale evidence handling, and finalization requirements.

## Testing
- Added coverage matrix unit tests for parsing, classification, stale fingerprint detection, CLI behavior, and safe write paths.
- Extended verification, doctor, and done finalizer tests to cover coverage-aware behavior.
- Local validation passed: project validators, OpenSpec strict validation, and the full test suite.