### PR TITLE
Align validation gate routing and tighten Claude agent namespace checks

### DIFF
--- a/docs/handoff-validation-profile.md
+++ b/docs/handoff-validation-profile.md
@@ -79,7 +79,7 @@ Gate Markdown files are parsed through the existing `aif-gate-result` contract. 
 | Status | Meaning |
 |---|---|
 | `pass` | The signal is present and acceptable. |
-| `warn` | Evidence is missing, optional, invalid, stale, or non-blocking. |
+| `warn` | A completed gate or evidence source reported warnings, or non-required evidence is missing/invalid/stale. |
 | `fail` | A gate reports a blocking failure. |
 | `stale` | Generated rules are missing, stale, or have missing/invalid trace metadata. |
 
@@ -87,18 +87,35 @@ Gate `fail` values set `blocking: true`.
 
 `generatedRules: "stale"` also sets `blocking: true` and has routing priority over gate failures. Handoff should run `/aif-mode sync --change <change-id>`, rebuild the summary, and then act on any remaining gate failures.
 
+Warnings are not treated equally for routing. A parsed gate result with `status: "warn"` is completed evidence and does not block by itself. Missing, unreadable, invalid, or stale evidence blocks only when that signal is required for the current stage.
+
+## Required Evidence By Stage
+
+| Stage | Required evidence |
+|---|---|
+| `planning` | none |
+| `implementing` | `verify` |
+| `review` | `review`, `security`, `rules`, `coverage` |
+| `done` | `verify`, `rules`, `coverage` |
+
+When required evidence is missing, unreadable, invalid, or stale, the summary keeps `next_stage` at the current stage and returns the owning command as `suggested_next`.
+
 ## Routing
 
 | Condition | `next_stage` | `suggested_next` |
 |---|---|---|
 | `generatedRules` is `stale` | current stage | `/aif-mode sync --change <change-id>` |
+| required review evidence is missing/invalid at review stage | `review` | `/aif-review <change-id>` |
+| required security evidence is missing/invalid at review stage | `review` | `/aif-security-checklist <change-id>` |
+| required rules evidence is missing/invalid | current stage | `/aif-rules-check` |
+| required verify or coverage evidence is missing/invalid/stale | current stage | `/aif-verify <change-id>` |
 | any gate is `fail` and generated rules are current | `implementing` | `/aif-fix <change-id>` |
 | review stage has no blockers | `done` | `/aif-done <change-id>` |
 | planning stage has no blockers | `implementing` | `/aif-implement <change-id>` |
 | implementing stage has no blockers | `review` | `/aif-verify <change-id>` |
 | done stage has no blockers | `done` | `/aif-done <change-id>` |
 
-Warnings do not block by themselves. Handoff can still display them or require a stricter policy outside this profile.
+Completed warnings do not block by themselves. Handoff can still display them or require a stricter policy outside this profile.
 
 ## CLI Exit Codes
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -106,7 +106,7 @@ fail -> /aif-fix -> /aif-verify -> /aif-done
 | **Planning** | `/aif-plan full`, `/aif-improve`; optional: `aifhub-plan-polisher` | — | Configurable stage mapping в Handoff orchestrator |
 | **Plan Ready** | no worker; gate/status only | — | Stage status tracking API |
 | **Implementing** | `/aif-implement`, `/aif-verify --check-only`; if fail: `/aif-fix` -> `/aif-verify --check-only` | — | Если позже понадобится отдельный handoff binding для verify/fix, это должен быть отдельный scope поверх core workflow |
-| **Review** | `/aif-review`, `/aif-security-checklist`, `/aif-rules-check`; if any gate fails: return to Implementing | `aif-review-handoff-gate.md`, `aif-security-checklist-handoff-gate.md`, `aif-rules-check-handoff-gate.md` | Multi-gate aggregation и conditional return |
+| **Review** | `/aif-review`, `/aif-security-checklist`, `/aif-rules-check`; if any required gate evidence is missing/invalid, stay in Review and run the owning command; if any completed gate fails, return to Implementing | `aif-review-handoff-gate.md`, `aif-security-checklist-handoff-gate.md`, `aif-rules-check-handoff-gate.md` | Multi-gate aggregation и conditional return |
 | **Done** | `/aif-done` | `aif-done-handoff-finalizer.md` | Explicit finalizer stage binding |
 
 ### Что работает сейчас вручную

