### PR TITLE
[codex] Add OpenSpec validation fixture suite

### DIFF
--- a/scripts/openspec-validation-fixtures.test.mjs
+++ b/scripts/openspec-validation-fixtures.test.mjs
@@ -1,0 +1,288 @@
+// openspec-validation-fixtures.test.mjs - fixture-driven OpenSpec validation scenarios
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  validateOpenSpecArtifactContract
+} from './openspec-artifact-validator.mjs';
+import {
+  compileOpenSpecRules
+} from './openspec-rules-compiler.mjs';
+import {
+  collectGeneratedRules
+} from './openspec-execution-context.mjs';
+import {
+  readOpenSpecCoverageMatrix
+} from './openspec-coverage-matrix.mjs';
+import {
+  buildOpenSpecDoneReadiness
+} from './openspec-done-readiness.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const FIXTURE_ROOT = path.join(REPO_ROOT, 'test', 'fixtures');
+const tempRoots = [];
+
+const FIXTURES = Object.freeze([
+  'openspec-valid-change',
+  'openspec-missing-delta-specs',
+  'openspec-stale-generated-rules',
+  'openspec-rule-violation',
+  'openspec-runtime-state-leak',
+  'openspec-coverage-missing',
+  'openspec-docs-only-skip-specs'
+]);
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-openspec-validation-fixtures-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function copyFixture(fixtureName) {
+  const rootDir = await createTempRoot();
+  await cp(path.join(FIXTURE_ROOT, fixtureName), rootDir, { recursive: true });
+  return rootDir;
+}
+
+async function readExpected(fixtureName) {
+  return JSON.parse(await readFile(path.join(FIXTURE_ROOT, fixtureName, 'expected.json'), 'utf8'));
+}
+
+function availableCliDetection() {
+  return {
+    available: true,
+    canValidate: true,
+    canArchive: true,
+    version: '1.3.1',
+    command: 'openspec',
+    reason: null,
+    errors: []
+  };
+}
+
+function missingCliDetection() {
+  return {
+    available: false,
+    canValidate: false,
+    canArchive: false,
+    version: null,
+    supportedRange: '>=1.3.1 <2.0.0',
+    versionSupported: false,
+    requiresNode: '>=20.19.0',
+    nodeVersion: '20.19.0',
+    nodeSupported: true,
+    command: 'openspec',
+    reason: 'missing-cli',
+    errors: [
+      {
+        code: 'missing-cli',
+        message: 'OpenSpec CLI is not available on PATH.'
+      }
+    ]
+  };
+}
+
+function commandResult(ok = true, overrides = {}) {
+  return {
+    ok,
+    command: 'openspec',
+    args: [],
+    exitCode: ok ? 0 : 1,
+    stdout: ok ? '{"ok":true}' : '',
+    stderr: ok ? '' : 'failed',
+    json: ok ? { ok: true } : null,
+    error: ok ? null : { code: 'openspec-failed', message: 'OpenSpec command failed.' },
+    ...overrides
+  };
+}
+
+function cleanGitStatus() {
+  return {
+    exitCode: 0,
+    stdout: '',
+    stderr: ''
+  };
+}
+
+async function prepareGeneratedRules(rootDir, fixtureName, changeId) {
+  const result = await compileOpenSpecRules(changeId, {
+    rootDir,
+    detectOpenSpec: async () => missingCliDetection(),
+    getCurrentBranch: async () => `feature/${changeId}`,
+    now: new Date('2026-05-11T00:00:00.000Z')
+  });
+
+  assert.equal(result.ok, true, `${fixtureName} generated rules should compile before fixture checks`);
+
+  if (fixtureName === 'openspec-stale-generated-rules') {
+    await writeFile(
+      path.join(rootDir, 'openspec', 'specs', 'auth', 'spec.md'),
+      [
+        '# Auth Base',
+        '',
+        '## Requirements',
+        '',
+        '### Requirement: Existing sign in changed after sync',
+        '',
+        'The system MUST preserve changed sign in behavior after generated rules were compiled.',
+        ''
+      ].join('\n'),
+      'utf8'
+    );
+  }
+}
+
+function normalizeArtifactContract(result, expected) {
+  return {
+    status: result.status,
+    blocking: result.blocking,
+    checks: selectCheckStatuses(result.checks, expected.checks),
+    suggested_next: result.suggested_next?.command ?? null
+  };
+}
+
+function normalizeGeneratedRules(result, expected) {
+  const generatedRules = {};
+  for (const kind of Object.keys(expected.generated_rules ?? {})) {
+    const rule = result.generatedRules.find((item) => item.kind === kind);
+    generatedRules[kind] = {
+      exists: rule?.exists ?? false,
+      stale: rule?.stale ?? null,
+      stale_source: normalizeStaleSource(rule?.staleSource),
+      trace: {
+        exists: rule?.trace?.exists ?? false,
+        valid: rule?.trace?.valid ?? false,
+        stale: rule?.trace?.stale ?? null
+      }
+    };
+  }
+
+  return {
+    status: result.errors.length > 0 ? 'fail' : result.warnings.length > 0 ? 'warn' : 'pass',
+    warning_codes: sortedCodes(result.warnings),
+    error_codes: sortedCodes(result.errors),
+    generated_rules: generatedRules
+  };
+}
+
+function normalizeStaleSource(value) {
+  if (value === 'trace-output') {
+    return 'trace';
+  }
+
+  return value ?? null;
+}
+
+function normalizeCoverageMatrix(result) {
+  return {
+    ok: result.ok,
+    exists: result.exists,
+    stale: result.stale,
+    status: result.coverage?.status ?? null,
+    blocking: result.coverage?.blocking ?? null,
+    summary: result.coverage?.summary ?? null,
+    diagnostic_codes: sortedCodes(result.diagnostics)
+  };
+}
+
+function normalizeDoneReadiness(result, expected) {
+  return {
+    status: result.status,
+    blocking: result.blocking,
+    checks: selectObjectKeys(result.checks, expected.checks),
+    diagnostic_codes: sortedCodes(result.diagnostics),
+    suggested_next: result.suggested_next?.command ?? null
+  };
+}
+
+function selectCheckStatuses(checks, expectedChecks) {
+  const statuses = {};
+  for (const id of Object.keys(expectedChecks ?? {})) {
+    statuses[id] = checks.find((check) => check.id === id)?.status ?? null;
+  }
+  return statuses;
+}
+
+function selectObjectKeys(value, expectedKeys) {
+  const selected = {};
+  for (const key of Object.keys(expectedKeys ?? {})) {
+    selected[key] = value?.[key] ?? null;
+  }
+  return selected;
+}
+
+function sortedCodes(diagnostics = []) {
+  return [...new Set((diagnostics ?? []).map((item) => item?.code).filter(Boolean))].sort();
+}
+
+function assertSection(fixtureName, sectionName, actual, expected) {
+  assert.deepEqual(
+    actual,
+    expected,
+    `${fixtureName} ${sectionName} normalized result should match expected.json`
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('OpenSpec validation fixtures', () => {
+  for (const fixtureName of FIXTURES) {
+    it(`matches expected validation outcomes for ${fixtureName}`, async () => {
+      const expected = await readExpected(fixtureName);
+      const rootDir = await copyFixture(fixtureName);
+      const changeId = expected.change_id;
+      await prepareGeneratedRules(rootDir, fixtureName, changeId);
+
+      const artifactContract = await validateOpenSpecArtifactContract({
+        rootDir,
+        changeId,
+        requireVerificationEvidence: true
+      });
+      const generatedRules = await collectGeneratedRules(changeId, { rootDir });
+      const coverage = await readOpenSpecCoverageMatrix(changeId, { rootDir });
+      const doneReadiness = await buildOpenSpecDoneReadiness({
+        rootDir,
+        changeId,
+        detectOpenSpec: async () => availableCliDetection(),
+        validateOpenSpecChange: async () => commandResult(true),
+        getOpenSpecStatus: async () => commandResult(true),
+        gitStatus: async () => cleanGitStatus()
+      });
+
+      assertSection(
+        fixtureName,
+        'artifact_contract',
+        normalizeArtifactContract(artifactContract, expected.artifact_contract),
+        expected.artifact_contract
+      );
+      assertSection(
+        fixtureName,
+        'rules_compiler_trace',
+        normalizeGeneratedRules(generatedRules, expected.rules_compiler_trace),
+        expected.rules_compiler_trace
+      );
+      assertSection(
+        fixtureName,
+        'coverage_matrix',
+        normalizeCoverageMatrix(coverage),
+        expected.coverage_matrix
+      );
+      assertSection(
+        fixtureName,
+        'done_readiness',
+        normalizeDoneReadiness(doneReadiness, expected.done_readiness),
+        expected.done_readiness
+      );
+    });
+  }
+});

--- a/test/fixtures/openspec-coverage-missing/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-coverage-missing/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-coverage-missing/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-coverage-missing/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-coverage-missing/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-coverage-missing/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,13 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-coverage-missing/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-coverage-missing/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-coverage-missing/expected.json
+++ b/test/fixtures/openspec-coverage-missing/expected.json
@@ -1,0 +1,80 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "pass",
+    "blocking": false,
+    "checks": {
+      "delta-specs-present": "pass",
+      "generated-rules-current": "pass",
+      "runtime-files-outside-change": "pass",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": null
+  },
+  "rules_compiler_trace": {
+    "status": "pass",
+    "warning_codes": [],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": false,
+    "exists": false,
+    "stale": null,
+    "status": null,
+    "blocking": null,
+    "summary": null,
+    "diagnostic_codes": [
+      "coverage-missing"
+    ]
+  },
+  "done_readiness": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "pass",
+      "generated_rules": "pass",
+      "rules_gate": "pass",
+      "coverage": "fail",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [
+      "coverage-evidence-missing"
+    ],
+    "suggested_next": "/aif-verify fixture-change"
+  }
+}

