### PR TITLE
feat(done): add pre-archive done readiness gate

### DIFF
--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -86,9 +86,62 @@ Missing verification evidence suggests:
 
 Doctor also reports `effectivePolicy` from `scripts/openspec-policy.mjs`, including CLI, generated-rules, rules-gate, spec-coverage, and `allowWarnOnDone` settings. Human diagnostics show whether missing or warning evidence is only degraded or blocking under the current policy.
 
-`/aif-done` runs the validator with verification evidence required and refuses to archive when the validator returns `fail`.
+`/aif-done` runs `scripts/openspec-done-readiness.mjs` before archive and writes `.ai-factory/qa/<change-id>/done-readiness.json`. The readiness gate checks OpenSpec validate, OpenSpec status, artifact contract, generated rules freshness, rules gate evidence, coverage, verify gate evidence, and dirty workspace state. Blocking failures refuse archive and include an exact suggested next command, such as `/aif-mode sync --change <change-id>`, `/aif-rules-check`, or `/aif-verify <change-id>`.
+
+The readiness gate runs the artifact validator with verification evidence required and refuses to archive when the validator returns `fail` or blocking `warn`.
 
 `/aif-verify` still writes validation/status/verify evidence under `.ai-factory/qa/<change-id>/` and does not archive. It also writes the separate OpenSpec coverage matrix described in [OpenSpec Coverage Matrix](spec-coverage.md).
+
+## Done Readiness
+
+Run the pre-archive gate directly when diagnosing `/aif-done` refusal:
+
+```bash
+node scripts/openspec-done-readiness.mjs --change <change-id> --json
+```
+
+It writes `.ai-factory/qa/<change-id>/done-readiness.json` unless `--no-write` is passed. Exit codes are `0` for `pass` or policy-accepted `warn`, `1` for blocking readiness failure, and `2` for invalid arguments or unresolved changes.
+
+Stable JSON fields:
+
+```json
+{
+  "schema_version": 1,
+  "gate": "done-readiness",
+  "change_id": "add-oauth-login",
+  "status": "pass",
+  "blocking": false,
+  "checks": {
+    "openspec_validate": "pass",
+    "openspec_status": "pass",
+    "artifact_contract": "pass",
+    "generated_rules": "pass",
+    "rules_gate": "pass",
+    "coverage": "pass",
+    "verify_gate": "pass",
+    "dirty_workspace": "pass"
+  },
+  "diagnostics": [],
+  "suggested_next": null
+}
+```
+
+Each diagnostic includes `check`, `level`, `blocking`, `code`, `message`, optional `path`, and optional `suggested_next`.
+
+Readiness checks:
+
+| Check | Blocking behavior |
+|---|---|
+| `openspec_validate` | blocks when required OpenSpec validation fails or done policy requires an unavailable CLI |
+| `openspec_status` | blocks only when status is unavailable or warning and `allowWarnOnDone.openspecStatus` is false |
+| `artifact_contract` | requires aggregate artifact contract `pass` before archive |
+| `generated_rules` | blocks stale or missing generated rules when `requireGeneratedRulesForDone` is true |
+| `rules_gate` | blocks missing, failed, or disallowed warning rules evidence when `requireRulesPassForDone` is true |
+| `coverage` | blocks missing, stale, failed, or disallowed warning coverage when `requireSpecCoverageForDone` is true |
+| `verify_gate` | blocks missing, invalid, failed, or ambiguous final verify gate evidence |
+| `dirty_workspace` | blocks uncommitted changes unless explicit dirty-state recording is enabled |
+
+Policy is intentionally stricter for done than verify. Verify can run degraded when CLI, generated rules, rules gate, or coverage evidence is unavailable unless the matching verify flag is true. Done requires archive readiness and applies `allowWarnOnDone` before accepting warning-only rules, coverage, or OpenSpec status.
 
 ## Read-Only Boundary
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -451,10 +451,12 @@ Reads:
 - current coverage evidence from `.ai-factory/qa/<change-id>/coverage.json`
 - durable rules gate evidence from `.ai-factory/qa/<change-id>/rules.md` when policy requires it
 - the read-only AIFHub OpenSpec artifact contract result
+- the pre-archive readiness result from `scripts/openspec-done-readiness.mjs`
 - git working tree state
 
 Writes:
 
+- `.ai-factory/qa/<change-id>/done-readiness.json`
 - `.ai-factory/qa/<change-id>/done.md`
 - `.ai-factory/qa/<change-id>/openspec-archive.json`
 - `.ai-factory/qa/<change-id>/raw/`