--- a/scripts/aif-gate-result.mjs
+++ b/scripts/aif-gate-result.mjs
@@ -10,10 +10,10 @@ export const SUPPORTED_STATUSES = Object.freeze(['pass', 'warn', 'fail']);
 
 const BLOCKING_STATUS = 'fail';
 const SUGGESTED_COMMANDS_BY_GATE = Object.freeze({
-  verify: ['/aif-fix'],
-  review: ['/aif-fix'],
-  security: ['/aif-fix'],
-  rules: ['/aif-rules', '/aif-fix']
+  verify: ['/aif-fix', '/aif-verify'],
+  review: ['/aif-fix', '/aif-review'],
+  security: ['/aif-fix', '/aif-security-checklist'],
+  rules: ['/aif-rules', '/aif-rules-check', '/aif-fix', '/aif-mode']
 });
 
 export function createGateResult(input = {}) {
@@ -197,6 +197,7 @@ export function validateGateResult(value, options = {}) {
     for (const [index, blocker] of normalized.blockers.entries()) {
       errors.push(...validateBlocker(blocker, index));
     }
+    errors.push(...validateRulesFailProvenance(normalized));
   }
 
   if (!Array.isArray(normalized.affected_files)) {
@@ -216,14 +217,18 @@ export function validateGateResult(value, options = {}) {
 
 function normalizeBlockers(blockers) {
   return Array.from(blockers ?? []).map((blocker) => {
+    const source = blocker !== null && typeof blocker === 'object' && !Array.isArray(blocker)
+      ? blocker
+      : {};
     const normalized = {
-      id: String(blocker?.id ?? '').trim(),
-      severity: normalizeLowerString(blocker?.severity),
-      summary: String(blocker?.summary ?? '').trim()
+      ...source,
+      id: String(source.id ?? '').trim(),
+      severity: normalizeLowerString(source.severity),
+      summary: String(source.summary ?? '').trim()
     };
 
-    if (blocker?.file !== undefined && blocker.file !== null) {
-      normalized.file = normalizePathString(blocker.file);
+    if (source.file !== undefined && source.file !== null) {
+      normalized.file = normalizePathString(source.file);
     }
 
     return normalized;
@@ -257,6 +262,47 @@ function validateBlocker(blocker, index) {
   return errors;
 }
 
+function validateRulesFailProvenance(result) {
+  if (result.gate !== 'rules' || result.status !== 'fail') {
+    return [];
+  }
+
+  if (result.blockers.length === 0) {
+    return [diagnostic(
+      'invalid-rules-fail-provenance',
+      'rules fail results must include at least one trace-backed blocker.'
+    )];
+  }
+
+  return result.blockers.flatMap((blocker, index) => {
+    if (hasRulesBlockerProvenance(blocker)) {
+      return [];
+    }
+
+    return [diagnostic(
+      'invalid-rules-fail-provenance',
+      `blockers[${index}] for rules fail must include rule_id, rule_source, evidence_path, or source.path plus source.requirement.`
+    )];
+  });
+}
+
+function hasRulesBlockerProvenance(blocker) {
+  return hasNonEmptyString(blocker?.rule_id)
+    || hasNonEmptyString(blocker?.rule_source)
+    || hasNonEmptyString(blocker?.evidence_path)
+    || (
+      blocker?.source !== null
+      && typeof blocker?.source === 'object'
+      && !Array.isArray(blocker.source)
+      && hasNonEmptyString(blocker.source.path)
+      && hasNonEmptyString(blocker.source.requirement)
+    );
+}
+
+function hasNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 function normalizeSuggestedNext(value) {
   if (value === null || value === undefined) {
     return null;
@@ -280,10 +326,10 @@ function validateSuggestedNext(value, gate) {
   const errors = [];
   if (typeof value.command !== 'string' || value.command.trim().length === 0) {
     errors.push(diagnostic('invalid-suggested-next-command', 'suggested_next.command must be a non-empty string.'));
-  } else if (SUPPORTED_GATES.includes(gate) && !SUGGESTED_COMMANDS_BY_GATE[gate].includes(value.command)) {
+  } else if (SUPPORTED_GATES.includes(gate) && !isAllowedSuggestedCommand(value.command, gate)) {
     errors.push(diagnostic(
       'invalid-suggested-next-command',
-      `suggested_next.command for ${gate} must be one of: ${SUGGESTED_COMMANDS_BY_GATE[gate].join(', ')}.`
+      `suggested_next.command for ${gate} must start with one of: ${SUGGESTED_COMMANDS_BY_GATE[gate].join(', ')}.`
     ));
   }
 
@@ -292,6 +338,13 @@ function validateSuggestedNext(value, gate) {
   }
 
   return errors;
+}
+
+function isAllowedSuggestedCommand(command, gate) {
+  const value = String(command ?? '').trim();
+  return SUGGESTED_COMMANDS_BY_GATE[gate].some((allowed) => (
+    value === allowed || value.startsWith(`${allowed} `)
+  ));
 }
 
 function createParsedBlock({ ok, result, raw, startLine, endLine, errors }) {

--- a/scripts/aif-gate-result.test.mjs
+++ b/scripts/aif-gate-result.test.mjs
@@ -43,7 +43,11 @@ describe('aif-gate-result helper', () => {
           id: 'rules-1',
           severity: 'error',
           file: 'src/example.ts',
-          summary: 'Required generated rules are missing.'
+          summary: 'Required generated rules are missing.',
+          source: {
+            path: 'openspec/changes/add-oauth/specs/auth/spec.md',
+            requirement: 'Generated rule traceability'
+          }
         }
       ],
       affectedFiles: ['src/example.ts'],
@@ -63,7 +67,11 @@ describe('aif-gate-result helper', () => {
           id: 'rules-1',
           severity: 'error',
           file: 'src/example.ts',
-          summary: 'Required generated rules are missing.'
+          summary: 'Required generated rules are missing.',
+          source: {
+            path: 'openspec/changes/add-oauth/specs/auth/spec.md',
+            requirement: 'Generated rule traceability'
+          }
         }
       ],
       affected_files: ['src/example.ts'],
@@ -130,7 +138,11 @@ describe('aif-gate-result helper', () => {
           id: 'rules-blocker',
           severity: 'error',
           file: 'src/rules.ts',
-          summary: 'Rule blocker.'
+          summary: 'Rule blocker.',
+          source: {
+            path: 'openspec/changes/add-oauth/specs/auth/spec.md',
+            requirement: 'Generated rule traceability'
+          }
         }
       ],
       affectedFiles: ['src/rules.ts'],
@@ -241,13 +253,144 @@ describe('aif-gate-result helper', () => {
       gate: 'rules',
       status: 'fail',
       blocking: true,
-      blockers: [],
+      blockers: [{
+        id: 'rules-blocker',
+        severity: 'error',
+        summary: 'Rule blocker.',
+        source: {
+          path: 'openspec/changes/add-oauth/specs/auth/spec.md',
+          requirement: 'Generated rule traceability'
+        }
+      }],
       affected_files: [],
       suggested_next: {
         command: '/aif-verify',
         reason: 'Wrong gate follow-up.'
       }
     }).errors[0].code, 'invalid-suggested-next-command');
+  });
+
+  it('accepts owned suggested commands with arguments and rejects near matches', () => {
+    const validRulesSync = validateGateResult({
+      schema_version: 1,
+      gate: 'rules',
+      status: 'warn',
+      blocking: false,
+      blockers: [],
+      affected_files: [],
+      suggested_next: {
+        command: '/aif-mode sync --change add-oauth-login',
+        reason: 'Generated rules are stale.'
+      }
+    });
+    assert.equal(validRulesSync.ok, true);
+
+    const validRulesCheck = validateGateResult({
+      schema_version: 1,
+      gate: 'rules',
+      status: 'warn',
+      blocking: false,
+      blockers: [],
+      affected_files: [],
+      suggested_next: {
+        command: '/aif-rules-check',
+        reason: 'Rerun the rules gate.'
+      }
+    });
+    assert.equal(validRulesCheck.ok, true);
+
+    const validVerifyFix = validateGateResult({
+      schema_version: 1,
+      gate: 'verify',
+      status: 'fail',
+      blocking: true,
+      blockers: [{ id: 'verify-failed', severity: 'error', summary: 'Verify failed.' }],
+      affected_files: [],
+      suggested_next: {
+        command: '/aif-fix add-oauth-login',
+        reason: 'Fix the failing verification finding.'
+      }
+    });
+    assert.equal(validVerifyFix.ok, true);
+
+    for (const command of ['/aif-mode-extra sync --change add-oauth-login', '/aif-fixup add-oauth-login', '/aif-commit']) {
+      const invalid = validateGateResult({
+        schema_version: 1,
+        gate: 'rules',
+        status: 'warn',
+        blocking: false,
+        blockers: [],
+        affected_files: [],
+        suggested_next: {
+          command,
+          reason: 'Not an allowed rules remediation command.'
+        }
+      });
+      assert.equal(invalid.errors[0].code, 'invalid-suggested-next-command');
+    }
+  });
+
+  it('preserves blocker provenance and requires provenance for rules failures', () => {
+    const result = createGateResult({
+      gate: 'rules',
+      status: 'fail',
+      blockers: [{
+        id: ' rules-provenance ',
+        severity: 'ERROR',
+        file: 'src/example.ts',
+        summary: 'Trace-backed generated rule failed.',
+        rule_id: 'openspec-generated-rule-1',
+        rule_source: '.ai-factory/rules/generated/openspec-merged-add-oauth-login.md',
+        evidence_path: 'src/example.ts',
+        source: {
+          path: 'openspec/changes/add-oauth-login/specs/auth/spec.md',
+          requirement: 'OAuth login'
+        }
+      }],
+      affectedFiles: [],
+      suggestedNext: {
+        command: '/aif-fix add-oauth-login',
+        reason: 'Fix the trace-backed rule failure.'
+      }
+    });
+
+    assert.equal(result.blockers[0].id, 'rules-provenance');
+    assert.equal(result.blockers[0].severity, 'error');
+    assert.equal(result.blockers[0].rule_id, 'openspec-generated-rule-1');
+    assert.equal(result.blockers[0].rule_source, '.ai-factory/rules/generated/openspec-merged-add-oauth-login.md');
+    assert.equal(result.blockers[0].evidence_path, 'src/example.ts');
+    assert.deepEqual(result.blockers[0].source, {
+      path: 'openspec/changes/add-oauth-login/specs/auth/spec.md',
+      requirement: 'OAuth login'
+    });
+
+    const missingBlocker = validateGateResult({
+      schema_version: 1,
+      gate: 'rules',
+      status: 'fail',
+      blocking: true,
+      blockers: [],
+      affected_files: [],
+      suggested_next: {
+        command: '/aif-fix add-oauth-login',
+        reason: 'Fix the rule failure.'
+      }
+    });
+    assert.equal(missingBlocker.errors.some((error) => error.code === 'invalid-rules-fail-provenance'), true);
+
+    const missingProvenance = validateGateResult({
+      schema_version: 1,
+      gate: 'rules',
+      status: 'fail',
+      blocking: true,
+      blockers: [{ id: 'rules-failed', severity: 'error', summary: 'Rule failed.' }],
+      affected_files: [],
+      suggested_next: {
+        command: '/aif-fix add-oauth-login',
+        reason: 'Fix the rule failure.'
+      }
+    });
+    assert.equal(missingProvenance.errors.some((error) => error.code === 'invalid-rules-fail-provenance'), true);
   });
 });
 

--- a/scripts/handoff-gate-summary.mjs
+++ b/scripts/handoff-gate-summary.mjs
@@ -31,6 +31,13 @@ const GATE_CANDIDATES = Object.freeze({
   verify: ['verify.md']
 });
 
+const REQUIRED_GATES_BY_STAGE = Object.freeze({
+  planning: [],
+  implementing: ['verify'],
+  review: ['review', 'security', 'rules', 'coverage'],
+  done: ['verify', 'rules', 'coverage']
+});
+
 export function parseHandoffGateSummaryArgs(argv = []) {
   const result = {
     ok: true,
@@ -115,6 +122,7 @@ export async function buildHandoffGateSummary(options = {}) {
   const changeId = resolved.changeId;
   const qaPath = resolved.qaPath ?? path.join(rootDir, '.ai-factory', 'qa', changeId);
   const gateResults = {};
+  const gateSignals = {};
   const diagnostics = normalizeDiagnostics(resolved.warnings, 'warning');
   const evidence = {
     generatedRules: '.ai-factory/rules/generated'
@@ -127,6 +135,7 @@ export async function buildHandoffGateSummary(options = {}) {
       readFile: options.readFile ?? readFile
     });
     gateResults[gate] = result.status;
+    gateSignals[gate] = result;
     if (result.evidencePath) {
       evidence[gate] = result.evidencePath;
     }
@@ -139,6 +148,7 @@ export async function buildHandoffGateSummary(options = {}) {
     qaPath
   });
   gateResults.coverage = coverage.status;
+  gateSignals.coverage = coverage;
   evidence.coverage = coverage.evidencePath;
   diagnostics.push(...coverage.diagnostics);
 
@@ -152,6 +162,7 @@ export async function buildHandoffGateSummary(options = {}) {
     changeId,
     stage,
     gates: gateResults,
+    signals: gateSignals,
     generatedRules: generatedRules.status
   });
 
@@ -249,6 +260,7 @@ async function readGateStatus(gate, options) {
     } catch (err) {
       return {
         status: 'warn',
+        issue: 'unreadable',
         evidencePath,
         diagnostics: [...fallbackDiagnostics, diagnostic({
           code: `${gate}-evidence-unreadable`,
@@ -274,6 +286,7 @@ async function readGateStatus(gate, options) {
     if (!latest.ok) {
       return {
         status: 'warn',
+        issue: 'invalid',
         evidencePath,
         diagnostics: [
           ...fallbackDiagnostics,
@@ -290,6 +303,7 @@ async function readGateStatus(gate, options) {
 
     return {
       status: latest.result.status,
+      issue: null,
       evidencePath,
       diagnostics: fallbackDiagnostics
     };
@@ -298,6 +312,7 @@ async function readGateStatus(gate, options) {
   if (firstExistingEvidencePath !== null) {
     return {
       status: 'warn',
+      issue: 'missing',
       evidencePath: firstExistingEvidencePath,
       diagnostics: fallbackDiagnostics
     };
@@ -305,6 +320,7 @@ async function readGateStatus(gate, options) {
 
   return {
     status: 'warn',
+    issue: 'missing',
     evidencePath: expectedPath,
     diagnostics: [diagnostic({
       code: `${gate}-evidence-missing`,
@@ -323,9 +339,11 @@ async function readCoverageStatus(changeId, options) {
     qaPath: options.qaPath
   });
   const status = normalizeCoverageStatus(coverage);
+  const issue = normalizeCoverageIssue(coverage);
 
   return {
     status,
+    issue,
     evidencePath: coverage?.relativePath ?? relativePath(options.rootDir, path.join(options.qaPath, 'coverage.json')),
     diagnostics: normalizeDiagnostics(coverage?.diagnostics ?? [], 'warning')
   };
@@ -367,7 +385,23 @@ function normalizeCoverageStatus(coverage) {
   return 'warn';
 }
 
-function routeSummary({ changeId, stage, gates, generatedRules }) {
+function normalizeCoverageIssue(coverage) {
+  if (coverage?.exists === false) {
+    return 'missing';
+  }
+
+  if (coverage?.exists === true && coverage.ok === false) {
+    return 'invalid';
+  }
+
+  if (coverage?.stale === true) {
+    return 'stale';
+  }
+
+  return null;
+}
+
+function routeSummary({ changeId, stage, gates, signals, generatedRules }) {
   const gateFailure = Object.entries(gates).find(([, status]) => status === 'fail');
 
   if (generatedRules === 'stale') {
@@ -375,6 +409,15 @@ function routeSummary({ changeId, stage, gates, generatedRules }) {
       blocking: true,
       nextStage: stage,
       suggestedNext: `/aif-mode sync --change ${changeId}`
+    };
+  }
+
+  const requiredEvidenceBlocker = findRequiredEvidenceBlocker(changeId, stage, signals);
+  if (requiredEvidenceBlocker) {
+    return {
+      blocking: true,
+      nextStage: stage,
+      suggestedNext: requiredEvidenceBlocker.suggestedNext
     };
   }
 
@@ -405,6 +448,38 @@ function routeSummary({ changeId, stage, gates, generatedRules }) {
     nextStage: mapping[stage].nextStage,
     suggestedNext: mapping[stage].suggestedNext
   };
+}
+
+function findRequiredEvidenceBlocker(changeId, stage, signals = {}) {
+  const requiredGates = REQUIRED_GATES_BY_STAGE[stage] ?? [];
+  for (const gate of requiredGates) {
+    const issue = signals[gate]?.issue ?? null;
+    if (issue === null) {
+      continue;
+    }
+
+    if (['missing', 'unreadable', 'invalid', 'stale'].includes(issue)) {
+      return {
+        gate,
+        issue,
+        suggestedNext: suggestedNextForRequiredGate(gate, changeId)
+      };
+    }
+  }
+
+  return null;
+}
+
+function suggestedNextForRequiredGate(gate, changeId) {
+  const mapping = {
+    review: (changeId) => `/aif-review ${changeId}`,
+    security: (changeId) => `/aif-security-checklist ${changeId}`,
+    rules: () => '/aif-rules-check',
+    coverage: (changeId) => `/aif-verify ${changeId}`,
+    verify: (changeId) => `/aif-verify ${changeId}`
+  };
+
+  return mapping[gate]?.(changeId) ?? `/aif-verify ${changeId}`;
 }
 
 function createUnresolvedSummary({ stage, diagnostics }) {

--- a/scripts/handoff-gate-summary.test.mjs
+++ b/scripts/handoff-gate-summary.test.mjs
@@ -55,6 +55,15 @@ async function writeGate(rootDir, changeId, fileName, gate, status) {
       status,
       blockers: status === 'fail'
         ? [{ id: `${gate}-failed`, severity: 'error', summary: `${gate} failed.` }]
+          .map((blocker) => gate === 'rules'
+            ? {
+                ...blocker,
+                source: {
+                  path: 'openspec/changes/add-oauth-login/specs/auth/spec.md',
+                  requirement: 'Generated rule traceability'
+                }
+              }
+            : blocker)
         : [],
       suggestedNext: status === 'fail'
         ? { command: '/aif-fix', reason: `${gate} failed.` }
@@ -217,7 +226,7 @@ describe('Handoff gate summary', () => {
     assert.equal(summary.suggested_next, '/aif-mode sync --change add-oauth-login');
   });
 
-  it('reports missing optional gate evidence as warnings without blocking', async () => {
+  it('keeps missing non-required planning gate evidence as warnings without blocking', async () => {
     const rootDir = await createTempRoot();
     await createOpenSpecChange(rootDir);
     await writeGate(rootDir, 'add-oauth-login', 'verify.md', 'verify', 'pass');
@@ -226,6 +235,7 @@ describe('Handoff gate summary', () => {
     const summary = await buildHandoffGateSummary({
       rootDir,
       changeId: 'add-oauth-login',
+      stage: 'planning',
       collectGeneratedRules: async () => generatedRulesPass()
     });
 
@@ -234,6 +244,155 @@ describe('Handoff gate summary', () => {
     assert.equal(summary.gates.security, 'warn');
     assert.equal(summary.blocking, false);
     assert.equal(summary.diagnostics.some((diagnostic) => diagnostic.code === 'rules-evidence-missing'), true);
+  });
+
+  it('blocks review routing when required review evidence is missing', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await writeGate(rootDir, 'add-oauth-login', 'rules.md', 'rules', 'pass');
+    await writeGate(rootDir, 'add-oauth-login', 'aif-security-checklist.md', 'security', 'pass');
+    await writeGate(rootDir, 'add-oauth-login', 'verify.md', 'verify', 'pass');
+    await writeCoverage(rootDir, 'add-oauth-login', 'pass');
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.review, 'warn');
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'review');
+    assert.equal(summary.suggested_next, '/aif-review add-oauth-login');
+  });
+
+  it('blocks review routing when required security or rules evidence is missing', async () => {
+    const securityRoot = await createTempRoot();
+    await createOpenSpecChange(securityRoot);
+    await writeGate(securityRoot, 'add-oauth-login', 'rules.md', 'rules', 'pass');
+    await writeGate(securityRoot, 'add-oauth-login', 'aif-review.md', 'review', 'pass');
+    await writeGate(securityRoot, 'add-oauth-login', 'verify.md', 'verify', 'pass');
+    await writeCoverage(securityRoot, 'add-oauth-login', 'pass');
+
+    const missingSecurity = await buildHandoffGateSummary({
+      rootDir: securityRoot,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+    assert.equal(missingSecurity.blocking, true);
+    assert.equal(missingSecurity.next_stage, 'review');
+    assert.equal(missingSecurity.suggested_next, '/aif-security-checklist add-oauth-login');
+
+    const rulesRoot = await createTempRoot();
+    await createOpenSpecChange(rulesRoot);
+    await writeGate(rulesRoot, 'add-oauth-login', 'aif-review.md', 'review', 'pass');
+    await writeGate(rulesRoot, 'add-oauth-login', 'aif-security-checklist.md', 'security', 'pass');
+    await writeGate(rulesRoot, 'add-oauth-login', 'verify.md', 'verify', 'pass');
+    await writeCoverage(rulesRoot, 'add-oauth-login', 'pass');
+
+    const missingRules = await buildHandoffGateSummary({
+      rootDir: rulesRoot,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+    assert.equal(missingRules.blocking, true);
+    assert.equal(missingRules.next_stage, 'review');
+    assert.equal(missingRules.suggested_next, '/aif-rules-check');
+  });
+
+  it('blocks done routing when required final evidence is missing', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    await writeGate(rootDir, 'add-oauth-login', 'rules.md', 'rules', 'pass');
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      stage: 'done',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'done');
+    assert.equal(summary.suggested_next, '/aif-verify add-oauth-login');
+  });
+
+  it('keeps parsed review warnings non-blocking when required evidence is present', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.review, 'warn');
+    assert.equal(summary.blocking, false);
+    assert.equal(summary.next_stage, 'done');
+  });
+
+  it('blocks required invalid gate evidence at the current stage', async () => {
+    const rootDir = await createTempRoot();
+    await createPassingReviewEvidence(rootDir);
+    await writeFixture(rootDir, '.ai-factory/qa/add-oauth-login/aif-review.md', [
+      '# Review',
+      '',
+      '```aif-gate-result',
+      '{"schema_version":1,"gate":"review"',
+      '```'
+    ].join('\n'));
+
+    const summary = await buildHandoffGateSummary({
+      rootDir,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+
+    assert.equal(summary.gates.review, 'warn');
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'review');
+    assert.equal(summary.suggested_next, '/aif-review add-oauth-login');
+  });
+
+  it('blocks stale required coverage while keeping parsed coverage warnings non-blocking', async () => {
+    const staleRoot = await createTempRoot();
+    await createPassingReviewEvidence(staleRoot);
+
+    const staleCoverage = await buildHandoffGateSummary({
+      rootDir: staleRoot,
+      changeId: 'add-oauth-login',
+      stage: 'done',
+      collectGeneratedRules: async () => generatedRulesPass(),
+      readOpenSpecCoverageMatrix: async () => ({
+        exists: true,
+        ok: true,
+        stale: true,
+        relativePath: '.ai-factory/qa/add-oauth-login/coverage.json',
+        coverage: { status: 'pass' },
+        diagnostics: [{ code: 'coverage-source-stale', message: 'Coverage source changed.' }]
+      })
+    });
+    assert.equal(staleCoverage.gates.coverage, 'warn');
+    assert.equal(staleCoverage.blocking, true);
+    assert.equal(staleCoverage.next_stage, 'done');
+    assert.equal(staleCoverage.suggested_next, '/aif-verify add-oauth-login');
+
+    const warnRoot = await createTempRoot();
+    await createPassingReviewEvidence(warnRoot);
+    const parsedWarn = await buildHandoffGateSummary({
+      rootDir: warnRoot,
+      changeId: 'add-oauth-login',
+      stage: 'review',
+      collectGeneratedRules: async () => generatedRulesPass()
+    });
+    assert.equal(parsedWarn.gates.coverage, 'warn');
+    assert.equal(parsedWarn.blocking, false);
   });
 
   it('continues scanning fallback gate evidence after narrative markdown without a gate result', async () => {
@@ -285,6 +444,9 @@ describe('Handoff gate summary', () => {
     });
 
     assert.equal(summary.gates.rules, 'warn');
+    assert.equal(summary.blocking, true);
+    assert.equal(summary.next_stage, 'review');
+    assert.equal(summary.suggested_next, '/aif-rules-check');
     assert.equal(summary.diagnostics.some((diagnostic) => diagnostic.code === 'rules-gate-result-invalid'), true);
   });
 

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -70,7 +70,11 @@ async function writeRulesGateEvidence(rootDir, changeId = 'add-oauth', status = 
         ? [{
           id: 'rules-failed',
           severity: 'error',
-          summary: 'Rules failed.'
+          summary: 'Rules failed.',
+          source: {
+            path: `openspec/changes/${changeId}/specs/auth/spec.md`,
+            requirement: 'Rules gate evidence'
+          }
         }]
         : [],
       affectedFiles: [],

--- a/scripts/validate-claude-agents.mjs
+++ b/scripts/validate-claude-agents.mjs
@@ -108,12 +108,18 @@ async function validate() {
     // Check name matches aifhub-* namespace
     const name = frontmatter.name || '';
     if (name && !name.startsWith('aifhub-')) {
-      log('WARN', `Agent name does not use aifhub-* namespace`, { file: relPath, name });
+      log('ERROR', `Agent name does not use aifhub-* namespace`, { file: relPath, name });
+      hasErrors = true;
     }
 
     if (!hasErrors) {
       log('INFO', `Agent OK`, { file: relPath });
     }
+  }
+
+  const manifestResult = await validateManifestTargets(repoRoot);
+  if (!manifestResult.ok) {
+    hasErrors = true;
   }
 
   if (hasErrors) {
@@ -123,6 +129,47 @@ async function validate() {
 
   log('INFO', 'All agent files passed');
   return 0;
+}
+
+async function validateManifestTargets(repoRoot) {
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(join(repoRoot, 'extension.json'), 'utf-8'));
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      log('DEBUG', 'extension.json not found; skipping manifest target validation');
+      return { ok: true };
+    }
+
+    log('ERROR', `Cannot read extension.json: ${err.message}`);
+    return { ok: false };
+  }
+
+  let ok = true;
+  const agentFiles = Array.isArray(manifest.agentFiles) ? manifest.agentFiles : [];
+  for (const [index, entry] of agentFiles.entries()) {
+    if (!isClaudeMarkdownAgentFile(entry)) {
+      continue;
+    }
+
+    const target = String(entry?.target ?? '').trim();
+    if (!target.startsWith('aifhub-') || !target.endsWith('.md')) {
+      log('ERROR', 'Claude agent target must use aifhub-*.md namespace', {
+        index,
+        target
+      });
+      ok = false;
+    }
+  }
+
+  return { ok };
+}
+
+function isClaudeMarkdownAgentFile(entry) {
+  const source = String(entry?.source ?? '').replace(/\\/g, '/');
+  const target = String(entry?.target ?? '').replace(/\\/g, '/');
+  return (source.includes('agent-files/claude/') && source.endsWith('.md'))
+    || (source.endsWith('.md') && target.endsWith('.md') && entry?.runtime === 'claude');
 }
 
 process.exit(await validate());

--- a/scripts/validate-claude-agents.test.mjs
+++ b/scripts/validate-claude-agents.test.mjs
@@ -78,6 +78,22 @@ maxTurns: 6
 You are a generic agent.
 `;
 
+const VALID_EXTENSION_JSON = JSON.stringify({
+  agentFiles: [{
+    runtime: 'claude',
+    source: './agent-files/claude/aifhub-test-agent.md',
+    target: 'aifhub-test-agent.md'
+  }]
+}, null, 2);
+
+const NON_NAMESPACED_TARGET_EXTENSION_JSON = JSON.stringify({
+  agentFiles: [{
+    runtime: 'claude',
+    source: './agent-files/claude/aifhub-test-agent.md',
+    target: 'test-agent.md'
+  }]
+}, null, 2);
+
 async function writeFixture(dir, relPath, content) {
   const fullPath = join(dir, relPath);
   await mkdir(join(fullPath, '..'), { recursive: true });
@@ -109,10 +125,24 @@ describe('validate-claude-agents.mjs', () => {
     assert.equal(code, 1);
   });
 
-  it('passes with warning for non-namespaced agent', async () => {
+  it('fails for non-namespaced agent frontmatter', async () => {
     await writeFixture(tmpDir, 'agent-files/claude/generic.md', NON_NAMESPACED_MD);
     const code = await runValidatorExitCode(tmpDir);
+    assert.equal(code, 1);
+  });
+
+  it('validates namespaced Claude manifest targets when extension.json exists', async () => {
+    await writeFixture(tmpDir, 'agent-files/claude/valid.md', VALID_MD);
+    await writeFixture(tmpDir, 'extension.json', VALID_EXTENSION_JSON);
+    const code = await runValidatorExitCode(tmpDir);
     assert.equal(code, 0);
+  });
+
+  it('fails for non-namespaced Claude manifest targets', async () => {
+    await writeFixture(tmpDir, 'agent-files/claude/valid.md', VALID_MD);
+    await writeFixture(tmpDir, 'extension.json', NON_NAMESPACED_TARGET_EXTENSION_JSON);
+    const code = await runValidatorExitCode(tmpDir);
+    assert.equal(code, 1);
   });
 
   it('fails when claude directory does not exist', async () => {

--- a/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/rules.md
+++ b/test/fixtures/openspec-rule-violation/.ai-factory/qa/fixture-change/rules.md
@@ -11,7 +11,11 @@
       "id": "fixture-rule-violation",
       "severity": "error",
       "file": "src/auth/login.ts",
-      "summary": "Fixture intentionally violates generated rule guidance."
+      "summary": "Fixture intentionally violates generated rule guidance.",
+      "source": {
+        "path": "openspec/changes/fixture-change/specs/auth/spec.md",
+        "requirement": "Fixture rule violation"
+      }
     }
   ],
   "affected_files": [


### PR DESCRIPTION
## Summary
- Updated gate-result validation to accept owned remediation commands with arguments while still rejecting near-match command prefixes.
- Preserved blocker provenance fields and added trace-backed requirements for failing rules gates.
- Tightened Handoff routing so required review, security, rules, verify, and coverage evidence blocks progression when missing, stale, or invalid.
- Made Claude agent validation fail on non-`aifhub-*` names and manifest targets.
- Refreshed the Handoff validation docs and added coverage for the new contracts.

## Testing
- Full test suite passed.
- Validation checks passed, including extension manifest, artifact boundary, agent validation, and doc link checks.
- OpenSpec verification and strict spec validation passed for the change.