--- a/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+Fixture-backed validation scenario.

--- a/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,5 @@
+# Proposal
+
+## Why
+
+Add a fixture-backed validation scenario.

--- a/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/specs/auth/spec.md
+++ b/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/specs/auth/spec.md
@@ -1,0 +1,13 @@
+# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: Fixture validation
+
+The system MUST validate fixture-backed OpenSpec scenarios.
+
+#### Scenario: fixture validates
+
+- GIVEN a fixture-backed OpenSpec change
+- WHEN validation runs
+- THEN the expected fixture outcome is recorded.

--- a/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-coverage-missing/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Implement fixture-backed validation in scripts/openspec-validation-fixtures.test.mjs and tests/validation-fixtures.test.ts.

--- a/test/fixtures/openspec-coverage-missing/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-coverage-missing/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.

--- a/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/coverage.json
+++ b/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/coverage.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "change_id": "fixture-change",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [],
+  "summary": {
+    "covered": 0,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [],
+  "stale": false,
+  "diagnostics": [],
+  "warnings": [],
+  "errors": []
+}

--- a/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,13 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-docs-only-skip-specs/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-docs-only-skip-specs/expected.json
+++ b/test/fixtures/openspec-docs-only-skip-specs/expected.json
@@ -1,0 +1,81 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "pass",
+    "blocking": false,
+    "checks": {
+      "delta-specs-present": "pass",
+      "generated-rules-current": "pass",
+      "runtime-files-outside-change": "pass",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": null
+  },
+  "rules_compiler_trace": {
+    "status": "pass",
+    "warning_codes": [],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": true,
+    "exists": true,
+    "stale": false,
+    "status": "pass",
+    "blocking": false,
+    "summary": {
+      "covered": 0,
+      "partial": 0,
+      "missing": 0,
+      "not_applicable": 0
+    },
+    "diagnostic_codes": []
+  },
+  "done_readiness": {
+    "status": "pass",
+    "blocking": false,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "pass",
+      "generated_rules": "pass",
+      "rules_gate": "pass",
+      "coverage": "pass",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [],
+    "suggested_next": null
+  }
+}