@@ -467,7 +469,7 @@ Does not write:
 - manual file moves from `openspec/changes` to archives
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
-Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` refuses archive when the artifact contract validator returns `fail`, or when coverage is missing, stale, invalid, or failed by policy.
+Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
 
 Next steps after `/aif-done`:
 

--- a/scripts/openspec-bugfix-workflow.test.mjs
+++ b/scripts/openspec-bugfix-workflow.test.mjs
@@ -259,6 +259,7 @@ async function finalizeWithArchive(rootDir, changeId) {
     rootDir,
     changeId,
     detectOpenSpec: async () => availableCliDetection(),
+    validateOpenSpecChange: async () => validationResult(changeId),
     getOpenSpecStatus: async () => statusResult(changeId),
     gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     archiveOpenSpecChange: async (requestedChangeId, options) => {

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -36,6 +36,12 @@ import {
   readOpenSpecPolicy,
   readOpenSpecRulesGateEvidence
 } from './openspec-policy.mjs';
+import {
+  DONE_READINESS_FILE,
+  buildOpenSpecDoneReadiness,
+  summarizeOpenSpecDoneReadiness,
+  writeOpenSpecDoneReadiness
+} from './openspec-done-readiness.mjs';
 
 const execFileAsync = promisify(execFile);
 const MODE = 'openspec-native';
@@ -48,20 +54,59 @@ const FINAL_SUMMARY_MARKDOWN = 'final-summary.md';
 export async function finalizeOpenSpecChange(options = {}) {
   const rootDir = resolveRootDir(options);
   const context = await buildDoneContext({ ...options, rootDir });
+  const readiness = shouldSkipReadinessForContext(context)
+    ? null
+    : await buildAndWriteDoneReadiness({
+      ...options,
+      rootDir,
+      policy: context.effectivePolicy
+    });
 
   if (!context.ok) {
+    const archive = createSkippedArchiveSummary(
+      context.changeId,
+      options,
+      readiness?.blocking ? 'done-readiness-failed' : 'context-failed'
+    );
     return {
       ...context,
       status: 'FAIL',
-      archive: createSkippedArchiveSummary(context.changeId, options, 'context-failed'),
-      workingTree: null,
+      readiness,
+      archive,
+      workingTree: readiness?.context?.workingTree ?? null,
       commitMessage: context.changeId ? createCommitMessage(context.changeId) : '',
-      prSummary: '',
+      prSummary: context.changeId
+        ? createPrSummary({
+          changeId: context.changeId,
+          context,
+          archive,
+          readiness
+        })
+        : '',
+      warnings: dedupeDiagnostics([
+        ...(context.warnings ?? []),
+        ...readinessWarnings(readiness),
+        ...archive.warnings
+      ]),
+      errors: dedupeDiagnostics([
+        ...(context.errors ?? []),
+        ...readinessErrors(readiness)
+      ]),
       summaryFiles: []
     };
   }
 
-  const workingTree = await detectWorkingTreeState({
+  if (readiness?.blocking) {
+    return createFinalizeFailure({
+      context,
+      readiness,
+      workingTree: readiness?.context?.workingTree ?? null,
+      archive: createSkippedArchiveSummary(context.changeId, options, 'done-readiness-failed'),
+      errors: readinessErrors(readiness)
+    });
+  }
+
+  const workingTree = readiness?.context?.workingTree ?? await detectWorkingTreeState({
     ...options,
     rootDir
   });
@@ -69,6 +114,7 @@ export async function finalizeOpenSpecChange(options = {}) {
   if (!workingTree.ok) {
     return createFinalizeFailure({
       context,
+      readiness,
       workingTree,
       archive: createSkippedArchiveSummary(context.changeId, options, 'dirty-working-tree'),
       errors: workingTree.errors
@@ -88,16 +134,19 @@ export async function finalizeOpenSpecChange(options = {}) {
     status: archive.ok ? archive.status : 'FAIL',
     context,
     verification: context.verification,
+    readiness,
     workingTree,
     archive,
     commitMessage: createCommitMessage(context.changeId),
     prSummary: createPrSummary({
       changeId: context.changeId,
       context,
-      archive
+      archive,
+      readiness
     }),
     warnings: dedupeDiagnostics([
       ...context.warnings,
+      ...readinessWarnings(readiness),
       ...workingTree.warnings,
       ...archive.warnings
     ]),
@@ -910,6 +959,7 @@ export function summarizeDoneResult(result, options = {}) {
   const changeId = result?.changeId ?? '<change-id>';
   const archived = result?.archive?.archived ? 'yes' : 'no';
   const skipSpecs = result?.archive?.skipSpecs ? 'yes' : 'no';
+  const readinessStatus = result?.readiness?.status ? String(result.readiness.status).toUpperCase() : null;
   const lines = [
     `Finalization status: ${status}`,
     `Change: ${changeId}`,
@@ -917,9 +967,18 @@ export function summarizeDoneResult(result, options = {}) {
     `Skip specs: ${skipSpecs}`
   ];
 
+  if (readinessStatus !== null) {
+    lines.push(`Done readiness: ${readinessStatus}`);
+  }
+
   if (Array.isArray(result?.summaryFiles) && result.summaryFiles.length > 0) {
     lines.push('Summary files:');
     lines.push(...result.summaryFiles.map((file) => `- ${file}`));
+  }
+
+  if (result?.readiness?.suggested_next) {
+    lines.push(`Suggested next: ${result.readiness.suggested_next.command}`);
+    lines.push(`Reason: ${result.readiness.suggested_next.reason}`);
   }
 
   if (options.includeErrors && Array.isArray(result?.errors) && result.errors.length > 0) {
@@ -1096,7 +1155,51 @@ function createSkippedArchiveSummary(changeId, options, reason) {
   };
 }
 
-function createFinalizeFailure({ context, workingTree, archive, errors }) {
+async function buildAndWriteDoneReadiness(options = {}) {
+  const readiness = await buildOpenSpecDoneReadiness(options);
+
+  if (!readiness.change_id) {
+    return readiness;
+  }
+
+  const written = await writeOpenSpecDoneReadiness(readiness.change_id, readiness, options);
+  return written.readiness;
+}
+
+function shouldSkipReadinessForContext(context) {
+  return (context?.errors ?? []).some((error) => error?.code === 'change-already-archived');
+}
+
+function readinessWarnings(readiness) {
+  return readinessDiagnostics(readiness)
+    .filter((diagnostic) => diagnostic.level === 'warn')
+    .map(toReadinessDiagnostic);
+}
+
+function readinessErrors(readiness) {
+  return readinessDiagnostics(readiness)
+    .filter((diagnostic) => diagnostic.blocking || diagnostic.level === 'fail')
+    .map(toReadinessDiagnostic);
+}
+
+function readinessDiagnostics(readiness) {
+  return Array.isArray(readiness?.diagnostics) ? readiness.diagnostics : [];
+}
+
+function toReadinessDiagnostic(diagnostic) {
+  const result = {
+    code: diagnostic.code ?? 'done-readiness-diagnostic',
+    message: diagnostic.message ?? 'Done readiness reported a diagnostic.'
+  };
+
+  if (diagnostic.path !== undefined && diagnostic.path !== null) {
+    result.path = diagnostic.path;
+  }
+
+  return result;
+}
+
+function createFinalizeFailure({ context, readiness, workingTree, archive, errors }) {
   return {
     ok: false,
     mode: MODE,
@@ -1104,16 +1207,19 @@ function createFinalizeFailure({ context, workingTree, archive, errors }) {
     status: 'FAIL',
     context,
     verification: context.verification,
+    readiness,
     workingTree,
     archive,
     commitMessage: createCommitMessage(context.changeId),
     prSummary: createPrSummary({
       changeId: context.changeId,
       context,
-      archive
+      archive,
+      readiness
     }),
     warnings: dedupeDiagnostics([
       ...context.warnings,
+      ...readinessWarnings(readiness),
       ...(workingTree?.warnings ?? []),
       ...(archive?.warnings ?? [])
     ]),
@@ -1424,10 +1530,12 @@ function createCommitMessage(changeId) {
   return `feat: finalize ${changeId}`;
 }
 
-function createPrSummary({ changeId, context, archive }) {
+function createPrSummary({ changeId, context, archive, readiness }) {
   const validationState = summarizeValidationState(context?.verification?.validation);
   const codeState = summarizeCodeState(context?.verification?.verify?.content);
   const coverageState = context?.coverage?.status ? context.coverage.status.toUpperCase() : 'UNKNOWN';
+  const readinessState = readiness?.status ? String(readiness.status).toUpperCase() : 'UNKNOWN';
+  const verificationState = context?.verification?.passed ? 'PASS' : 'FAIL';
   return [
     '## Summary',
     '',
@@ -1442,13 +1550,15 @@ function createPrSummary({ changeId, context, archive }) {
     '',
     '## Verification',
     '',
-    '- /aif-verify: PASS',
+    `- /aif-verify: ${verificationState}`,
+    `- Done readiness: ${readinessState}`,
     `- OpenSpec validation: ${validationState}`,
     `- Code verification: ${codeState}`,
     `- Coverage matrix: ${coverageState}`,
     '',
     '## Artifacts',
     '',
+    `- .ai-factory/qa/${changeId}/${DONE_READINESS_FILE}`,
     `- .ai-factory/qa/${changeId}/coverage.json`,
     `- .ai-factory/qa/${changeId}/done.md`,
     `- .ai-factory/qa/${changeId}/openspec-archive.json`,
@@ -1460,10 +1570,11 @@ function createPrSummary({ changeId, context, archive }) {
 function renderDoneMarkdown(changeId, summary) {
   const context = summary.context ?? {};
   const archive = summary.archive ?? {};
+  const readiness = summary.readiness ?? null;
   const verificationGate = context?.verification?.passed ? 'PASS' : 'FAIL';
   const finalizationStatus = summary.status ?? (summary.ok ? 'PASS' : 'FAIL');
   const canonicalPaths = collectCanonicalArtifactPaths(context.canonicalArtifacts);
-  const qaEvidencePaths = collectQaEvidencePaths(changeId, context.verification, context.coverage);
+  const qaEvidencePaths = collectQaEvidencePaths(changeId, context.verification, context.coverage, readiness);
   const runtimeTracePaths = Array.isArray(context.runtimeTraces)
     ? context.runtimeTraces.map((trace) => trace.path)
     : [];
@@ -1474,6 +1585,12 @@ function renderDoneMarkdown(changeId, summary) {
     '## Finalization status',
     '',
     finalizationStatus,
+    '',
+    '## Done readiness',
+    '',
+    ...(readiness === null
+      ? ['Done readiness: UNKNOWN']
+      : summarizeOpenSpecDoneReadiness(readiness).split('\n')),
     '',
     '## Verification gate',
     '',
@@ -1510,7 +1627,7 @@ function renderDoneMarkdown(changeId, summary) {
     '',
     '## Suggested PR summary',
     '',
-    summary.prSummary ?? createPrSummary({ changeId, context, archive })
+    summary.prSummary ?? createPrSummary({ changeId, context, archive, readiness })
   ].join('\n');
 }
 
@@ -1546,9 +1663,10 @@ function collectCanonicalArtifactPaths(canonicalArtifacts = {}) {
   return paths;
 }
 
-function collectQaEvidencePaths(changeId, verification, coverage) {
+function collectQaEvidencePaths(changeId, verification, coverage, readiness) {
   const paths = [
     verification?.verify?.path,
+    readiness?.evidence_path ?? `.ai-factory/qa/${changeId}/${DONE_READINESS_FILE}`,
     coverage ? `.ai-factory/qa/${changeId}/coverage.json` : null,
     `.ai-factory/qa/${changeId}/${ARCHIVE_JSON}`,
     `.ai-factory/qa/${changeId}/${DONE_MARKDOWN}`

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -756,6 +756,7 @@ describe('OpenSpec done finalizer API', () => {
       rootDir,
       changeId: 'add-oauth',
       detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async () => statusResult(),
       readLatestVerificationEvidence: async () => verificationEvidence(),
       readOpenSpecCoverageMatrix: async () => coverageEvidence(),
       validateOpenSpecArtifactContract: async () => ({
@@ -782,8 +783,10 @@ describe('OpenSpec done finalizer API', () => {
 
     assert.equal(result.ok, false);
     assert.equal(result.archive.archived, false);
+    assert.equal(result.readiness.status, 'fail');
     assert.equal(result.errors[0].code, 'artifact-contract-failed');
     assert.equal(archiveCalls, 0);
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done-readiness.json')), true);
   });
 
   it('finalizes passing changes, writes done summaries, and stays out of canonical/legacy paths', async () => {
@@ -795,6 +798,7 @@ describe('OpenSpec done finalizer API', () => {
       rootDir,
       changeId: 'add-oauth',
       detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async () => statusResult(),
       getOpenSpecStatus: async () => statusResult(),
       gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
       readLatestVerificationEvidence: async () => verificationEvidence(),
@@ -806,14 +810,19 @@ describe('OpenSpec done finalizer API', () => {
     assert.equal(result.archive.archived, true);
     assert.match(result.commitMessage, /^feat: finalize add-oauth$/);
     assert.match(result.prSummary, /## OpenSpec/);
+    assert.match(result.prSummary, /Done readiness: PASS/);
     assert.match(result.prSummary, /Coverage matrix: PASS/);
     assert.match(summarizeDoneResult(result), /Finalization status: PASS/);
 
+    const readinessPath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done-readiness.json');
     const donePath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done.md');
     const finalSummaryPath = path.join(rootDir, '.ai-factory', 'state', 'add-oauth', 'final-summary.md');
+    assert.equal(await pathExists(readinessPath), true, 'done-readiness.json should be written under QA path');
     assert.equal(await pathExists(donePath), true, 'done.md should be written under QA path');
     assert.equal(await pathExists(finalSummaryPath), true, 'final-summary.md should be written under state path');
+    assert.equal((await readJson(readinessPath)).gate, 'done-readiness');
     assert.match(await readFile(donePath, 'utf8'), /# Done: add-oauth/);
+    assert.match(await readFile(donePath, 'utf8'), /## Done readiness/);
     assert.match(await readFile(donePath, 'utf8'), /Coverage matrix: PASS/);
     assert.match(await readFile(donePath, 'utf8'), /Archived: yes/);
     assert.match(await readFile(finalSummaryPath, 'utf8'), /## Suggested PR summary/);
@@ -831,6 +840,7 @@ describe('OpenSpec done finalizer API', () => {
       changeId: 'add-oauth',
       allowDirty: true,
       detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async () => statusResult(),
       gitStatus: async () => ({ exitCode: 0, stdout: ' M README.md\n', stderr: '' }),
       readLatestVerificationEvidence: async () => verificationEvidence(),
       readOpenSpecCoverageMatrix: async () => coverageEvidence(),

--- a/scripts/openspec-done-readiness.mjs
+++ b/scripts/openspec-done-readiness.mjs
@@ -1,0 +1,1150 @@
+#!/usr/bin/env node
+// openspec-done-readiness.mjs - pre-archive readiness gate for OpenSpec done finalization
+import { execFile } from 'node:child_process';
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import {
+  ensureRuntimeLayout as defaultEnsureRuntimeLayout,
+  normalizeChangeId,
+  resolveActiveChange as defaultResolveActiveChange
+} from './active-change-resolver.mjs';
+import {
+  getLatestGateResult
+} from './aif-gate-result.mjs';
+import {
+  collectGeneratedRules as defaultCollectGeneratedRules
+} from './openspec-execution-context.mjs';
+import {
+  readLatestVerificationEvidence as defaultReadLatestVerificationEvidence
+} from './openspec-verification-context.mjs';
+import {
+  detectOpenSpec as defaultDetectOpenSpec,
+  getOpenSpecStatus as defaultGetOpenSpecStatus,
+  validateOpenSpecChange as defaultValidateOpenSpecChange
+} from './openspec-runner.mjs';
+import {
+  validateOpenSpecArtifactContract as defaultValidateOpenSpecArtifactContract
+} from './openspec-artifact-validator.mjs';
+import {
+  readOpenSpecCoverageMatrix as defaultReadOpenSpecCoverageMatrix
+} from './openspec-coverage-matrix.mjs';
+import {
+  readOpenSpecPolicy,
+  readOpenSpecRulesGateEvidence as defaultReadOpenSpecRulesGateEvidence
+} from './openspec-policy.mjs';
+
+const execFileAsync = promisify(execFile);
+
+export const DONE_READINESS_SCHEMA_VERSION = 1;
+export const DONE_READINESS_GATE = 'done-readiness';
+export const DONE_READINESS_FILE = 'done-readiness.json';
+
+const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
+const DEFAULT_STATE_DIR = path.join('.ai-factory', 'state');
+const CHECKS = Object.freeze([
+  'openspec_validate',
+  'openspec_status',
+  'artifact_contract',
+  'generated_rules',
+  'rules_gate',
+  'coverage',
+  'verify_gate',
+  'dirty_workspace'
+]);
+const SUGGESTION_PRIORITY = Object.freeze([
+  'generated_rules',
+  'rules_gate',
+  'coverage',
+  'verify_gate',
+  'artifact_contract',
+  'openspec_validate',
+  'openspec_status',
+  'dirty_workspace'
+]);
+
+export async function buildOpenSpecDoneReadiness(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const resolveActiveChange = options.resolveActiveChange ?? defaultResolveActiveChange;
+  const ensureRuntimeLayout = options.ensureRuntimeLayout ?? defaultEnsureRuntimeLayout;
+  const resolved = await resolveActiveChange({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId: options.changeId,
+    getCurrentBranch: options.getCurrentBranch
+  });
+
+  if (!resolved.ok) {
+    return createReadinessResult({
+      changeId: resolved.changeId ?? null,
+      checks: emptyChecks('fail'),
+      diagnostics: [{
+        check: 'openspec_validate',
+        level: 'fail',
+        blocking: true,
+        code: resolved.errors?.[0]?.code ?? 'active-change-unresolved',
+        message: resolved.errors?.[0]?.message ?? 'Unable to resolve an active OpenSpec change.',
+        suggested_next: {
+          command: '/aif-mode status',
+          reason: 'select or pass an active OpenSpec change before checking done readiness'
+        }
+      }],
+      paths: {},
+      resolver: createResolverSummary(resolved)
+    });
+  }
+
+  const layout = await ensureRuntimeLayout(resolved.changeId, {
+    rootDir,
+    cwd: options.cwd,
+    stateDir: options.stateDir ?? DEFAULT_STATE_DIR,
+    qaDir: options.qaDir ?? DEFAULT_QA_DIR
+  });
+  assertSafeRuntimePath(rootDir, layout.qaPath, 'Done readiness QA path');
+  assertSafeRuntimePath(rootDir, layout.statePath, 'Done readiness state path');
+
+  const policy = options.policy ?? await readOpenSpecPolicy({ ...options, rootDir });
+  const checks = emptyChecks('pass');
+  const diagnostics = [];
+  const context = {
+    resolver: createResolverSummary(resolved),
+    paths: {
+      change: resolved.changePath,
+      qa: layout.qaPath,
+      state: layout.statePath,
+      readiness: toPosix(path.relative(rootDir, path.join(layout.qaPath, DONE_READINESS_FILE)))
+    },
+    effectivePolicy: policy,
+    openspec: null,
+    validation: null,
+    status: null,
+    artifactContract: null,
+    generatedRules: null,
+    rulesGate: null,
+    coverage: null,
+    verification: null,
+    workingTree: null
+  };
+
+  const openspec = await inspectOpenSpecCapability(rootDir, options);
+  context.openspec = openspec;
+  const validation = await inspectOpenSpecValidation(resolved.changeId, {
+    ...options,
+    rootDir,
+    openspec,
+    policy
+  });
+  context.validation = validation.value;
+  recordCheck(checks, diagnostics, validation);
+
+  const status = await inspectOpenSpecStatus(resolved.changeId, {
+    ...options,
+    rootDir,
+    openspec,
+    policy
+  });
+  context.status = status.value;
+  recordCheck(checks, diagnostics, status);
+
+  const artifactContract = await inspectArtifactContract(resolved.changeId, {
+    ...options,
+    rootDir
+  });
+  context.artifactContract = artifactContract.value;
+  recordCheck(checks, diagnostics, artifactContract);
+
+  const generatedRules = await inspectGeneratedRules(resolved.changeId, {
+    ...options,
+    rootDir,
+    policy
+  });
+  context.generatedRules = generatedRules.value;
+  recordCheck(checks, diagnostics, generatedRules);
+
+  const rulesGate = await inspectRulesGate(resolved.changeId, {
+    ...options,
+    rootDir,
+    qaPath: layout.qaPath,
+    policy
+  });
+  context.rulesGate = rulesGate.value;
+  recordCheck(checks, diagnostics, rulesGate);
+
+  const coverage = await inspectCoverage(resolved.changeId, {
+    ...options,
+    rootDir,
+    qaPath: layout.qaPath,
+    policy
+  });
+  context.coverage = coverage.value;
+  recordCheck(checks, diagnostics, coverage);
+
+  const verification = await inspectVerifyGate(resolved.changeId, {
+    ...options,
+    rootDir,
+    qaPath: layout.qaPath
+  });
+  context.verification = verification.value;
+  recordCheck(checks, diagnostics, verification);
+
+  const workingTree = await inspectDirtyWorkspace({
+    ...options,
+    rootDir
+  });
+  context.workingTree = workingTree.value;
+  recordCheck(checks, diagnostics, workingTree);
+
+  return createReadinessResult({
+    changeId: resolved.changeId,
+    checks,
+    diagnostics: dedupeDiagnostics(diagnostics),
+    paths: context.paths,
+    resolver: context.resolver,
+    context
+  });
+}
+
+export async function writeOpenSpecDoneReadiness(changeId, readiness, options = {}) {
+  const rootDir = resolveRootDir(options);
+  const normalized = normalizeChangeId(changeId ?? readiness?.change_id);
+
+  if (!normalized.ok) {
+    throw new Error(normalized.error.message);
+  }
+
+  const qaPath = resolveQaPath(rootDir, normalized.changeId, options);
+  assertSafeRuntimePath(rootDir, qaPath, 'Done readiness QA path');
+  await mkdir(qaPath, { recursive: true });
+
+  const readinessPath = path.join(qaPath, DONE_READINESS_FILE);
+  const relativePath = toPosix(path.relative(rootDir, readinessPath));
+  const persisted = {
+    ...readiness,
+    change_id: normalized.changeId,
+    evidence_path: relativePath
+  };
+  if (readiness?.context !== undefined) {
+    Object.defineProperty(persisted, 'context', {
+      value: readiness.context,
+      enumerable: false,
+      configurable: false,
+      writable: false
+    });
+  }
+  await writeFile(readinessPath, `${JSON.stringify(persisted, null, 2)}\n`, 'utf8');
+
+  return {
+    ok: true,
+    changeId: normalized.changeId,
+    path: relativePath,
+    readiness: persisted,
+    warnings: [],
+    errors: []
+  };
+}
+
+export function summarizeOpenSpecDoneReadiness(readiness, options = {}) {
+  const result = readiness ?? {};
+  const lines = [
+    `Done readiness: ${String(result.status ?? 'unknown').toUpperCase()}`,
+    `Change: ${result.change_id ?? 'unresolved'}`,
+    `Blocking: ${result.blocking ? 'yes' : 'no'}`
+  ];
+
+  const evidencePath = result.evidence_path ?? options.evidencePath;
+  if (evidencePath) {
+    lines.push(`Evidence: ${evidencePath}`);
+  }
+
+  lines.push('', 'Checks:');
+  const checks = result.checks ?? {};
+  for (const check of CHECKS) {
+    lines.push(`- ${String(checks[check] ?? 'missing').toUpperCase()} ${check}`);
+  }
+
+  const diagnostics = Array.isArray(result.diagnostics) ? result.diagnostics : [];
+  if (diagnostics.length > 0) {
+    lines.push('', 'Diagnostics:');
+    for (const diagnostic of diagnostics) {
+      const suffix = diagnostic.path ? ` (${diagnostic.path})` : '';
+      lines.push(`- ${String(diagnostic.level ?? 'warn').toUpperCase()} ${diagnostic.code}${suffix}: ${diagnostic.message}`);
+    }
+  }
+
+  if (result.suggested_next) {
+    lines.push(
+      '',
+      `Suggested next: ${result.suggested_next.command}`,
+      `Reason: ${result.suggested_next.reason}`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function parseDoneReadinessArgs(argv) {
+  const args = Array.from(argv ?? []);
+  const parsed = {
+    ok: true,
+    changeId: null,
+    json: false,
+    write: true
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--change') {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        return invalidArgs('Missing value for --change.');
+      }
+      parsed.changeId = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--json') {
+      parsed.json = true;
+      continue;
+    }
+
+    if (arg === '--no-write') {
+      parsed.write = false;
+      continue;
+    }
+
+    return invalidArgs(`Unknown option: ${arg}.`);
+  }
+
+  return parsed;
+}
+
+export async function runDoneReadinessCommand(argv, options = {}) {
+  const parsed = parseDoneReadinessArgs(argv);
+  if (!parsed.ok) {
+    return {
+      exitCode: 2,
+      stdout: '',
+      stderr: `${parsed.error}\n`
+    };
+  }
+
+  const readiness = await buildOpenSpecDoneReadiness({
+    ...options,
+    changeId: parsed.changeId ?? options.changeId
+  });
+  let output = readiness;
+
+  if (parsed.write && readiness.change_id) {
+    const written = await writeOpenSpecDoneReadiness(readiness.change_id, readiness, options);
+    output = written.readiness;
+  }
+
+  const stdout = parsed.json
+    ? `${JSON.stringify(output, null, 2)}\n`
+    : `${summarizeOpenSpecDoneReadiness(output)}\n`;
+  const unresolved = output.change_id === null || output.change_id === undefined;
+  const exitCode = unresolved ? 2 : output.blocking ? 1 : 0;
+
+  return {
+    exitCode,
+    stdout,
+    stderr: ''
+  };
+}
+
+async function inspectOpenSpecCapability(rootDir, options) {
+  const detectOpenSpec = options.detectOpenSpec ?? defaultDetectOpenSpec;
+  try {
+    const detection = await detectOpenSpec(createRunOptions(options, rootDir));
+    return {
+      available: Boolean(detection?.available),
+      canValidate: Boolean(detection?.canValidate),
+      canArchive: Boolean(detection?.canArchive),
+      version: detection?.version ?? null,
+      command: detection?.command ?? 'openspec',
+      reason: detection?.reason ?? null,
+      errors: detection?.errors ?? []
+    };
+  } catch (err) {
+    return {
+      available: false,
+      canValidate: false,
+      canArchive: false,
+      version: null,
+      command: 'openspec',
+      reason: err?.code ?? 'openspec-detection-failed',
+      errors: [{
+        code: err?.code ?? 'openspec-detection-failed',
+        message: err?.message ?? 'OpenSpec CLI capability detection failed.'
+      }]
+    };
+  }
+}
+
+async function inspectOpenSpecValidation(changeId, options) {
+  const required = Boolean(options.policy?.requirements?.cli?.done);
+  if (!options.openspec?.canValidate) {
+    return checkResult({
+      check: 'openspec_validate',
+      level: required ? 'fail' : 'warn',
+      blocking: required,
+      code: required ? 'openspec-cli-required-for-done' : 'openspec-cli-unavailable',
+      message: required
+        ? 'OpenSpec CLI validation capability is required before /aif-done can archive.'
+        : 'OpenSpec CLI validation capability is unavailable; continuing because done CLI is not required.',
+      value: null,
+      suggestedNext: {
+        command: `/aif-done ${changeId}`,
+        reason: 'install a compatible OpenSpec CLI before archive-required finalization'
+      }
+    });
+  }
+
+  const validateOpenSpecChange = options.validateOpenSpecChange ?? defaultValidateOpenSpecChange;
+  const raw = await validateOpenSpecChange(changeId, createRunOptions(options, options.rootDir));
+  const validation = normalizeCommandResult(raw);
+
+  if (validation.ok) {
+    return checkResult({
+      check: 'openspec_validate',
+      level: 'pass',
+      code: 'openspec-validation-pass',
+      message: 'OpenSpec validation passed.',
+      value: validation
+    });
+  }
+
+  return checkResult({
+    check: 'openspec_validate',
+    level: 'fail',
+    blocking: true,
+    code: 'openspec-validation-failed',
+    message: validation.error?.message ?? 'OpenSpec validation failed before done finalization.',
+    value: validation,
+    suggestedNext: {
+      command: `/aif-verify ${changeId}`,
+      reason: 'fix OpenSpec validation errors and rerun verification before done finalization'
+    }
+  });
+}
+
+async function inspectOpenSpecStatus(changeId, options) {
+  if (!options.openspec?.canValidate) {
+    const allowed = Boolean(options.policy?.allowWarnOnDone?.openspecStatus);
+    return checkResult({
+      check: 'openspec_status',
+      level: allowed ? 'warn' : 'fail',
+      blocking: !allowed,
+      code: 'openspec-status-unavailable',
+      message: allowed
+        ? 'OpenSpec status is unavailable and accepted by done warning policy.'
+        : 'OpenSpec status is unavailable and allowWarnOnDone.openspecStatus is false.',
+      value: null,
+      suggestedNext: {
+        command: `/aif-done ${changeId}`,
+        reason: 'make OpenSpec status available before archive-required finalization'
+      }
+    });
+  }
+
+  const getOpenSpecStatus = options.getOpenSpecStatus ?? defaultGetOpenSpecStatus;
+  const raw = await getOpenSpecStatus(changeId, createRunOptions(options, options.rootDir));
+  const status = normalizeCommandResult(raw);
+
+  if (status.ok) {
+    return checkResult({
+      check: 'openspec_status',
+      level: 'pass',
+      code: 'openspec-status-pass',
+      message: 'OpenSpec status passed.',
+      value: status
+    });
+  }
+
+  const allowed = Boolean(options.policy?.allowWarnOnDone?.openspecStatus);
+  return checkResult({
+    check: 'openspec_status',
+    level: allowed ? 'warn' : 'fail',
+    blocking: !allowed,
+    code: 'openspec-status-warn',
+    message: allowed
+      ? 'OpenSpec status returned warnings accepted by done policy.'
+      : 'OpenSpec status returned warnings and allowWarnOnDone.openspecStatus is false.',
+    value: status,
+    suggestedNext: {
+      command: `/aif-mode doctor --change ${changeId}`,
+      reason: 'inspect OpenSpec status warnings before done finalization'
+    }
+  });
+}
+
+async function inspectArtifactContract(changeId, options) {
+  const validateOpenSpecArtifactContract = options.validateOpenSpecArtifactContract ?? defaultValidateOpenSpecArtifactContract;
+  const result = await validateOpenSpecArtifactContract({
+    ...options,
+    changeId,
+    requireVerificationEvidence: true
+  });
+
+  if (result?.status === 'pass') {
+    return checkResult({
+      check: 'artifact_contract',
+      level: 'pass',
+      code: 'artifact-contract-pass',
+      message: 'AIFHub artifact contract passed.',
+      value: result
+    });
+  }
+
+  const failing = (result?.checks ?? []).find((check) => check.status === 'fail')
+    ?? (result?.checks ?? []).find((check) => check.status === 'warn');
+  return checkResult({
+    check: 'artifact_contract',
+    level: result?.status === 'warn' ? 'warn' : 'fail',
+    blocking: true,
+    code: `artifact-contract-${result?.status ?? 'missing'}`,
+    message: failing?.message ?? 'AIFHub artifact contract must pass before archive.',
+    path: failing?.path,
+    value: result,
+    suggestedNext: result?.suggested_next ?? {
+      command: `/aif-mode doctor --change ${changeId}`,
+      reason: 'resolve AIFHub artifact contract diagnostics before done finalization'
+    }
+  });
+}
+
+async function inspectGeneratedRules(changeId, options) {
+  const collectGeneratedRules = options.collectGeneratedRules ?? defaultCollectGeneratedRules;
+  const result = await collectGeneratedRules(changeId, {
+    ...options,
+    rootDir: options.rootDir
+  });
+  const diagnostics = [
+    ...(result?.errors ?? []),
+    ...(result?.warnings ?? [])
+  ];
+
+  if (diagnostics.length === 0) {
+    return checkResult({
+      check: 'generated_rules',
+      level: 'pass',
+      code: 'generated-rules-pass',
+      message: 'Generated OpenSpec rules are present and current.',
+      value: result
+    });
+  }
+
+  const required = Boolean(options.policy?.requirements?.generatedRules?.done);
+  const first = diagnostics[0] ?? {};
+  return checkResult({
+    check: 'generated_rules',
+    level: required ? 'fail' : 'warn',
+    blocking: required,
+    code: first.code ?? 'generated-rules-not-current',
+    message: first.message ?? 'Generated OpenSpec rules are missing or stale.',
+    path: first.path ?? '.ai-factory/rules/generated',
+    value: result,
+    suggestedNext: {
+      command: `/aif-mode sync --change ${changeId}`,
+      reason: 'generated rules are missing or stale'
+    }
+  });
+}
+
+async function inspectRulesGate(changeId, options) {
+  const readRulesGate = options.readOpenSpecRulesGateEvidence ?? defaultReadOpenSpecRulesGateEvidence;
+  const rulesGate = await readRulesGate(changeId, {
+    ...options,
+    rootDir: options.rootDir,
+    qaPath: options.qaPath
+  });
+  const status = rulesGate?.status ?? 'missing';
+
+  if (status === 'pass') {
+    return checkResult({
+      check: 'rules_gate',
+      level: 'pass',
+      code: 'rules-gate-pass',
+      message: 'Rules gate passed.',
+      path: rulesGate.path,
+      value: rulesGate
+    });
+  }
+
+  const allowWarn = Boolean(options.policy?.allowWarnOnDone?.rules);
+  const required = Boolean(options.policy?.requirements?.rulesPass?.done);
+  const acceptedWarn = status === 'warn' && allowWarn;
+  const blocking = acceptedWarn ? false : required;
+  const error = rulesGate?.errors?.[0];
+  return checkResult({
+    check: 'rules_gate',
+    level: blocking ? 'fail' : 'warn',
+    blocking,
+    code: error?.code ?? `rules-gate-${status}`,
+    message: acceptedWarn
+      ? 'Rules gate completed with warnings accepted by done policy.'
+      : error?.message ?? `Rules gate evidence is ${status}.`,
+    path: rulesGate?.path,
+    value: rulesGate,
+    suggestedNext: {
+      command: '/aif-rules-check',
+      reason: 'rules gate evidence must pass before done finalization'
+    }
+  });
+}
+
+async function inspectCoverage(changeId, options) {
+  const readCoverage = options.readOpenSpecCoverageMatrix ?? defaultReadOpenSpecCoverageMatrix;
+  const coverage = await readCoverage(changeId, {
+    ...options,
+    rootDir: options.rootDir,
+    qaPath: options.qaPath
+  });
+  const coverageStatus = coverage?.coverage?.status ?? (coverage?.exists ? 'invalid' : 'missing');
+  const allowWarn = Boolean(options.policy?.allowWarnOnDone?.coverage);
+  const required = Boolean(options.policy?.requirements?.specCoverage?.done);
+
+  if (coverage?.exists && coverage.ok && !coverage.stale && coverageStatus === 'pass') {
+    return checkResult({
+      check: 'coverage',
+      level: 'pass',
+      code: 'coverage-pass',
+      message: 'OpenSpec coverage passed.',
+      path: coverage.relativePath,
+      value: coverage
+    });
+  }
+
+  if (coverage?.exists && coverage.ok && !coverage.stale && coverageStatus === 'warn' && allowWarn) {
+    return checkResult({
+      check: 'coverage',
+      level: 'warn',
+      blocking: false,
+      code: 'coverage-policy-warn',
+      message: 'OpenSpec coverage completed with warnings accepted by done policy.',
+      path: coverage.relativePath,
+      value: coverage
+    });
+  }
+
+  const blocking = coverageStatus === 'warn' && !allowWarn ? true : required;
+  const code = !coverage?.exists
+    ? 'coverage-evidence-missing'
+    : !coverage.ok
+      ? 'coverage-evidence-invalid'
+      : coverage.stale
+        ? 'coverage-evidence-stale'
+        : `coverage-policy-${coverageStatus}`;
+  const message = coverage?.diagnostics?.[0]?.message
+    ?? (coverageStatus === 'warn'
+      ? 'OpenSpec coverage completed with warnings and allowWarnOnDone.coverage is false.'
+      : `OpenSpec coverage evidence is ${coverageStatus}.`);
+  return checkResult({
+    check: 'coverage',
+    level: blocking ? 'fail' : 'warn',
+    blocking,
+    code,
+    message,
+    path: coverage?.relativePath,
+    value: coverage,
+    suggestedNext: {
+      command: `/aif-verify ${changeId}`,
+      reason: 'coverage evidence must be current and acceptable before done finalization'
+    }
+  });
+}
+
+async function inspectVerifyGate(changeId, options) {
+  const readLatestVerificationEvidence = options.readLatestVerificationEvidence ?? defaultReadLatestVerificationEvidence;
+  const evidence = await readLatestVerificationEvidence(changeId, {
+    ...options,
+    rootDir: options.rootDir,
+    qaPath: options.qaPath
+  });
+  const verifyContent = evidence?.verify?.content ?? '';
+  const gate = evidence?.gateResult ?? getLatestGateResult(verifyContent, { gate: 'verify' });
+
+  if (!evidence?.verify?.exists) {
+    return checkResult({
+      check: 'verify_gate',
+      level: 'fail',
+      blocking: true,
+      code: 'verification-evidence-missing',
+      message: `Run /aif-verify ${changeId} before /aif-done.`,
+      path: evidence?.verify?.path,
+      value: evidence,
+      suggestedNext: {
+        command: `/aif-verify ${changeId}`,
+        reason: 'verification evidence is required before done finalization'
+      }
+    });
+  }
+
+  if (Array.isArray(evidence.errors) && evidence.errors.length > 0) {
+    return checkResult({
+      check: 'verify_gate',
+      level: 'fail',
+      blocking: true,
+      code: 'verification-not-passed',
+      message: evidence.errors[0]?.message ?? 'Verification evidence contains errors.',
+      path: evidence.verify.path,
+      value: evidence,
+      suggestedNext: {
+        command: `/aif-verify ${changeId}`,
+        reason: 'rerun verification after fixing verification evidence errors'
+      }
+    });
+  }
+
+  if (gate === null || gate === undefined) {
+    return verifyGateFailure(changeId, evidence, 'verification-gate-missing', 'Verification evidence is missing the final aif-gate-result block for the verify gate.');
+  }
+
+  if (!gate.ok) {
+    return verifyGateFailure(changeId, evidence, 'verification-gate-invalid', 'Verification evidence contains an invalid final aif-gate-result block for the verify gate.');
+  }
+
+  if (gate.result.status === 'fail') {
+    return checkResult({
+      check: 'verify_gate',
+      level: 'fail',
+      blocking: true,
+      code: 'verification-gate-failed',
+      message: 'The latest verify gate result failed.',
+      path: evidence.verify.path,
+      value: evidence,
+      suggestedNext: {
+        command: `/aif-fix ${changeId}`,
+        reason: 'fix the failing verification evidence before rerunning /aif-verify'
+      }
+    });
+  }
+
+  if (/\b(Code verification:\s*PENDING|Code verification:\s*BLOCKED)\b/i.test(verifyContent) || /\b(Verdict:\s*FAIL|OpenSpec validation:\s*FAIL|\/aif-verify:\s*FAIL)\b/i.test(verifyContent)) {
+    return verifyGateFailure(changeId, evidence, 'verification-ambiguous', 'Verification evidence is ambiguous; rerun /aif-verify before finalizing.');
+  }
+
+  if (!hasFinalPassSignal(verifyContent)) {
+    return verifyGateFailure(changeId, evidence, 'verification-ambiguous', 'Verification evidence is ambiguous; rerun /aif-verify before finalizing.');
+  }
+
+  return checkResult({
+    check: 'verify_gate',
+    level: gate.result.status === 'warn' ? 'warn' : 'pass',
+    blocking: false,
+    code: gate.result.status === 'warn' ? 'verification-gate-warn' : 'verification-gate-pass',
+    message: gate.result.status === 'warn'
+      ? 'The latest verify gate completed with warnings.'
+      : 'The latest verify gate passed.',
+    path: evidence.verify.path,
+    value: evidence
+  });
+}
+
+function verifyGateFailure(changeId, evidence, code, message) {
+  return checkResult({
+    check: 'verify_gate',
+    level: 'fail',
+    blocking: true,
+    code,
+    message,
+    path: evidence?.verify?.path,
+    value: evidence,
+    suggestedNext: {
+      command: `/aif-verify ${changeId}`,
+      reason: 'verification evidence must pass before done finalization'
+    }
+  });
+}
+
+async function inspectDirtyWorkspace(options) {
+  const workingTree = await detectWorkingTreeState(options);
+
+  if (!workingTree.dirty && workingTree.ok && workingTree.isGitRepo) {
+    return checkResult({
+      check: 'dirty_workspace',
+      level: 'pass',
+      code: 'working-tree-clean',
+      message: 'Working tree is clean.',
+      value: workingTree
+    });
+  }
+
+  if (workingTree.ok) {
+    return checkResult({
+      check: 'dirty_workspace',
+      level: workingTree.dirty ? 'warn' : 'warn',
+      blocking: false,
+      code: workingTree.warnings?.[0]?.code ?? 'working-tree-state-recorded',
+      message: workingTree.warnings?.[0]?.message ?? 'Working tree state was recorded.',
+      value: workingTree
+    });
+  }
+
+  return checkResult({
+    check: 'dirty_workspace',
+    level: 'fail',
+    blocking: true,
+    code: workingTree.errors?.[0]?.code ?? 'dirty-working-tree',
+    message: workingTree.errors?.[0]?.message ?? 'Working tree is not ready for archive.',
+    value: workingTree,
+    suggestedNext: {
+      command: 'git status --short',
+      reason: 'commit or stash local changes before /aif-done, or rerun with explicit dirty-state recording'
+    }
+  });
+}
+
+export async function detectWorkingTreeState(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const gitStatus = options.gitStatus ?? defaultGitStatus;
+  let status;
+
+  try {
+    status = await gitStatus({ cwd: rootDir });
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      return createNonGitWorkingTree(err.message);
+    }
+
+    throw err;
+  }
+
+  const exitCode = status?.exitCode ?? 0;
+  const stdout = normalizeOutput(status?.stdout);
+  const stderr = normalizeOutput(status?.stderr);
+
+  if (exitCode !== 0) {
+    if (/not a git repository/i.test(stderr) || /not a git repository/i.test(stdout)) {
+      return createNonGitWorkingTree(stderr || stdout);
+    }
+
+    return {
+      ok: false,
+      isGitRepo: true,
+      dirty: false,
+      entries: [],
+      warnings: [],
+      errors: [{
+        code: 'git-status-failed',
+        message: 'Unable to inspect working tree state.',
+        detail: stderr || stdout || null
+      }]
+    };
+  }
+
+  const entries = stdout.split(/\r?\n/).filter((line) => line.length > 0);
+  const dirty = entries.length > 0;
+
+  if (!dirty) {
+    return {
+      ok: true,
+      isGitRepo: true,
+      dirty: false,
+      entries: [],
+      warnings: [],
+      errors: []
+    };
+  }
+
+  if (options.allowDirty || options.recordDirtyState) {
+    return {
+      ok: true,
+      isGitRepo: true,
+      dirty: true,
+      entries,
+      warnings: [{
+        code: 'dirty-working-tree-recorded',
+        message: 'Working tree dirty state was recorded because explicit dirty-state recording is enabled.'
+      }],
+      errors: []
+    };
+  }
+
+  return {
+    ok: false,
+    isGitRepo: true,
+    dirty: true,
+    entries,
+    warnings: [],
+    errors: [{
+      code: 'dirty-working-tree',
+      message: 'Working tree has uncommitted changes. Commit/stash or run with explicit dirty-state recording.'
+    }]
+  };
+}
+
+function createReadinessResult({ changeId, checks, diagnostics, paths, resolver, context }) {
+  const blocking = diagnostics.some((diagnostic) => diagnostic.blocking);
+  const status = blocking ? 'fail' : diagnostics.some((diagnostic) => diagnostic.level === 'warn') ? 'warn' : 'pass';
+  const suggestedNext = chooseSuggestedNext(diagnostics);
+
+  const result = {
+    schema_version: DONE_READINESS_SCHEMA_VERSION,
+    gate: DONE_READINESS_GATE,
+    change_id: changeId ?? null,
+    status,
+    blocking,
+    checks,
+    diagnostics: diagnostics.map(stripInternalDiagnosticFields),
+    suggested_next: suggestedNext,
+    paths,
+    resolver
+  };
+
+  if (context !== undefined) {
+    Object.defineProperty(result, 'context', {
+      value: context,
+      enumerable: false,
+      configurable: false,
+      writable: false
+    });
+  }
+
+  return result;
+}
+
+function recordCheck(checks, diagnostics, result) {
+  checks[result.check] = result.level;
+
+  if (result.level !== 'pass') {
+    diagnostics.push({
+      check: result.check,
+      level: result.level,
+      blocking: Boolean(result.blocking),
+      code: result.code,
+      message: result.message,
+      path: result.path,
+      value: result.value,
+      suggested_next: result.suggestedNext
+    });
+  }
+}
+
+function checkResult({ check, level, blocking = level === 'fail', code, message, path: checkPath, value, suggestedNext }) {
+  return {
+    check,
+    level,
+    blocking,
+    code,
+    message,
+    path: checkPath,
+    value,
+    suggestedNext
+  };
+}
+
+function chooseSuggestedNext(diagnostics) {
+  const blocking = diagnostics.filter((diagnostic) => diagnostic.blocking && diagnostic.suggested_next);
+
+  for (const check of SUGGESTION_PRIORITY) {
+    const diagnostic = blocking.find((item) => item.check === check);
+    if (diagnostic?.suggested_next) {
+      return diagnostic.suggested_next;
+    }
+  }
+
+  return blocking[0]?.suggested_next ?? null;
+}
+
+function stripInternalDiagnosticFields(diagnostic) {
+  const result = {
+    check: diagnostic.check,
+    level: diagnostic.level,
+    blocking: Boolean(diagnostic.blocking),
+    code: diagnostic.code,
+    message: diagnostic.message
+  };
+
+  if (diagnostic.path !== undefined && diagnostic.path !== null) {
+    result.path = diagnostic.path;
+  }
+
+  if (diagnostic.suggested_next !== undefined && diagnostic.suggested_next !== null) {
+    result.suggested_next = diagnostic.suggested_next;
+  }
+
+  return result;
+}
+
+function emptyChecks(status) {
+  return Object.fromEntries(CHECKS.map((check) => [check, status]));
+}
+
+function createResolverSummary(result) {
+  return {
+    source: result?.source ?? null,
+    candidates: result?.candidates ?? [],
+    warnings: result?.warnings ?? []
+  };
+}
+
+function normalizeCommandResult(result) {
+  return {
+    ok: Boolean(result?.ok),
+    command: result?.command ?? 'openspec',
+    args: Array.from(result?.args ?? []),
+    exitCode: result?.exitCode ?? null,
+    json: result?.json ?? null,
+    stdout: normalizeOutput(result?.stdout),
+    stderr: normalizeOutput(result?.stderr),
+    error: result?.error ?? (result?.ok ? null : {
+      code: 'openspec-command-failed',
+      message: normalizeOutput(result?.stderr) || normalizeOutput(result?.stdout) || 'OpenSpec command failed.'
+    })
+  };
+}
+
+function hasFinalPassSignal(content = '') {
+  return /\b(Verdict:\s*PASS|\/aif-verify:\s*PASS|Code verification:\s*PASS)\b/i.test(content);
+}
+
+function resolveQaPath(rootDir, changeId, options = {}) {
+  if (options.qaPath !== undefined) {
+    return path.resolve(options.qaPath);
+  }
+
+  const qaRoot = path.resolve(rootDir, options.qaDir ?? DEFAULT_QA_DIR);
+  return path.join(qaRoot, changeId);
+}
+
+function createRunOptions(options, rootDir) {
+  const runOptions = {
+    cwd: rootDir,
+    command: options.command,
+    env: options.env,
+    executor: options.executor,
+    nodeVersion: options.nodeVersion
+  };
+
+  for (const key of Object.keys(runOptions)) {
+    if (runOptions[key] === undefined) {
+      delete runOptions[key];
+    }
+  }
+
+  return runOptions;
+}
+
+async function defaultGitStatus({ cwd }) {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd,
+      windowsHide: true
+    });
+
+    return {
+      exitCode: 0,
+      stdout,
+      stderr
+    };
+  } catch (err) {
+    return {
+      exitCode: typeof err?.code === 'number' ? err.code : (err?.status ?? 1),
+      stdout: normalizeOutput(err?.stdout),
+      stderr: normalizeOutput(err?.stderr ?? err?.message)
+    };
+  }
+}
+
+function createNonGitWorkingTree(detail) {
+  return {
+    ok: true,
+    isGitRepo: false,
+    dirty: false,
+    entries: [],
+    warnings: [{
+      code: 'not-a-git-repository',
+      message: 'Working tree state could not be checked because this is not a git repository.',
+      detail
+    }],
+    errors: []
+  };
+}
+
+function assertSafeRuntimePath(rootDir, targetPath, label) {
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedTarget = path.resolve(targetPath);
+
+  if (!isWithinDirectory(resolvedTarget, resolvedRoot)) {
+    throw new Error(`${label} escapes repository root: ${resolvedTarget}`);
+  }
+
+  for (const forbiddenDir of [
+    path.join(resolvedRoot, 'openspec', 'changes'),
+    path.join(resolvedRoot, '.ai-factory', 'plans')
+  ]) {
+    if (isWithinDirectory(resolvedTarget, forbiddenDir)) {
+      throw new Error(`${label} must stay outside canonical OpenSpec changes and legacy plan folders: ${resolvedTarget}`);
+    }
+  }
+}
+
+function isWithinDirectory(targetPath, directoryPath) {
+  const relative = path.relative(directoryPath, targetPath);
+  return relative.length === 0 || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function resolveRootDir(options = {}) {
+  return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function normalizeOutput(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  const result = [];
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic?.check ?? ''}:${diagnostic?.code ?? ''}:${diagnostic?.message ?? ''}:${diagnostic?.path ?? ''}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(diagnostic);
+    }
+  }
+
+  return result;
+}
+
+function invalidArgs(error) {
+  return {
+    ok: false,
+    error
+  };
+}
+
+async function main() {
+  const result = await runDoneReadinessCommand(process.argv.slice(2));
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  process.exitCode = result.exitCode;
+}
+
+const isDirect = process.argv[1] !== undefined
+  && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirect) {
+  main().catch((err) => {
+    process.stderr.write(`${err?.message ?? String(err)}\n`);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/openspec-done-readiness.test.mjs
+++ b/scripts/openspec-done-readiness.test.mjs
@@ -1,0 +1,396 @@
+// openspec-done-readiness.test.mjs - tests for OpenSpec done readiness gate
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildOpenSpecDoneReadiness,
+  detectWorkingTreeState,
+  runDoneReadinessCommand,
+  summarizeOpenSpecDoneReadiness,
+  writeOpenSpecDoneReadiness
+} from './openspec-done-readiness.mjs';
+import {
+  createGateResult,
+  renderGateResultBlock
+} from './aif-gate-result.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-done-readiness-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createOpenSpecChange(rootDir, changeId = 'add-oauth') {
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, '# Tasks\n\n- [x] 1.1 Implement\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/specs/auth/spec.md`, [
+    '# Delta for Auth',
+    '',
+    '## ADDED Requirements',
+    '',
+    '### Requirement: OAuth login',
+    '',
+    'The system MUST support OAuth login.',
+    '',
+    '#### Scenario: Successful login',
+    '',
+    '- GIVEN a valid provider response',
+    '- WHEN the user logs in',
+    '- THEN a session is created.',
+    ''
+  ].join('\n'));
+}
+
+function availableCliDetection() {
+  return {
+    available: true,
+    canValidate: true,
+    canArchive: true,
+    version: '1.3.1',
+    command: 'openspec',
+    reason: null,
+    errors: []
+  };
+}
+
+function missingCliDetection() {
+  return {
+    available: false,
+    canValidate: false,
+    canArchive: false,
+    version: null,
+    command: 'openspec',
+    reason: 'missing-cli',
+    errors: [{ code: 'missing-cli', message: 'OpenSpec CLI is not available.' }]
+  };
+}
+
+function commandResult(ok = true, overrides = {}) {
+  return {
+    ok,
+    command: 'openspec',
+    args: [],
+    exitCode: ok ? 0 : 1,
+    stdout: ok ? '{"ok":true}' : '',
+    stderr: ok ? '' : 'failed',
+    json: ok ? { ok: true } : null,
+    error: ok ? null : { code: 'openspec-failed', message: 'OpenSpec command failed.' },
+    ...overrides
+  };
+}
+
+function verificationEvidence(overrides = {}) {
+  const status = overrides.gateStatus ?? 'pass';
+  const content = overrides.content ?? [
+    '# Verify: add-oauth',
+    '',
+    'Verdict: PASS',
+    'Code verification: PASS',
+    '',
+    renderGateResultBlock(createGateResult({
+      gate: 'verify',
+      status,
+      blockers: status === 'fail'
+        ? [{ id: 'verify-failed', severity: 'error', summary: 'Verify failed.' }]
+        : []
+    })),
+    ''
+  ].join('\n');
+
+  return {
+    ok: true,
+    changeId: 'add-oauth',
+    validation: { ok: true, skipped: false },
+    status: { ok: true },
+    verify: {
+      exists: overrides.verifyExists ?? true,
+      path: '.ai-factory/qa/add-oauth/verify.md',
+      content
+    },
+    gateResult: overrides.gateResult,
+    warnings: [],
+    errors: overrides.errors ?? []
+  };
+}
+
+function coverageEvidence(overrides = {}) {
+  const status = overrides.status ?? 'pass';
+  return {
+    ok: overrides.ok ?? true,
+    exists: overrides.exists ?? true,
+    stale: overrides.stale ?? false,
+    changeId: 'add-oauth',
+    relativePath: '.ai-factory/qa/add-oauth/coverage.json',
+    coverage: {
+      schema_version: 1,
+      change_id: 'add-oauth',
+      status,
+      blocking: status === 'fail',
+      policy: { mode: 'strict', missing_requirement: 'fail' },
+      requirements: [],
+      summary: { covered: 1, partial: 0, missing: 0, not_applicable: 0 },
+      sources: [],
+      stale: overrides.stale ?? false,
+      diagnostics: [],
+      warnings: [],
+      errors: []
+    },
+    diagnostics: overrides.diagnostics ?? [],
+    warnings: [],
+    errors: []
+  };
+}
+
+function rulesGateEvidence(status = 'pass') {
+  return {
+    exists: true,
+    ok: status === 'pass',
+    status,
+    path: '.ai-factory/qa/add-oauth/rules.md',
+    gateResult: null,
+    warnings: [],
+    errors: status === 'pass' ? [] : [{
+      code: `rules-gate-${status}`,
+      message: `Rules gate is ${status}.`,
+      path: '.ai-factory/qa/add-oauth/rules.md'
+    }]
+  };
+}
+
+function artifactContract(status = 'pass') {
+  return {
+    schema_version: 1,
+    validator: 'aifhub-openspec-artifact-contract',
+    change_id: 'add-oauth',
+    status,
+    blocking: status === 'fail',
+    checks: status === 'pass'
+      ? [{ id: 'generated-rules-current', status: 'pass', path: '.ai-factory/rules/generated', message: 'Generated rules are current.' }]
+      : [{ id: 'generated-rules-current', status, path: '.ai-factory/rules/generated', message: 'Generated rules are stale.' }],
+    suggested_next: status === 'pass'
+      ? null
+      : { command: '/aif-mode sync --change add-oauth', reason: 'generated rules are stale' }
+  };
+}
+
+function generatedRules(overrides = {}) {
+  return {
+    generatedRules: [],
+    warnings: overrides.warnings ?? [],
+    errors: overrides.errors ?? []
+  };
+}
+
+function passingOptions(overrides = {}) {
+  return {
+    detectOpenSpec: async () => availableCliDetection(),
+    validateOpenSpecChange: async () => commandResult(true),
+    getOpenSpecStatus: async () => commandResult(true),
+    validateOpenSpecArtifactContract: async () => artifactContract('pass'),
+    collectGeneratedRules: async () => generatedRules(),
+    readOpenSpecRulesGateEvidence: async () => rulesGateEvidence('pass'),
+    readOpenSpecCoverageMatrix: async () => coverageEvidence(),
+    readLatestVerificationEvidence: async () => verificationEvidence(),
+    gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    ...overrides
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec done readiness gate', () => {
+  it('builds and writes passing readiness under QA evidence', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions()
+    });
+    assert.equal(readiness.status, 'pass');
+    assert.equal(readiness.blocking, false);
+    assert.equal(readiness.checks.openspec_validate, 'pass');
+    assert.equal(readiness.checks.artifact_contract, 'pass');
+
+    const written = await writeOpenSpecDoneReadiness('add-oauth', readiness, { rootDir });
+    assert.equal(written.path, '.ai-factory/qa/add-oauth/done-readiness.json');
+    const persisted = JSON.parse(await readFile(path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'done-readiness.json'), 'utf8'));
+    assert.equal(persisted.gate, 'done-readiness');
+    assert.equal(Object.hasOwn(persisted, 'context'), false);
+    assert.equal(persisted.evidence_path, '.ai-factory/qa/add-oauth/done-readiness.json');
+  });
+
+  it('blocks generated-rules readiness failures with a sync suggestion', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        collectGeneratedRules: async () => generatedRules({
+          warnings: [{
+            code: 'generated-rules-stale',
+            message: 'Generated rules are stale.',
+            path: '.ai-factory/rules/generated/openspec-merged-add-oauth.md'
+          }]
+        })
+      })
+    });
+
+    assert.equal(readiness.status, 'fail');
+    assert.equal(readiness.checks.generated_rules, 'fail');
+    assert.equal(readiness.suggested_next.command, '/aif-mode sync --change add-oauth');
+  });
+
+  it('requires artifact contract pass instead of accepting warnings', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        validateOpenSpecArtifactContract: async () => artifactContract('warn')
+      })
+    });
+
+    assert.equal(readiness.status, 'fail');
+    assert.equal(readiness.checks.artifact_contract, 'warn');
+    assert.equal(readiness.diagnostics.some((diagnostic) => diagnostic.code === 'artifact-contract-warn'), true);
+  });
+
+  it('accepts OpenSpec status warnings according to done policy', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        getOpenSpecStatus: async () => commandResult(false, {
+          error: { code: 'status-warn', message: 'Status has warnings.' }
+        })
+      })
+    });
+
+    assert.equal(readiness.status, 'warn');
+    assert.equal(readiness.blocking, false);
+    assert.equal(readiness.checks.openspec_status, 'warn');
+  });
+
+  it('blocks dirty workspace unless explicit dirty recording is enabled', async () => {
+    const dirty = await detectWorkingTreeState({
+      rootDir: 'C:/tmp',
+      gitStatus: async () => ({ exitCode: 0, stdout: ' M README.md\n', stderr: '' })
+    });
+    assert.equal(dirty.ok, false);
+    assert.equal(dirty.errors[0].code, 'dirty-working-tree');
+
+    const recorded = await detectWorkingTreeState({
+      rootDir: 'C:/tmp',
+      allowDirty: true,
+      gitStatus: async () => ({ exitCode: 0, stdout: ' M README.md\n', stderr: '' })
+    });
+    assert.equal(recorded.ok, true);
+    assert.equal(recorded.warnings[0].code, 'dirty-working-tree-recorded');
+  });
+
+  it('renders the exact suggested next command and reason', async () => {
+    const summary = summarizeOpenSpecDoneReadiness({
+      change_id: 'add-oauth',
+      status: 'fail',
+      blocking: true,
+      checks: {
+        openspec_validate: 'pass',
+        openspec_status: 'pass',
+        artifact_contract: 'pass',
+        generated_rules: 'fail',
+        rules_gate: 'pass',
+        coverage: 'pass',
+        verify_gate: 'pass',
+        dirty_workspace: 'pass'
+      },
+      diagnostics: [],
+      suggested_next: {
+        command: '/aif-mode sync --change add-oauth',
+        reason: 'generated rules are missing or stale'
+      }
+    });
+
+    assert.match(summary, /Suggested next: \/aif-mode sync --change add-oauth/);
+    assert.match(summary, /Reason: generated rules are missing or stale/);
+  });
+
+  it('runs the CLI with deterministic JSON output and exit codes', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const result = await runDoneReadinessCommand(['--change', 'add-oauth', '--json'], {
+      rootDir,
+      ...passingOptions()
+    });
+
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.gate, 'done-readiness');
+    assert.equal(parsed.status, 'pass');
+  });
+
+  it('returns exit code 2 for invalid args', async () => {
+    const result = await runDoneReadinessCommand(['--change'], {});
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /Missing value for --change/);
+  });
+
+  it('returns exit code 2 for unresolved explicit changes', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir, 'existing-change');
+
+    const result = await runDoneReadinessCommand(['--change', 'missing-change', '--json'], {
+      rootDir,
+      ...passingOptions()
+    });
+
+    assert.equal(result.exitCode, 2);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.change_id, null);
+    assert.equal(parsed.diagnostics[0].code, 'explicit-change-not-found');
+  });
+
+  it('blocks missing CLI under strict done policy', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        detectOpenSpec: async () => missingCliDetection()
+      })
+    });
+
+    assert.equal(readiness.status, 'fail');
+    assert.equal(readiness.checks.openspec_validate, 'fail');
+    assert.equal(readiness.diagnostics.some((diagnostic) => diagnostic.code === 'openspec-cli-required-for-done'), true);
+  });
+});

