### PR TITLE
Expose validation gates for Handoff orchestration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,8 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 6. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
 7. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
 8. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
-9. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+9. [Handoff Validation Profile](handoff-validation-profile.md) for the read-only orchestration summary contract.
+10. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
 
 The remaining runtime-specific guides are supporting references:
 
@@ -31,6 +32,7 @@ The remaining runtime-specific guides are supporting references:
 - [Claude Agents](claude-agents.md)
 - [Codex Plan Mode](codex-plan-mode.md)
 - [Handoff Naming](handoff.md)
+- [Handoff Validation Profile](handoff-validation-profile.md)
 
 ## Guides
 
@@ -43,6 +45,7 @@ The remaining runtime-specific guides are supporting references:
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness, and integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
 | [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |
+| [Handoff Validation Profile](handoff-validation-profile.md) | Read-only validation summary contract for Handoff orchestration |
 | [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec and AI Factory runtime state contract |
 | [AIFHub MCP](aifhub-mcp.md) | Optional MCP server tools and runtime-specific config shapes |
 | [Codex Agents](codex-agents.md) | Namespaced Codex subagents and invocation contract |
@@ -89,5 +92,6 @@ npm test
 - [OpenSpec Coverage Matrix](spec-coverage.md)
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [Active Change Resolver](active-change-resolver.md)
+- [Handoff Validation Profile](handoff-validation-profile.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)
 - [AIFHub MCP](aifhub-mcp.md)

--- a/docs/handoff-validation-profile.md
+++ b/docs/handoff-validation-profile.md
@@ -1,0 +1,122 @@
+[← Handoff Naming](handoff.md) · [Back to Documentation](README.md)
+
+# Handoff Validation Profile
+
+## Purpose
+
+The Handoff validation profile is a read-only orchestration contract for OpenSpec-native AIFHub changes.
+
+It lets a Handoff orchestrator read one JSON summary instead of parsing every gate Markdown file, coverage artifact, and generated-rules trace directly. It is not a separate runtime, not a public slash command, and not a replacement for `/aif-verify` or `/aif-done`.
+
+The profile is produced by:
+
+```bash
+node scripts/handoff-gate-summary.mjs --change <change-id> --stage review --json
+```
+
+## JSON Contract
+
+```json
+{
+  "schema_version": 1,
+  "change_id": "add-oauth-login",
+  "stage": "review",
+  "gates": {
+    "rules": "pass",
+    "review": "warn",
+    "security": "pass",
+    "verify": "pass",
+    "coverage": "warn"
+  },
+  "generatedRules": "pass",
+  "blocking": false,
+  "next_stage": "done",
+  "suggested_next": "/aif-done add-oauth-login",
+  "diagnostics": [],
+  "evidence": {
+    "rules": ".ai-factory/qa/add-oauth-login/rules.md",
+    "review": ".ai-factory/qa/add-oauth-login/aif-review.md",
+    "security": ".ai-factory/qa/add-oauth-login/aif-security-checklist.md",
+    "verify": ".ai-factory/qa/add-oauth-login/verify.md",
+    "coverage": ".ai-factory/qa/add-oauth-login/coverage.json",
+    "generatedRules": ".ai-factory/rules/generated"
+  }
+}
+```
+
+Handoff should treat these fields as the minimal stable contract:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Contract version. Current value is `1`. |
+| `change_id` | Resolved OpenSpec change id. |
+| `stage` | Input stage: `planning`, `implementing`, `review`, or `done`. |
+| `gates` | Aggregated gate statuses for rules, review, security, verify, and coverage. |
+| `generatedRules` | Derived generated-rules freshness: `pass`, `warn`, or `stale`. |
+| `blocking` | Whether Handoff should stop progression. |
+| `next_stage` | Stage Handoff should move to after this summary. |
+| `suggested_next` | Exact public command to run next. |
+
+`diagnostics` and `evidence` are included for debugging and auditability.
+
+## Evidence Inputs
+
+The summary reads existing files only. It does not create runtime directories and does not write QA evidence.
+
+| Signal | Candidate evidence |
+|---|---|
+| `rules` | `.ai-factory/qa/<change-id>/rules.md`, `aif-rules-check.md`, `rules-check.md`, `gates/rules.md` |
+| `review` | `.ai-factory/qa/<change-id>/review.md`, `aif-review.md`, `gates/review.md` |
+| `security` | `.ai-factory/qa/<change-id>/security.md`, `aif-security-checklist.md`, `gates/security.md` |
+| `verify` | `.ai-factory/qa/<change-id>/verify.md` |
+| `coverage` | `.ai-factory/qa/<change-id>/coverage.json` |
+| `generatedRules` | `.ai-factory/rules/generated/openspec-*.md` plus `openspec-rules-trace-<change-id>.json` |
+
+Gate Markdown files are parsed through the existing `aif-gate-result` contract. If the latest matching `aif-gate-result` block is invalid, the profile reports that gate as `warn` and does not fall back to an older valid block.
+
+## Status Semantics
+
+| Status | Meaning |
+|---|---|
+| `pass` | The signal is present and acceptable. |
+| `warn` | Evidence is missing, optional, invalid, stale, or non-blocking. |
+| `fail` | A gate reports a blocking failure. |
+| `stale` | Generated rules are missing, stale, or have missing/invalid trace metadata. |
+
+Gate `fail` values set `blocking: true`.
+
+`generatedRules: "stale"` also sets `blocking: true` and has routing priority over gate failures. Handoff should run `/aif-mode sync --change <change-id>`, rebuild the summary, and then act on any remaining gate failures.
+
+## Routing
+
+| Condition | `next_stage` | `suggested_next` |
+|---|---|---|
+| `generatedRules` is `stale` | current stage | `/aif-mode sync --change <change-id>` |
+| any gate is `fail` and generated rules are current | `implementing` | `/aif-fix <change-id>` |
+| review stage has no blockers | `done` | `/aif-done <change-id>` |
+| planning stage has no blockers | `implementing` | `/aif-implement <change-id>` |
+| implementing stage has no blockers | `review` | `/aif-verify <change-id>` |
+| done stage has no blockers | `done` | `/aif-done <change-id>` |
+
+Warnings do not block by themselves. Handoff can still display them or require a stricter policy outside this profile.
+
+## CLI Exit Codes
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Summary was produced and `blocking` is `false`. |
+| `1` | Summary was produced and `blocking` is `true`. |
+| `2` | Arguments are invalid, the change cannot be resolved, or the summary cannot be produced. |
+
+When `--json` is used, stdout contains JSON only.
+
+## Boundary
+
+This profile does not run fixes, regenerate generated rules, write QA evidence, archive an OpenSpec change, mutate Handoff DB state, or activate `injections/handoff/*` prompt assets.
+
+The owning commands remain:
+
+- `/aif-mode sync --change <change-id>` for generated rules.
+- `/aif-fix <change-id>` for selected blocking findings.
+- `/aif-verify <change-id>` for authoritative verification.
+- `/aif-done <change-id>` for final readiness and archive/finalization.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -13,6 +13,8 @@
 Названия стадий можно использовать как краткие названия этапов, но они не обязаны совпадать со slash commands.
 Legacy slash aliases и handoff stage names — разные смысловые слои.
 
+Для machine-readable orchestration summary см. [Handoff Validation Profile](handoff-validation-profile.md). Этот профиль даёт Handoff один JSON summary по validation gates, но не является отдельным runtime.
+
 ## Future Handoff Prompt Stubs
 
 Кроме stage vocabulary, в `injections/handoff/` лежат четыре future stub prompt assets для review/security/rules/done layer.
@@ -125,5 +127,7 @@ passing full /aif-verify -> /aif-done (archive, commit/PR drafts, governance/evo
 - **Auto-transition**: переход между stages по verdict (pass/fail) должен управляться orchestrator, а не вручную.
 - **Multi-gate aggregation**: параллельный запуск review/security/rules gates и агрегация findings.
 - **Runtime binding stubs**: активация `injections/handoff/*.md` через Handoff runtime, а не через `extension.json`.
+
+Текущий read-only bridge для aggregation contract описан в [Handoff Validation Profile](handoff-validation-profile.md): Handoff может читать один summary вместо прямого парсинга всех gate Markdown files.
 
 Handoff не auto-использует `aifhub-*` agents — для этого требуется upstream support configurable stage mapping.

--- a/scripts/handoff-gate-summary.mjs
+++ b/scripts/handoff-gate-summary.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+// handoff-gate-summary.mjs - read-only Handoff orchestration gate summary
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  normalizeChangeId,
+  resolveActiveChange as defaultResolveActiveChange
+} from './active-change-resolver.mjs';
+import { getLatestGateResult } from './aif-gate-result.mjs';
+import { readOpenSpecCoverageMatrix as defaultReadOpenSpecCoverageMatrix } from './openspec-coverage-matrix.mjs';
+import { collectGeneratedRules as defaultCollectGeneratedRules } from './openspec-execution-context.mjs';
+
+export const HANDOFF_GATE_SUMMARY_SCHEMA_VERSION = 1;
+export const HANDOFF_GATE_STAGES = Object.freeze(['planning', 'implementing', 'review', 'done']);
+export const HANDOFF_GATE_STATUSES = Object.freeze(['pass', 'warn', 'fail']);
+
+const GENERATED_RULES_STALE_CODES = new Set([
+  'missing-generated-rules',
+  'stale-generated-rules',
+  'missing-generated-rules-trace',
+  'invalid-generated-rules-trace'
+]);
+
+const GATE_CANDIDATES = Object.freeze({
+  rules: ['rules.md', 'aif-rules-check.md', 'rules-check.md', path.join('gates', 'rules.md')],
+  review: ['review.md', 'aif-review.md', path.join('gates', 'review.md')],
+  security: ['security.md', 'aif-security-checklist.md', path.join('gates', 'security.md')],
+  verify: ['verify.md']
+});
+
+export function parseHandoffGateSummaryArgs(argv = []) {
+  const result = {
+    ok: true,
+    changeId: null,
+    stage: 'review',
+    json: false,
+    help: false,
+    errors: []
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+      continue;
+    }
+
+    if (arg === '--json') {
+      result.json = true;
+      continue;
+    }
+
+    if (arg === '--change') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        result.errors.push('Missing value for --change.');
+      } else {
+        const normalized = normalizeChangeId(value);
+        if (!normalized.ok) {
+          result.errors.push(normalized.error.message);
+        } else {
+          result.changeId = normalized.changeId;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg === '--stage') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        result.errors.push('Missing value for --stage.');
+      } else if (!HANDOFF_GATE_STAGES.includes(value)) {
+        result.errors.push(`Invalid --stage '${value}'. Expected one of: ${HANDOFF_GATE_STAGES.join(', ')}.`);
+        index += 1;
+      } else {
+        result.stage = value;
+        index += 1;
+      }
+      continue;
+    }
+
+    result.errors.push(`Unknown argument: ${arg}.`);
+  }
+
+  result.ok = result.errors.length === 0;
+  return result;
+}
+
+export async function buildHandoffGateSummary(options = {}) {
+  const rootDir = resolveRootDir(options);
+  const stage = normalizeStage(options.stage);
+  const resolveActiveChange = options.resolveActiveChange ?? defaultResolveActiveChange;
+  const resolved = await resolveActiveChange({
+    rootDir,
+    cwd: options.cwd ?? process.cwd(),
+    changeId: options.changeId,
+    getCurrentBranch: options.getCurrentBranch
+  });
+
+  if (!resolved.ok) {
+    return createUnresolvedSummary({
+      stage,
+      diagnostics: [
+        ...normalizeDiagnostics(resolved.warnings, 'warning'),
+        ...normalizeDiagnostics(resolved.errors, 'error')
+      ]
+    });
+  }
+
+  const changeId = resolved.changeId;
+  const qaPath = resolved.qaPath ?? path.join(rootDir, '.ai-factory', 'qa', changeId);
+  const gateResults = {};
+  const diagnostics = normalizeDiagnostics(resolved.warnings, 'warning');
+  const evidence = {
+    generatedRules: '.ai-factory/rules/generated'
+  };
+
+  for (const gate of ['rules', 'review', 'security', 'verify']) {
+    const result = await readGateStatus(gate, {
+      rootDir,
+      qaPath,
+      readFile: options.readFile ?? readFile
+    });
+    gateResults[gate] = result.status;
+    if (result.evidencePath) {
+      evidence[gate] = result.evidencePath;
+    }
+    diagnostics.push(...result.diagnostics);
+  }
+
+  const coverage = await readCoverageStatus(changeId, {
+    ...options,
+    rootDir,
+    qaPath
+  });
+  gateResults.coverage = coverage.status;
+  evidence.coverage = coverage.evidencePath;
+  diagnostics.push(...coverage.diagnostics);
+
+  const generatedRules = await readGeneratedRulesStatus(changeId, {
+    ...options,
+    rootDir
+  });
+  diagnostics.push(...generatedRules.diagnostics);
+
+  const routing = routeSummary({
+    changeId,
+    stage,
+    gates: gateResults,
+    generatedRules: generatedRules.status
+  });
+
+  return {
+    schema_version: HANDOFF_GATE_SUMMARY_SCHEMA_VERSION,
+    change_id: changeId,
+    stage,
+    gates: gateResults,
+    generatedRules: generatedRules.status,
+    blocking: routing.blocking,
+    next_stage: routing.nextStage,
+    suggested_next: routing.suggestedNext,
+    diagnostics: dedupeDiagnostics(diagnostics),
+    evidence
+  };
+}
+
+export function summarizeHandoffGateSummary(summary) {
+  if (!summary || summary.ok === false) {
+    return [
+      'Handoff gate summary: ERROR',
+      ...(summary?.diagnostics ?? []).map((diagnostic) => `${diagnostic.severity.toUpperCase()} [${diagnostic.code}] ${diagnostic.message}`)
+    ].join('\n');
+  }
+
+  const gateText = Object.entries(summary.gates ?? {})
+    .map(([gate, status]) => `${gate}=${status}`)
+    .join(', ');
+  const status = summary.blocking ? 'BLOCKING' : 'NON-BLOCKING';
+
+  return [
+    `Handoff gate summary: ${status}`,
+    `Change: ${summary.change_id}`,
+    `Stage: ${summary.stage} -> ${summary.next_stage}`,
+    `Gates: ${gateText}`,
+    `Generated rules: ${summary.generatedRules}`,
+    `Suggested next: ${summary.suggested_next ?? 'none'}`
+  ].join('\n');
+}
+
+export async function runHandoffGateSummaryCommand(argv = process.argv.slice(2), options = {}) {
+  const parsed = parseHandoffGateSummaryArgs(argv);
+
+  if (parsed.help) {
+    const usage = createUsageText();
+    if (parsed.json) {
+      process.stdout.write(`${JSON.stringify({ ok: true, usage }, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${usage}\n`);
+    }
+    return parsed.ok ? 0 : 2;
+  }
+
+  if (!parsed.ok) {
+    writeCommandOutput(createCommandError(parsed.errors), parsed.json);
+    return 2;
+  }
+
+  const summary = await buildHandoffGateSummary({
+    ...options,
+    changeId: parsed.changeId,
+    stage: parsed.stage
+  });
+
+  if (summary.ok === false) {
+    writeCommandOutput(summary, parsed.json);
+    return 2;
+  }
+
+  writeCommandOutput(summary, parsed.json);
+  return summary.blocking ? 1 : 0;
+}
+
+async function readGateStatus(gate, options) {
+  const candidates = GATE_CANDIDATES[gate];
+  const expectedPath = relativePath(options.rootDir, path.join(options.qaPath, candidates[0]));
+
+  for (const candidate of candidates) {
+    const candidatePath = path.join(options.qaPath, candidate);
+    const evidencePath = relativePath(options.rootDir, candidatePath);
+
+    try {
+      await access(candidatePath);
+    } catch {
+      continue;
+    }
+
+    let content;
+    try {
+      content = await options.readFile(candidatePath, 'utf8');
+    } catch (err) {
+      return {
+        status: 'warn',
+        evidencePath,
+        diagnostics: [diagnostic({
+          code: `${gate}-evidence-unreadable`,
+          severity: 'warning',
+          message: `${gate} gate evidence could not be read: ${evidencePath}.`,
+          path: evidencePath,
+          detail: err?.message ?? String(err)
+        })]
+      };
+    }
+
+    const latest = getLatestGateResult(content, { gate });
+    if (latest === null) {
+      return {
+        status: 'warn',
+        evidencePath,
+        diagnostics: [diagnostic({
+          code: `${gate}-gate-result-missing`,
+          severity: 'warning',
+          message: `${gate} gate evidence has no aif-gate-result block: ${evidencePath}.`,
+          path: evidencePath
+        })]
+      };
+    }
+
+    if (!latest.ok) {
+      return {
+        status: 'warn',
+        evidencePath,
+        diagnostics: latest.errors.map((error) => diagnostic({
+          code: `${gate}-gate-result-invalid`,
+          severity: 'warning',
+          message: `${gate} gate latest aif-gate-result block is invalid: ${error.message}`,
+          path: evidencePath,
+          detail: error.code
+        }))
+      };
+    }
+
+    return {
+      status: latest.result.status,
+      evidencePath,
+      diagnostics: []
+    };
+  }
+
+  return {
+    status: 'warn',
+    evidencePath: expectedPath,
+    diagnostics: [diagnostic({
+      code: `${gate}-evidence-missing`,
+      severity: 'warning',
+      message: `${gate} gate evidence is missing at ${expectedPath}.`,
+      path: expectedPath
+    })]
+  };
+}
+
+async function readCoverageStatus(changeId, options) {
+  const readCoverage = options.readOpenSpecCoverageMatrix ?? defaultReadOpenSpecCoverageMatrix;
+  const coverage = await readCoverage(changeId, {
+    ...options,
+    rootDir: options.rootDir,
+    qaPath: options.qaPath
+  });
+  const status = normalizeCoverageStatus(coverage);
+
+  return {
+    status,
+    evidencePath: coverage?.relativePath ?? relativePath(options.rootDir, path.join(options.qaPath, 'coverage.json')),
+    diagnostics: normalizeDiagnostics(coverage?.diagnostics ?? [], 'warning')
+  };
+}
+
+async function readGeneratedRulesStatus(changeId, options) {
+  const collectGeneratedRules = options.collectGeneratedRules ?? defaultCollectGeneratedRules;
+  const generated = await collectGeneratedRules(changeId, {
+    ...options,
+    rootDir: options.rootDir
+  });
+  const warnings = normalizeDiagnostics(generated?.warnings ?? [], 'warning');
+  const errors = normalizeDiagnostics(generated?.errors ?? [], 'error');
+  const hasStaleRules = (generated?.generatedRules ?? []).some((item) => item?.exists === false || item?.stale === true);
+  const hasStaleDiagnostics = [...warnings, ...errors].some((item) => GENERATED_RULES_STALE_CODES.has(item.code));
+  const status = errors.length > 0 || hasStaleRules || hasStaleDiagnostics
+    ? 'stale'
+    : warnings.length > 0
+      ? 'warn'
+      : 'pass';
+
+  return {
+    status,
+    diagnostics: [...warnings, ...errors]
+  };
+}
+
+function normalizeCoverageStatus(coverage) {
+  const status = coverage?.coverage?.status;
+
+  if (status === 'fail') {
+    return 'fail';
+  }
+
+  if (coverage?.exists && coverage.ok && !coverage.stale && HANDOFF_GATE_STATUSES.includes(status)) {
+    return status;
+  }
+
+  return 'warn';
+}
+
+function routeSummary({ changeId, stage, gates, generatedRules }) {
+  const gateFailure = Object.entries(gates).find(([, status]) => status === 'fail');
+
+  if (generatedRules === 'stale') {
+    return {
+      blocking: true,
+      nextStage: stage,
+      suggestedNext: `/aif-mode sync --change ${changeId}`
+    };
+  }
+
+  if (gateFailure) {
+    return {
+      blocking: true,
+      nextStage: 'implementing',
+      suggestedNext: `/aif-fix ${changeId}`
+    };
+  }
+
+  if (stage === 'review') {
+    return {
+      blocking: false,
+      nextStage: 'done',
+      suggestedNext: `/aif-done ${changeId}`
+    };
+  }
+
+  const mapping = {
+    planning: { nextStage: 'implementing', suggestedNext: `/aif-implement ${changeId}` },
+    implementing: { nextStage: 'review', suggestedNext: `/aif-verify ${changeId}` },
+    done: { nextStage: 'done', suggestedNext: `/aif-done ${changeId}` }
+  };
+
+  return {
+    blocking: false,
+    nextStage: mapping[stage].nextStage,
+    suggestedNext: mapping[stage].suggestedNext
+  };
+}
+
+function createUnresolvedSummary({ stage, diagnostics }) {
+  return {
+    ok: false,
+    schema_version: HANDOFF_GATE_SUMMARY_SCHEMA_VERSION,
+    change_id: null,
+    stage,
+    diagnostics: dedupeDiagnostics(diagnostics)
+  };
+}
+
+function createCommandError(errors) {
+  return {
+    ok: false,
+    schema_version: HANDOFF_GATE_SUMMARY_SCHEMA_VERSION,
+    change_id: null,
+    diagnostics: errors.map((message) => diagnostic({
+      code: 'invalid-arguments',
+      severity: 'error',
+      message
+    })),
+    errors
+  };
+}
+
+function writeCommandOutput(result, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (result.ok === false) {
+    process.stderr.write(`${summarizeHandoffGateSummary(result)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${summarizeHandoffGateSummary(result)}\n`);
+}
+
+function createUsageText() {
+  return [
+    'Usage: node scripts/handoff-gate-summary.mjs [--change <id>] [--stage planning|implementing|review|done] [--json]',
+    'Builds a read-only Handoff orchestration gate summary.'
+  ].join('\n');
+}
+
+function normalizeStage(value) {
+  const stage = value ?? 'review';
+  if (!HANDOFF_GATE_STAGES.includes(stage)) {
+    throw new Error(`Invalid Handoff stage: ${stage}`);
+  }
+  return stage;
+}
+
+function normalizeDiagnostics(items, defaultSeverity) {
+  return items.map((item) => {
+    if (typeof item === 'string') {
+      return diagnostic({
+        code: 'diagnostic',
+        severity: defaultSeverity,
+        message: item
+      });
+    }
+
+    return diagnostic({
+      code: item.code ?? 'diagnostic',
+      severity: item.severity ?? defaultSeverity,
+      message: item.message ?? String(item),
+      path: item.path,
+      detail: item.detail
+    });
+  });
+}
+
+function diagnostic({ code, severity, message, path: diagnosticPath, detail }) {
+  return {
+    code,
+    severity,
+    message,
+    ...(diagnosticPath ? { path: toPosix(diagnosticPath) } : {}),
+    ...(detail ? { detail } : {})
+  };
+}
+
+function dedupeDiagnostics(items) {
+  const seen = new Set();
+  const result = [];
+
+  for (const item of items) {
+    const key = JSON.stringify(item);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(item);
+  }
+
+  return result;
+}
+
+function resolveRootDir(options) {
+  return path.resolve(options.rootDir ?? process.cwd());
+}
+
+function relativePath(rootDir, targetPath) {
+  return toPosix(path.relative(rootDir, targetPath));
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(fileURLToPath(import.meta.url)).href && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exitCode = await runHandoffGateSummaryCommand();
+}

--- a/scripts/handoff-gate-summary.mjs
+++ b/scripts/handoff-gate-summary.mjs
@@ -228,6 +228,8 @@ export async function runHandoffGateSummaryCommand(argv = process.argv.slice(2),
 async function readGateStatus(gate, options) {
   const candidates = GATE_CANDIDATES[gate];
   const expectedPath = relativePath(options.rootDir, path.join(options.qaPath, candidates[0]));
+  const fallbackDiagnostics = [];
+  let firstExistingEvidencePath = null;
 
   for (const candidate of candidates) {
     const candidatePath = path.join(options.qaPath, candidate);
@@ -239,6 +241,8 @@ async function readGateStatus(gate, options) {
       continue;
     }
 
+    firstExistingEvidencePath ??= evidencePath;
+
     let content;
     try {
       content = await options.readFile(candidatePath, 'utf8');
@@ -246,7 +250,7 @@ async function readGateStatus(gate, options) {
       return {
         status: 'warn',
         evidencePath,
-        diagnostics: [diagnostic({
+        diagnostics: [...fallbackDiagnostics, diagnostic({
           code: `${gate}-evidence-unreadable`,
           severity: 'warning',
           message: `${gate} gate evidence could not be read: ${evidencePath}.`,
@@ -258,36 +262,44 @@ async function readGateStatus(gate, options) {
 
     const latest = getLatestGateResult(content, { gate });
     if (latest === null) {
-      return {
-        status: 'warn',
-        evidencePath,
-        diagnostics: [diagnostic({
-          code: `${gate}-gate-result-missing`,
-          severity: 'warning',
-          message: `${gate} gate evidence has no aif-gate-result block: ${evidencePath}.`,
-          path: evidencePath
-        })]
-      };
+      fallbackDiagnostics.push(diagnostic({
+        code: `${gate}-gate-result-missing`,
+        severity: 'warning',
+        message: `${gate} gate evidence has no aif-gate-result block: ${evidencePath}.`,
+        path: evidencePath
+      }));
+      continue;
     }
 
     if (!latest.ok) {
       return {
         status: 'warn',
         evidencePath,
-        diagnostics: latest.errors.map((error) => diagnostic({
-          code: `${gate}-gate-result-invalid`,
-          severity: 'warning',
-          message: `${gate} gate latest aif-gate-result block is invalid: ${error.message}`,
-          path: evidencePath,
-          detail: error.code
-        }))
+        diagnostics: [
+          ...fallbackDiagnostics,
+          ...latest.errors.map((error) => diagnostic({
+            code: `${gate}-gate-result-invalid`,
+            severity: 'warning',
+            message: `${gate} gate latest aif-gate-result block is invalid: ${error.message}`,
+            path: evidencePath,
+            detail: error.code
+          }))
+        ]
       };
     }
 
     return {
       status: latest.result.status,
       evidencePath,
-      diagnostics: []
+      diagnostics: fallbackDiagnostics
+    };
+  }
+
+  if (firstExistingEvidencePath !== null) {
+    return {
+      status: 'warn',
+      evidencePath: firstExistingEvidencePath,
+      diagnostics: fallbackDiagnostics
     };
   }
 

--- a/scripts/handoff-gate-summary.test.mjs
+++ b/scripts/handoff-gate-summary.test.mjs
@@ -236,6 +236,30 @@ describe('Handoff gate summary', () => {
     assert.equal(summary.diagnostics.some((diagnostic) => diagnostic.code === 'rules-evidence-missing'), true);
   });
 
+  it('continues scanning fallback gate evidence after narrative markdown without a gate result', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await writeGate(rootDir, 'add-oauth-login', 'rules.md', 'rules', 'pass');
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth-login/review.md', '# Review\n\nNarrative review notes.\n');
+    await writeGate(rootDir, 'add-oauth-login', 'gates/review.md', 'review', 'fail');
+    await writeGate(rootDir, 'add-oauth-login', 'aif-security-checklist.md', 'security', 'pass');
+    await writeGate(rootDir, 'add-oauth-login', 'verify.md', 'verify', 'pass');
+    await writeCoverage(rootDir, 'add-oauth-login', 'pass');
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.review, 'fail');
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'implementing');
+    assert.equal(summary.suggested_next, '/aif-fix add-oauth-login');
+    assert.equal(summary.evidence.review, '.ai-factory/qa/add-oauth-login/gates/review.md');
+    assert.equal(summary.diagnostics.some((diagnostic) => diagnostic.code === 'review-gate-result-missing'), true);
+  });
+
   it('does not fall back when the latest gate result block is invalid', async () => {
     const rootDir = await createTempRoot();
     await createPassingReviewEvidence(rootDir);

--- a/scripts/handoff-gate-summary.test.mjs
+++ b/scripts/handoff-gate-summary.test.mjs
@@ -1,0 +1,343 @@
+// handoff-gate-summary.test.mjs - tests for Handoff orchestration gate summary
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildHandoffGateSummary,
+  parseHandoffGateSummaryArgs,
+  runHandoffGateSummaryCommand,
+  summarizeHandoffGateSummary
+} from './handoff-gate-summary.mjs';
+import {
+  createGateResult,
+  renderGateResultBlock
+} from './aif-gate-result.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-handoff-gates-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+async function createOpenSpecChange(rootDir, changeId = 'add-oauth-login') {
+  await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+  await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, '# Tasks\n');
+}
+
+async function writeGate(rootDir, changeId, fileName, gate, status) {
+  await writeFixture(rootDir, `.ai-factory/qa/${changeId}/${fileName}`, [
+    `# ${gate}`,
+    '',
+    renderGateResultBlock(createGateResult({
+      gate,
+      status,
+      blockers: status === 'fail'
+        ? [{ id: `${gate}-failed`, severity: 'error', summary: `${gate} failed.` }]
+        : [],
+      suggestedNext: status === 'fail'
+        ? { command: '/aif-fix', reason: `${gate} failed.` }
+        : null
+    })),
+    ''
+  ].join('\n'));
+}
+
+async function writeCoverage(rootDir, changeId, status = 'warn') {
+  await writeFixture(rootDir, `.ai-factory/qa/${changeId}/coverage.json`, JSON.stringify({
+    schema_version: 1,
+    change_id: changeId,
+    status,
+    blocking: status === 'fail',
+    requirements: [],
+    summary: { covered: 0, partial: 0, missing: 0, not_applicable: 0 },
+    diagnostics: []
+  }, null, 2));
+}
+
+function generatedRulesPass() {
+  return {
+    ok: true,
+    changeId: 'add-oauth-login',
+    generatedRules: [
+      { kind: 'merged', path: '.ai-factory/rules/generated/openspec-merged-add-oauth-login.md', exists: true, stale: false },
+      { kind: 'change', path: '.ai-factory/rules/generated/openspec-change-add-oauth-login.md', exists: true, stale: false },
+      { kind: 'base', path: '.ai-factory/rules/generated/openspec-base.md', exists: true, stale: false }
+    ],
+    warnings: [],
+    errors: []
+  };
+}
+
+function generatedRulesStale(warningCode = 'stale-generated-rules') {
+  return {
+    ...generatedRulesPass(),
+    warnings: [{
+      code: warningCode,
+      message: 'Generated rules are stale.',
+      path: '.ai-factory/rules/generated/openspec-merged-add-oauth-login.md'
+    }]
+  };
+}
+
+async function createPassingReviewEvidence(rootDir, changeId = 'add-oauth-login') {
+  await createOpenSpecChange(rootDir, changeId);
+  await writeGate(rootDir, changeId, 'rules.md', 'rules', 'pass');
+  await writeGate(rootDir, changeId, 'aif-review.md', 'review', 'warn');
+  await writeGate(rootDir, changeId, 'aif-security-checklist.md', 'security', 'pass');
+  await writeGate(rootDir, changeId, 'verify.md', 'verify', 'pass');
+  await writeCoverage(rootDir, changeId, 'warn');
+}
+
+async function captureStdout(fn) {
+  const originalWrite = process.stdout.write;
+  const chunks = [];
+  process.stdout.write = (chunk, ...args) => {
+    chunks.push(String(chunk));
+    const callback = args.find((arg) => typeof arg === 'function');
+    if (callback) {
+      callback();
+    }
+    return true;
+  };
+
+  try {
+    return {
+      result: await fn(),
+      stdout: chunks.join('')
+    };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe('Handoff gate summary', () => {
+  it('builds the sample review summary shape from one orchestration result', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.schema_version, 1);
+    assert.equal(summary.change_id, 'add-oauth-login');
+    assert.equal(summary.stage, 'review');
+    assert.deepEqual(summary.gates, {
+      rules: 'pass',
+      review: 'warn',
+      security: 'pass',
+      verify: 'pass',
+      coverage: 'warn'
+    });
+    assert.equal(summary.generatedRules, 'pass');
+    assert.equal(summary.blocking, false);
+    assert.equal(summary.next_stage, 'done');
+    assert.equal(summary.suggested_next, '/aif-done add-oauth-login');
+    assert.match(summarizeHandoffGateSummary(summary), /Suggested next: \/aif-done add-oauth-login/);
+  });
+
+  it('routes rules failures to implementation when generated rules are current', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+    await writeGate(rootDir, 'add-oauth-login', 'rules.md', 'rules', 'fail');
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.rules, 'fail');
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'implementing');
+    assert.equal(summary.suggested_next, '/aif-fix add-oauth-login');
+  });
+
+  it('gives stale generated rules routing priority while preserving gate failures', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+    await writeGate(rootDir, 'add-oauth-login', 'rules.md', 'rules', 'fail');
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesStale()
+    });
+
+    assert.equal(summary.generatedRules, 'stale');
+    assert.equal(summary.gates.rules, 'fail');
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'review');
+    assert.equal(summary.suggested_next, '/aif-mode sync --change add-oauth-login');
+  });
+
+  it('classifies missing generated-rule traces as stale', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesStale('missing-generated-rules-trace')
+    });
+
+    assert.equal(summary.generatedRules, 'stale');
+    assert.equal(summary.suggested_next, '/aif-mode sync --change add-oauth-login');
+  });
+
+  it('reports missing optional gate evidence as warnings without blocking', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await writeGate(rootDir, 'add-oauth-login', 'verify.md', 'verify', 'pass');
+    await writeCoverage(rootDir, 'add-oauth-login', 'pass');
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.rules, 'warn');
+    assert.equal(summary.gates.review, 'warn');
+    assert.equal(summary.gates.security, 'warn');
+    assert.equal(summary.blocking, false);
+    assert.equal(summary.diagnostics.some((diagnostic) => diagnostic.code === 'rules-evidence-missing'), true);
+  });
+
+  it('does not fall back when the latest gate result block is invalid', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+    const pass = createGateResult({
+      gate: 'rules',
+      status: 'pass',
+      blockers: [],
+      affectedFiles: [],
+      suggestedNext: null
+    });
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth-login/rules.md', [
+      renderGateResultBlock(pass),
+      '',
+      '```aif-gate-result',
+      '{"schema_version":1,"gate":"rules"',
+      '```'
+    ].join('\n'));
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.rules, 'warn');
+    assert.equal(summary.diagnostics.some((diagnostic) => diagnostic.code === 'rules-gate-result-invalid'), true);
+  });
+
+  it('does not create runtime or QA directories while summarizing absent evidence', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    const qaPath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth-login');
+
+    assert.equal(await pathExists(qaPath), false);
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.verify, 'warn');
+    assert.equal(await pathExists(qaPath), false);
+  });
+
+  it('parses CLI args and returns deterministic JSON exit codes', async () => {
+    assert.deepEqual(parseHandoffGateSummaryArgs([
+      '--change',
+      'add-oauth-login',
+      '--stage',
+      'review',
+      '--json'
+    ]), {
+      ok: true,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      json: true,
+      help: false,
+      errors: []
+    });
+
+    const invalidStage = parseHandoffGateSummaryArgs(['--stage', 'qa']);
+    assert.equal(invalidStage.ok, false);
+    assert.match(invalidStage.errors[0], /Invalid --stage/);
+
+    const passRoot = await createTempRoot();
+    await createPassingReviewEvidence(passRoot);
+    const pass = await captureStdout(() => runHandoffGateSummaryCommand([
+      '--change',
+      'add-oauth-login',
+      '--stage',
+      'review',
+      '--json'
+    ], {
+      rootDir: passRoot,
+      collectGeneratedRules: async () => generatedRulesPass()
+    }));
+
+    assert.equal(pass.result, 0);
+    assert.equal(JSON.parse(pass.stdout).blocking, false);
+
+    const failRoot = await createTempRoot();
+    await createPassingReviewEvidence(failRoot);
+    await writeGate(failRoot, 'add-oauth-login', 'rules.md', 'rules', 'fail');
+    const fail = await captureStdout(() => runHandoffGateSummaryCommand([
+      '--change',
+      'add-oauth-login',
+      '--json'
+    ], {
+      rootDir: failRoot,
+      collectGeneratedRules: async () => generatedRulesPass()
+    }));
+
+    assert.equal(fail.result, 1);
+    assert.equal(JSON.parse(fail.stdout).suggested_next, '/aif-fix add-oauth-login');
+
+    const invalid = await captureStdout(() => runHandoffGateSummaryCommand([
+      '--stage',
+      'qa',
+      '--json'
+    ], {}));
+
+    assert.equal(invalid.result, 2);
+    assert.equal(JSON.parse(invalid.stdout).ok, false);
+  });
+});


### PR DESCRIPTION
## Summary
- Added a Handoff validation profile that defines the orchestration contract for reading gate status, blocking semantics, and next-step routing.
- Implemented `scripts/handoff-gate-summary.mjs` to produce a single JSON summary from rules, review, security, verify, coverage, and generated-rules inputs.
- Added tests for routing behavior, stale generated rules handling, blocking detection, and read-only summary generation.
- Linked the new profile from the Handoff docs and docs index.

## Testing
- `node --test scripts/handoff-gate-summary.test.mjs`
- `npm run validate`
- `npm test`
- `openspec validate expose-handoff-validation-gates --type change --strict --no-interactive --no-color`
- `node scripts/openspec-artifact-validator.mjs --change expose-handoff-validation-gates --json`
- `git diff --check`