--- a/test/fixtures/openspec-docs-only-skip-specs/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-docs-only-skip-specs/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+Docs-only validation fixture.

--- a/test/fixtures/openspec-docs-only-skip-specs/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-docs-only-skip-specs/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,7 @@
+# Proposal
+
+## Why
+
+This is a docs-only fixture for validation behavior.
+
+skip-specs reason: docs-only because this fixture changes no product behavior and no workflow behavior.

--- a/test/fixtures/openspec-docs-only-skip-specs/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-docs-only-skip-specs/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Update documentation-only fixture metadata.

--- a/test/fixtures/openspec-docs-only-skip-specs/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-docs-only-skip-specs/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.

--- a/test/fixtures/openspec-missing-delta-specs/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-missing-delta-specs/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/coverage.json
+++ b/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/coverage.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "change_id": "fixture-change",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [],
+  "summary": {
+    "covered": 0,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [],
+  "stale": false,
+  "diagnostics": [],
+  "warnings": [],
+  "errors": []
+}

--- a/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,13 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-missing-delta-specs/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-missing-delta-specs/expected.json
+++ b/test/fixtures/openspec-missing-delta-specs/expected.json
@@ -1,0 +1,83 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "delta-specs-present": "fail",
+      "generated-rules-current": "pass",
+      "runtime-files-outside-change": "pass",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": "/aif-mode sync --change fixture-change"
+  },
+  "rules_compiler_trace": {
+    "status": "pass",
+    "warning_codes": [],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": true,
+    "exists": true,
+    "stale": false,
+    "status": "pass",
+    "blocking": false,
+    "summary": {
+      "covered": 0,
+      "partial": 0,
+      "missing": 0,
+      "not_applicable": 0
+    },
+    "diagnostic_codes": []
+  },
+  "done_readiness": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "fail",
+      "generated_rules": "pass",
+      "rules_gate": "pass",
+      "coverage": "pass",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [
+      "artifact-contract-fail"
+    ],
+    "suggested_next": "/aif-mode sync --change fixture-change"
+  }
+}