--- a/scripts/openspec-v1-integration.test.mjs
+++ b/scripts/openspec-v1-integration.test.mjs
@@ -530,6 +530,7 @@ describe('Full OpenSpec v1 mocked paths', () => {
       rootDir,
       changeId: 'add-oauth',
       detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async () => validationResult('add-oauth'),
       getOpenSpecStatus: async () => statusResult('add-oauth'),
       gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
       archiveOpenSpecChange: async (changeId, options) => {

--- a/scripts/openspec-v1-integration.test.mjs
+++ b/scripts/openspec-v1-integration.test.mjs
@@ -618,7 +618,8 @@ describe('Full OpenSpec v1 mocked paths', () => {
     assert.ok(verification.warnings.some((warning) => warning.code === 'openspec-cli-unavailable'));
     assert.equal(finalized.ok, false);
     assert.equal(finalized.errors[0].code, 'openspec-cli-required-for-done');
-    assert.equal(finalized.archive.warnings[0].code, 'context-failed');
+    assert.equal(finalized.readiness.status, 'fail');
+    assert.equal(finalized.archive.warnings[0].code, 'done-readiness-failed');
     assert.deepEqual(canonicalAfter, canonicalBefore);
     assert.equal(await pathExists(rootDir, 'openspec/specs/archive'), false);
   });

--- a/scripts/openspec-workflow-smoke.test.mjs
+++ b/scripts/openspec-workflow-smoke.test.mjs
@@ -295,6 +295,7 @@ async function finalizeWithArchive(rootDir, changeId) {
     rootDir,
     changeId,
     detectOpenSpec: async () => availableCliDetection(),
+    validateOpenSpecChange: async () => validationResult(changeId),
     getOpenSpecStatus: async () => statusResult(changeId),
     gitStatus: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     archiveOpenSpecChange: async (requestedChangeId, options) => {

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -30,9 +30,11 @@ OpenSpec-native mode finalizes the verified change state through `scripts/opensp
 - Require `.ai-factory/qa/<change-id>/coverage.json` to exist, be current, and have coverage status `pass` or policy-accepted `warn`.
 - Require generated rules and durable rules gate evidence according to `requireGeneratedRulesForDone` and `requireRulesPassForDone`; generated rules readiness does not satisfy rules gate pass.
 - Apply `allowWarnOnDone.rules`, `allowWarnOnDone.coverage`, and `allowWarnOnDone.openspecStatus` before accepting warning-only finalization evidence.
+- Always run the pre-archive readiness gate through `scripts/openspec-done-readiness.mjs` before archive and persist `.ai-factory/qa/<change-id>/done-readiness.json`.
 - If verification has not run or verdict is `fail`, stop and suggest `/aif-verify` or `/aif-fix`.
 - If the verify gate result is missing, invalid, or `fail`, stop and suggest rerunning `/aif-verify <change-id>` or `/aif-fix <change-id>`.
 - If coverage, generated rules, or rules gate evidence is missing, invalid, stale, failed, or warning-only when policy does not allow the warning, stop and suggest the owning command (`/aif-mode sync --change <change-id>`, `/aif-rules-check`, or `/aif-verify <change-id>`).
+- If readiness reports a blocking failure, refuse archive and show `suggested_next.command` and `suggested_next.reason` exactly.
 - Refuse unverified changes; do not accept `Code verification: PENDING` as final verification.
 - Check dirty working tree state before archive and either fail or record it only when explicit dirty-state recording is requested.
 
@@ -55,7 +57,7 @@ Read generated rules as derived guidance when present:
 Runtime state and QA evidence live outside canonical changes:
 
 - `.ai-factory/state/<change-id>/`
-- `.ai-factory/qa/<change-id>/`, including `verify.md` and `coverage.json`
+- `.ai-factory/qa/<change-id>/`, including `verify.md`, `coverage.json`, and `done-readiness.json`
 - `.ai-factory/qa/<change-id>/rules.md` when a durable rules gate is required or available
 
 ### Archive Policy
@@ -77,6 +79,7 @@ Runtime state and QA evidence live outside canonical changes:
 Normal output must report:
 
 - selected `change-id`;
+- readiness status, blocking checks, and exact suggested next command when blocked;
 - verification status and refusal reason when unverified;
 - dirty working tree state;
 - archive result;
@@ -183,7 +186,7 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 | Artifact | Owner | This Skill |
 |----------|-------|------------|
 | `openspec/changes/<change-id>/` | OpenSpec-native workflow | Reads before archive; OpenSpec CLI owns lifecycle mutation |
-| `.ai-factory/qa/<change-id>/` | `/aif-verify` and **aif-done** | Reads verification and coverage evidence; writes `done.md`, `openspec-archive.json`, and raw archive output |
+| `.ai-factory/qa/<change-id>/` | `/aif-verify` and **aif-done** | Reads verification and coverage evidence; writes `done-readiness.json`, `done.md`, `openspec-archive.json`, and raw archive output |
 | `.ai-factory/state/<change-id>/` | OpenSpec-native runtime and **aif-done** | Reads traces; writes `final-summary.md` |
 | `.ai-factory/specs/<plan-id>/` | **aif-done** legacy mode only | Creates or refreshes on legacy finalization |
 | `.ai-factory/specs/index.yaml` | **aif-done** | Updates |


### PR DESCRIPTION
## Summary

- Add a dedicated OpenSpec done-readiness gate that writes `.ai-factory/qa/<change-id>/done-readiness.json` before archive.
- Integrate readiness into `/aif-done` finalization so blocking readiness failures refuse archive and surface an exact next command.
- Document readiness behavior and update done/finalizer summaries to include readiness evidence.
- Add regression coverage for unresolved explicit changes returning exit code 2.

## Verification

- `/aif-verify add-pre-archive-done-readiness-gate` -> warn, no blockers
- `/aif-rules-check` -> pass
- `/aif-done` -> pass, archived as `2026-05-10-add-pre-archive-done-readiness-gate`
- `node --test scripts/openspec-done-readiness.test.mjs scripts/openspec-done-finalizer.test.mjs scripts/openspec-v1-integration.test.mjs scripts/openspec-workflow-smoke.test.mjs` -> 36 passed
- `npm run validate` -> pass
- `npm test` -> 322 passed
- `openspec validate --all --no-color` -> 7 passed, 0 failed

## Notes

Done readiness currently reports `WARN` only because the verify gate completed with non-blocking warnings. All blocking done policy checks pass.