--- a/test/fixtures/openspec-missing-delta-specs/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-missing-delta-specs/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+This fixture intentionally omits delta specs.

--- a/test/fixtures/openspec-missing-delta-specs/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-missing-delta-specs/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,5 @@
+# Proposal
+
+## Why
+
+This behavior-changing fixture is missing required delta specs.

--- a/test/fixtures/openspec-missing-delta-specs/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-missing-delta-specs/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Implement fixture-backed validation in scripts/openspec-validation-fixtures.test.mjs and tests/validation-fixtures.test.ts.

--- a/test/fixtures/openspec-missing-delta-specs/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-missing-delta-specs/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.

--- a/test/fixtures/openspec-rule-violation/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-rule-violation/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/coverage.json
+++ b/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/coverage.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "change_id": "fixture-change",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [],
+  "summary": {
+    "covered": 0,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [],
+  "stale": false,
+  "diagnostics": [],
+  "warnings": [],
+  "errors": []
+}

--- a/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,22 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "fail",
+  "blocking": true,
+  "blockers": [
+    {
+      "id": "fixture-rule-violation",
+      "severity": "error",
+      "file": "src/auth/login.ts",
+      "summary": "Fixture intentionally violates generated rule guidance."
+    }
+  ],
+  "affected_files": [
+    "src/auth/login.ts"
+  ],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-rule-violation/expected.json
+++ b/test/fixtures/openspec-rule-violation/expected.json
@@ -1,0 +1,83 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "pass",
+    "blocking": false,
+    "checks": {
+      "delta-specs-present": "pass",
+      "generated-rules-current": "pass",
+      "runtime-files-outside-change": "pass",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": null
+  },
+  "rules_compiler_trace": {
+    "status": "pass",
+    "warning_codes": [],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": true,
+    "exists": true,
+    "stale": false,
+    "status": "pass",
+    "blocking": false,
+    "summary": {
+      "covered": 0,
+      "partial": 0,
+      "missing": 0,
+      "not_applicable": 0
+    },
+    "diagnostic_codes": []
+  },
+  "done_readiness": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "pass",
+      "generated_rules": "pass",
+      "rules_gate": "fail",
+      "coverage": "pass",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [
+      "rules-gate-fail"
+    ],
+    "suggested_next": "/aif-rules-check"
+  }
+}

--- a/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+Fixture-backed validation scenario.

--- a/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,5 @@
+# Proposal
+
+## Why
+
+Add a fixture-backed validation scenario.

--- a/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/specs/auth/spec.md
+++ b/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/specs/auth/spec.md
@@ -1,0 +1,13 @@
+# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: Fixture validation
+
+The system MUST validate fixture-backed OpenSpec scenarios.
+
+#### Scenario: fixture validates
+
+- GIVEN a fixture-backed OpenSpec change
+- WHEN validation runs
+- THEN the expected fixture outcome is recorded.

--- a/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-rule-violation/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Implement fixture-backed validation in scripts/openspec-validation-fixtures.test.mjs and tests/validation-fixtures.test.ts.

--- a/test/fixtures/openspec-rule-violation/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-rule-violation/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.

--- a/test/fixtures/openspec-runtime-state-leak/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-runtime-state-leak/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/coverage.json
+++ b/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/coverage.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "change_id": "fixture-change",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [],
+  "summary": {
+    "covered": 0,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [],
+  "stale": false,
+  "diagnostics": [],
+  "warnings": [],
+  "errors": []
+}

--- a/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,13 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-runtime-state-leak/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-runtime-state-leak/expected.json
+++ b/test/fixtures/openspec-runtime-state-leak/expected.json
@@ -1,0 +1,83 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "delta-specs-present": "pass",
+      "generated-rules-current": "pass",
+      "runtime-files-outside-change": "fail",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": "/aif-mode sync --change fixture-change"
+  },
+  "rules_compiler_trace": {
+    "status": "pass",
+    "warning_codes": [],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": true,
+    "exists": true,
+    "stale": false,
+    "status": "pass",
+    "blocking": false,
+    "summary": {
+      "covered": 0,
+      "partial": 0,
+      "missing": 0,
+      "not_applicable": 0
+    },
+    "diagnostic_codes": []
+  },
+  "done_readiness": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "fail",
+      "generated_rules": "pass",
+      "rules_gate": "pass",
+      "coverage": "pass",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [
+      "artifact-contract-fail"
+    ],
+    "suggested_next": "/aif-mode sync --change fixture-change"
+  }
+}

--- a/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+Fixture-backed validation scenario.

--- a/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/openspec-validation.json
@@ -1,0 +1,3 @@
+{
+  "leaked": true
+}

--- a/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,5 @@
+# Proposal
+
+## Why
+
+Add a fixture-backed validation scenario.

--- a/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/specs/auth/spec.md
+++ b/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/specs/auth/spec.md
@@ -1,0 +1,13 @@
+# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: Fixture validation
+
+The system MUST validate fixture-backed OpenSpec scenarios.
+
+#### Scenario: fixture validates
+
+- GIVEN a fixture-backed OpenSpec change
+- WHEN validation runs
+- THEN the expected fixture outcome is recorded.

--- a/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-runtime-state-leak/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Implement fixture-backed validation in scripts/openspec-validation-fixtures.test.mjs and tests/validation-fixtures.test.ts.

--- a/test/fixtures/openspec-runtime-state-leak/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-runtime-state-leak/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.

--- a/test/fixtures/openspec-stale-generated-rules/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-stale-generated-rules/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/coverage.json
+++ b/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/coverage.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "change_id": "fixture-change",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [],
+  "summary": {
+    "covered": 0,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [],
+  "stale": false,
+  "diagnostics": [],
+  "warnings": [],
+  "errors": []
+}

--- a/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,13 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-stale-generated-rules/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-stale-generated-rules/expected.json
+++ b/test/fixtures/openspec-stale-generated-rules/expected.json
@@ -1,0 +1,86 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "warn",
+    "blocking": false,
+    "checks": {
+      "delta-specs-present": "pass",
+      "generated-rules-current": "warn",
+      "runtime-files-outside-change": "pass",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": "/aif-mode sync --change fixture-change"
+  },
+  "rules_compiler_trace": {
+    "status": "warn",
+    "warning_codes": [
+      "stale-generated-rules"
+    ],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": true,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": true
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": true,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": true
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": true,
+    "exists": true,
+    "stale": false,
+    "status": "pass",
+    "blocking": false,
+    "summary": {
+      "covered": 0,
+      "partial": 0,
+      "missing": 0,
+      "not_applicable": 0
+    },
+    "diagnostic_codes": []
+  },
+  "done_readiness": {
+    "status": "fail",
+    "blocking": true,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "warn",
+      "generated_rules": "fail",
+      "rules_gate": "pass",
+      "coverage": "pass",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [
+      "artifact-contract-warn",
+      "stale-generated-rules"
+    ],
+    "suggested_next": "/aif-mode sync --change fixture-change"
+  }
+}

--- a/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+Fixture-backed validation scenario.

--- a/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,5 @@
+# Proposal
+
+## Why
+
+Add a fixture-backed validation scenario.

--- a/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/specs/auth/spec.md
+++ b/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/specs/auth/spec.md
@@ -1,0 +1,13 @@
+# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: Fixture validation
+
+The system MUST validate fixture-backed OpenSpec scenarios.
+
+#### Scenario: fixture validates
+
+- GIVEN a fixture-backed OpenSpec change
+- WHEN validation runs
+- THEN the expected fixture outcome is recorded.

--- a/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-stale-generated-rules/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Implement fixture-backed validation in scripts/openspec-validation-fixtures.test.mjs and tests/validation-fixtures.test.ts.

--- a/test/fixtures/openspec-stale-generated-rules/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-stale-generated-rules/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.

--- a/test/fixtures/openspec-valid-change/.ai-factory/config.yaml
+++ b/test/fixtures/openspec-valid-change/.ai-factory/config.yaml
@@ -1,0 +1,10 @@
+aifhub:
+  artifactProtocol: openspec
+  openspec:
+    requireCliForDone: true
+    requireGeneratedRulesForDone: true
+    requireRulesPassForDone: true
+    requireSpecCoverageForDone: true
+paths:
+  qa: .ai-factory/qa
+  generated_rules: .ai-factory/rules/generated

--- a/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/coverage.json
+++ b/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/coverage.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "change_id": "fixture-change",
+  "status": "pass",
+  "blocking": false,
+  "policy": {
+    "mode": "strict",
+    "missing_requirement": "fail"
+  },
+  "requirements": [],
+  "summary": {
+    "covered": 0,
+    "partial": 0,
+    "missing": 0,
+    "not_applicable": 0
+  },
+  "sources": [],
+  "stale": false,
+  "diagnostics": [],
+  "warnings": [],
+  "errors": []
+}

--- a/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/openspec-validation.json
+++ b/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/openspec-validation.json
@@ -1,0 +1,4 @@
+{
+  "ok": true,
+  "skipped": false
+}

--- a/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/rules.md
@@ -1,0 +1,13 @@
+# Rules Gate
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "rules",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/verify.md
+++ b/test/fixtures/openspec-valid-change/.ai-factory/qa/fixture-change/verify.md
@@ -1,0 +1,16 @@
+# Verify: fixture-change
+
+Verdict: PASS
+Code verification: PASS
+
+```aif-gate-result
+{
+  "schema_version": 1,
+  "gate": "verify",
+  "status": "pass",
+  "blocking": false,
+  "blockers": [],
+  "affected_files": [],
+  "suggested_next": null
+}
+```

--- a/test/fixtures/openspec-valid-change/expected.json
+++ b/test/fixtures/openspec-valid-change/expected.json
@@ -1,0 +1,81 @@
+{
+  "change_id": "fixture-change",
+  "artifact_contract": {
+    "status": "pass",
+    "blocking": false,
+    "checks": {
+      "delta-specs-present": "pass",
+      "generated-rules-current": "pass",
+      "runtime-files-outside-change": "pass",
+      "qa-verify-gate": "pass"
+    },
+    "suggested_next": null
+  },
+  "rules_compiler_trace": {
+    "status": "pass",
+    "warning_codes": [],
+    "error_codes": [],
+    "generated_rules": {
+      "merged": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "change": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      },
+      "base": {
+        "exists": true,
+        "stale": false,
+        "stale_source": "trace",
+        "trace": {
+          "exists": true,
+          "valid": true,
+          "stale": false
+        }
+      }
+    }
+  },
+  "coverage_matrix": {
+    "ok": true,
+    "exists": true,
+    "stale": false,
+    "status": "pass",
+    "blocking": false,
+    "summary": {
+      "covered": 0,
+      "partial": 0,
+      "missing": 0,
+      "not_applicable": 0
+    },
+    "diagnostic_codes": []
+  },
+  "done_readiness": {
+    "status": "pass",
+    "blocking": false,
+    "checks": {
+      "openspec_validate": "pass",
+      "openspec_status": "pass",
+      "artifact_contract": "pass",
+      "generated_rules": "pass",
+      "rules_gate": "pass",
+      "coverage": "pass",
+      "verify_gate": "pass",
+      "dirty_workspace": "pass"
+    },
+    "diagnostic_codes": [],
+    "suggested_next": null
+  }
+}

--- a/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/design.md
+++ b/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/design.md
@@ -1,0 +1,3 @@
+# Design
+
+Fixture-backed validation scenario.

--- a/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/proposal.md
+++ b/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/proposal.md
@@ -1,0 +1,5 @@
+# Proposal
+
+## Why
+
+Add a fixture-backed validation scenario.

--- a/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/specs/auth/spec.md
+++ b/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/specs/auth/spec.md
@@ -1,0 +1,13 @@
+# Auth Delta
+
+## ADDED Requirements
+
+### Requirement: Fixture validation
+
+The system MUST validate fixture-backed OpenSpec scenarios.
+
+#### Scenario: fixture validates
+
+- GIVEN a fixture-backed OpenSpec change
+- WHEN validation runs
+- THEN the expected fixture outcome is recorded.

--- a/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/tasks.md
+++ b/test/fixtures/openspec-valid-change/openspec/changes/fixture-change/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] 1.1 Implement fixture-backed validation in scripts/openspec-validation-fixtures.test.mjs and tests/validation-fixtures.test.ts.

--- a/test/fixtures/openspec-valid-change/openspec/specs/auth/spec.md
+++ b/test/fixtures/openspec-valid-change/openspec/specs/auth/spec.md
@@ -1,0 +1,7 @@
+# Auth Base
+
+## Requirements
+
+### Requirement: Existing sign in
+
+The system MUST preserve existing sign in behavior.


### PR DESCRIPTION
## Summary

Adds a fixture-driven OpenSpec validation test suite covering one positive fixture and six negative validation scenarios.

- Adds `scripts/openspec-validation-fixtures.test.mjs` to copy fixtures into temp workspaces and compare stable `expected.json` snapshots.
- Adds fixtures for missing delta specs, stale generated rules, rules gate failure, runtime state leakage, missing coverage, and docs-only skip-specs behavior.
- Separately asserts artifact contract, rules compiler trace, coverage matrix, and done-readiness outputs for every fixture.

## Validation

- `npm test` -> 329 passed, 0 failed
- `node --test scripts/openspec-validation-fixtures.test.mjs` -> 7 passed, 0 failed
- `npm run validate` -> passed
- `openspec validate add-openspec-validation-fixtures --type change --strict --json --no-interactive --no-color` -> passed
- `git diff --check` -> passed

## Notes

Generated OpenSpec rules and QA evidence were refreshed locally but remain ignored runtime artifacts, so the PR contains only the committed test runner and fixture files.