### PR TITLE
docs(validation): clarify durable rules gate evidence in OpenSpec workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,37 @@ Implement, check optional gates, verify, fix if needed, finalize, sync, commit, 
 /aif-evolve
 ```
 
+Core AI Factory workflow:
+
+```text
+/aif-explore
+/aif-plan full "..."
+/aif-improve <change-id>
+/aif-implement <change-id>
+/aif-verify <change-id>
+/aif-commit
+/aif-evolve
+```
+
+OpenSpec validation overlay:
+
+```text
+/aif-mode sync --change <change-id>
+/aif-rules-check
+/aif-review
+/aif-security-checklist
+/aif-mode doctor --change <change-id>
+/aif-done <change-id>
+```
+
 `/aif-done` finalizes the OpenSpec lifecycle. It archives the accepted OpenSpec change through the OpenSpec CLI when archive is required and writes final evidence under `.ai-factory/qa/<change-id>/` plus final summaries under `.ai-factory/state/<change-id>/`.
 
 It does not replace `/aif-commit`. After `/aif-done`, run `/aif-commit` or your normal git workflow to commit implementation changes, OpenSpec archive/spec changes, QA evidence, and final summaries.
 
-Optional gates:
+Validation gates:
+
+- Optional before verify in relaxed/manual workflow.
+- Required before `/aif-done` when done policy requires durable gate evidence.
 
 - `/aif-rules-check` - read-only rules compliance.
 - `/aif-review` - read-only code review.

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -88,6 +88,21 @@ Doctor also reports `effectivePolicy` from `scripts/openspec-policy.mjs`, includ
 
 `/aif-done` runs `scripts/openspec-done-readiness.mjs` before archive and writes `.ai-factory/qa/<change-id>/done-readiness.json`. The readiness gate checks OpenSpec validate, OpenSpec status, artifact contract, generated rules freshness, rules gate evidence, coverage, verify gate evidence, and dirty workspace state. Blocking failures refuse archive and include an exact suggested next command, such as `/aif-mode sync --change <change-id>`, `/aif-rules-check`, or `/aif-verify <change-id>`.
 
+When `requireRulesPassForDone` is true, save the final `/aif-rules-check` output, or at least its final `aif-gate-result` block, to `.ai-factory/qa/<change-id>/rules.md` before `/aif-done`:
+
+```bash
+node scripts/write-gate-evidence.mjs \
+  --change add-oauth-login \
+  --gate rules \
+  --from /tmp/aif-rules-check-output.md
+```
+
+```bash
+node scripts/write-gate-evidence.mjs --change add-oauth-login --gate rules
+```
+
+The second form reads Markdown from stdin.
+
 The readiness gate runs the artifact validator with verification evidence required and refuses to archive when the validator returns `fail` or blocking `warn`.
 
 `/aif-verify` still writes validation/status/verify evidence under `.ai-factory/qa/<change-id>/` and does not archive. It also writes the separate OpenSpec coverage matrix described in [OpenSpec Coverage Matrix](spec-coverage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ planning:
 implementation:
   /aif-implement <change-id>                        # required
 
-optional gates:
+validation gates:
   /aif-mode sync --change <change-id>               # optional if specs/rules changed
   /aif-rules-check                                  # optional/recommended rules gate
   /aif-review                                       # optional read-only review gate
@@ -350,7 +350,20 @@ Writes:
 
 `/aif-rules-check` is optional after implementation or fixes and useful for strict/high-risk changes. In OpenSpec-native mode it uses generated rules first, loads trace JSON when present, returns a final `aif-gate-result` with `gate: "rules"`, and does not regenerate generated rules.
 
-When done policy requires a rules pass, persist the final rules gate block under `.ai-factory/qa/<change-id>/rules.md`. Generated rules freshness and rules gate pass are separate signals.
+When `requireRulesPassForDone` is true, save the final `/aif-rules-check` output, or at least its final `aif-gate-result` block, to `.ai-factory/qa/<change-id>/rules.md`. Generated rules freshness and rules gate pass are separate signals.
+
+```bash
+node scripts/write-gate-evidence.mjs \
+  --change add-oauth-login \
+  --gate rules \
+  --from /tmp/aif-rules-check-output.md
+```
+
+```bash
+node scripts/write-gate-evidence.mjs --change add-oauth-login --gate rules
+```
+
+In the stdin form, paste or pipe the Markdown gate output into the command.
 
 Generated-rule `FAIL` findings must cite trace-backed `source.path` and `source.requirement`. The generated trace includes output hashes for generated markdown, so status/doctor can warn when generated rule text is manually edited without source-spec changes. If the generated trace is missing or invalid, generated-rule findings are capped at `WARN`; rerun sync to regenerate trace metadata.
 
@@ -470,6 +483,8 @@ Does not write:
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
 Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
+
+If `requireRulesPassForDone` is true and readiness reports missing rules gate evidence, rerun `/aif-rules-check` and persist the final output with `node scripts/write-gate-evidence.mjs --change add-oauth-login --gate rules --from /tmp/aif-rules-check-output.md`, or save at least the final `aif-gate-result` block to `.ai-factory/qa/<change-id>/rules.md`.
 
 Next steps after `/aif-done`:
 

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -83,6 +83,12 @@ describe('complete OpenSpec workflow documentation contract', () => {
 
     assertIncludes(quickStart, '/aif-done` finalizes the OpenSpec lifecycle', 'README.md Quick Start');
     assertIncludes(quickStart, 'It does not replace `/aif-commit`', 'README.md Quick Start');
+    assertIncludes(quickStart, 'Validation gates:', 'README.md Quick Start');
+    assertIncludes(quickStart, 'Optional before verify in relaxed/manual workflow.', 'README.md Quick Start');
+    assertIncludes(quickStart, 'Required before `/aif-done` when done policy requires durable gate evidence.', 'README.md Quick Start');
+    assertIncludes(quickStart, 'Core AI Factory workflow:', 'README.md Quick Start');
+    assertIncludes(quickStart, 'OpenSpec validation overlay:', 'README.md Quick Start');
+    assertNotIncludes(quickStart, 'Optional gates:', 'README.md Quick Start');
   });
 
   it('documents the complete manual workflow in docs/usage.md in workflow order', async () => {
@@ -114,6 +120,22 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '/aif-commit',
       '/aif-evolve'
     ], 'docs/usage.md workflow');
+  });
+
+  it('documents durable rules gate evidence persistence for strict done readiness', async () => {
+    const usage = await readRepoFile('docs/usage.md');
+    const validation = await readRepoFile('docs/openspec-validation.md');
+
+    for (const [label, source] of [
+      ['docs/usage.md', usage],
+      ['docs/openspec-validation.md', validation]
+    ]) {
+      assertIncludes(source, 'requireRulesPassForDone', label);
+      assertIncludes(source, '.ai-factory/qa/<change-id>/rules.md', label);
+      assertIncludes(source, 'node scripts/write-gate-evidence.mjs --change add-oauth-login --gate rules', label);
+      assertIncludes(source, '--from /tmp/aif-rules-check-output.md', label);
+      assertIncludes(source, 'final `aif-gate-result` block', label);
+    }
   });
 
   it('documents planned bug fixes separately from post-verify fixes', async () => {

--- a/scripts/write-gate-evidence.mjs
+++ b/scripts/write-gate-evidence.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// write-gate-evidence.mjs - persist validated AI Factory gate evidence
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { normalizeChangeId } from './active-change-resolver.mjs';
+import { getLatestGateResult, SUPPORTED_GATES } from './aif-gate-result.mjs';
+
+const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
+
+export function parseWriteGateEvidenceArgs(argv = []) {
+  const result = {
+    ok: true,
+    changeId: null,
+    gate: null,
+    from: null,
+    json: false,
+    force: false,
+    help: false,
+    errors: []
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+      continue;
+    }
+
+    if (arg === '--json') {
+      result.json = true;
+      continue;
+    }
+
+    if (arg === '--force') {
+      result.force = true;
+      continue;
+    }
+
+    if (arg === '--change') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        result.errors.push('Missing value for --change.');
+      } else {
+        const normalized = normalizeChangeId(value);
+        if (!normalized.ok) {
+          result.errors.push(normalized.error.message);
+        } else {
+          result.changeId = normalized.changeId;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg === '--gate') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        result.errors.push('Missing value for --gate.');
+      } else {
+        const gate = String(value).trim().toLowerCase();
+        if (!SUPPORTED_GATES.includes(gate)) {
+          result.errors.push(`Invalid --gate '${value}'. Expected one of: ${SUPPORTED_GATES.join(', ')}.`);
+        } else {
+          result.gate = gate;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg === '--from') {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        result.errors.push('Missing value for --from.');
+      } else {
+        result.from = value;
+        index += 1;
+      }
+      continue;
+    }
+
+    result.errors.push(`Unknown argument: ${arg}.`);
+  }
+
+  if (!result.help) {
+    if (result.changeId === null) {
+      result.errors.push('Missing required --change <change-id>.');
+    }
+    if (result.gate === null) {
+      result.errors.push(`Missing required --gate <${SUPPORTED_GATES.join('|')}>.`);
+    }
+  }
+
+  result.ok = result.errors.length === 0;
+  return result;
+}
+
+export async function writeGateEvidence(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const normalized = normalizeChangeId(options.changeId);
+  if (!normalized.ok) {
+    return commandFailure('invalid-change-id', normalized.error.message);
+  }
+
+  const gate = String(options.gate ?? '').trim().toLowerCase();
+  if (!SUPPORTED_GATES.includes(gate)) {
+    return commandFailure('invalid-gate', `Invalid --gate '${options.gate}'. Expected one of: ${SUPPORTED_GATES.join(', ')}.`);
+  }
+
+  const markdownResult = await readInputMarkdown({
+    ...options,
+    rootDir,
+    readFile: options.readFile ?? readFile
+  });
+  if (!markdownResult.ok) {
+    return markdownResult;
+  }
+
+  const latest = getLatestGateResult(markdownResult.markdown, { gate });
+  if (latest === null) {
+    return commandFailure(
+      'invalid-gate-evidence',
+      `No valid aif-gate-result block found for gate '${gate}'.`
+    );
+  }
+
+  if (!latest.ok) {
+    return commandFailure(
+      'invalid-gate-evidence',
+      `Invalid latest aif-gate-result block for gate '${gate}': ${latest.errors.map((error) => error.message).join('; ')}`
+    );
+  }
+
+  const targetPath = path.join(rootDir, DEFAULT_QA_DIR, normalized.changeId, `${gate}.md`);
+  const relativeTargetPath = toPosix(path.relative(rootDir, targetPath));
+
+  if (!options.force && await pathExists(targetPath, options.access ?? access)) {
+    return commandFailure(
+      'evidence-exists',
+      `Gate evidence already exists at ${relativeTargetPath}. Rerun with --force to overwrite it.`,
+      relativeTargetPath
+    );
+  }
+
+  await (options.mkdir ?? mkdir)(path.dirname(targetPath), { recursive: true });
+  await (options.writeFile ?? writeFile)(targetPath, markdownResult.markdown, 'utf8');
+
+  return {
+    ok: true,
+    change_id: normalized.changeId,
+    gate,
+    path: relativeTargetPath,
+    status: latest.result.status
+  };
+}
+
+export async function runWriteGateEvidenceCommand(argv = process.argv.slice(2), options = {}) {
+  const parsed = parseWriteGateEvidenceArgs(argv);
+
+  if (parsed.help) {
+    const usage = createUsageText();
+    if (parsed.json) {
+      process.stdout.write(`${JSON.stringify({ ok: true, usage }, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${usage}\n`);
+    }
+    return parsed.ok ? 0 : 2;
+  }
+
+  if (!parsed.ok) {
+    writeCommandOutput(commandFailure('invalid-arguments', parsed.errors.join(' ')), parsed.json);
+    return 2;
+  }
+
+  const markdown = parsed.from === null
+    ? await readStream(options.stdin ?? process.stdin)
+    : undefined;
+
+  const result = await writeGateEvidence({
+    ...options,
+    rootDir: options.rootDir ?? process.cwd(),
+    changeId: parsed.changeId,
+    gate: parsed.gate,
+    from: parsed.from,
+    markdown,
+    force: parsed.force
+  });
+
+  writeCommandOutput(result, parsed.json);
+  return result.ok ? 0 : 2;
+}
+
+async function readInputMarkdown(options) {
+  if (options.markdown !== undefined && options.markdown !== null) {
+    return {
+      ok: true,
+      markdown: String(options.markdown)
+    };
+  }
+
+  if (options.from === undefined || options.from === null || String(options.from).trim().length === 0) {
+    return commandFailure('missing-input', 'No gate evidence markdown was provided.');
+  }
+
+  const inputPath = path.isAbsolute(options.from)
+    ? options.from
+    : path.resolve(options.rootDir, options.from);
+
+  try {
+    return {
+      ok: true,
+      markdown: await options.readFile(inputPath, 'utf8')
+    };
+  } catch (err) {
+    return commandFailure(
+      'input-unreadable',
+      `Gate evidence input could not be read: ${toPosix(path.relative(options.rootDir, inputPath))}.`,
+      toPosix(path.relative(options.rootDir, inputPath)),
+      err?.message ?? String(err)
+    );
+  }
+}
+
+async function pathExists(targetPath, accessFn) {
+  try {
+    await accessFn(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readStream(stream) {
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function writeCommandOutput(result, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (!result.ok) {
+    process.stderr.write(`${result.errors.map((error) => error.message).join('\n')}\n`);
+    return;
+  }
+
+  process.stdout.write(`Wrote ${result.gate} gate evidence to ${result.path} (${result.status}).\n`);
+}
+
+function commandFailure(code, message, targetPath, detail) {
+  return {
+    ok: false,
+    errors: [
+      {
+        code,
+        message,
+        ...(targetPath ? { path: targetPath } : {}),
+        ...(detail ? { detail } : {})
+      }
+    ]
+  };
+}
+
+function createUsageText() {
+  return [
+    'Usage: node scripts/write-gate-evidence.mjs --change <id> --gate rules|review|security|verify [--from <markdown-file>] [--force] [--json]',
+    'Reads gate Markdown from --from or stdin, validates the final matching aif-gate-result block, and writes .ai-factory/qa/<change-id>/<gate>.md.'
+  ].join('\n');
+}
+
+function toPosix(value) {
+  return String(value ?? '').replaceAll(path.sep, '/');
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === pathToFileURL(fileURLToPath(import.meta.url)).href) {
+  process.exitCode = await runWriteGateEvidenceCommand();
+}

--- a/scripts/write-gate-evidence.test.mjs
+++ b/scripts/write-gate-evidence.test.mjs
@@ -1,0 +1,338 @@
+// write-gate-evidence.test.mjs - tests for durable gate evidence persistence
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import {
+  parseWriteGateEvidenceArgs,
+  runWriteGateEvidenceCommand,
+  writeGateEvidence
+} from './write-gate-evidence.mjs';
+import {
+  createGateResult,
+  renderGateResultBlock
+} from './aif-gate-result.mjs';
+
+const tempRoots = [];
+
+async function createTempRoot() {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), 'aifhub-gate-evidence-'));
+  tempRoots.push(rootDir);
+  return rootDir;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeFixture(rootDir, relativePath, content) {
+  const targetPath = path.join(rootDir, ...relativePath.split('/'));
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, content, 'utf8');
+  return targetPath;
+}
+
+function evidencePath(rootDir, changeId, gate) {
+  return path.join(rootDir, '.ai-factory', 'qa', changeId, `${gate}.md`);
+}
+
+function gateMarkdown(gate, status = 'pass') {
+  return [
+    `# ${gate} gate`,
+    '',
+    renderGateResultBlock(createGateResult({
+      gate,
+      status,
+      blockers: status === 'fail'
+        ? [{
+            id: `${gate}-failure`,
+            severity: 'error',
+            summary: `${gate} failed.`,
+            ...(gate === 'rules'
+              ? {
+                  source: {
+                    path: 'openspec/changes/add-oauth-login/specs/auth/spec.md',
+                    requirement: 'Rules gate evidence'
+                  }
+                }
+              : {})
+          }]
+        : [],
+      affectedFiles: [],
+      suggestedNext: status === 'fail'
+        ? { command: gate === 'rules' ? '/aif-rules-check' : '/aif-fix', reason: `${gate} failed.` }
+        : null
+    })),
+    ''
+  ].join('\n');
+}
+
+async function captureCommand(argv, options = {}) {
+  const stdout = [];
+  const stderr = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  process.stdout.write = (chunk, ...args) => {
+    stdout.push(String(chunk));
+    const callback = args.find((arg) => typeof arg === 'function');
+    callback?.();
+    return true;
+  };
+  process.stderr.write = (chunk, ...args) => {
+    stderr.push(String(chunk));
+    const callback = args.find((arg) => typeof arg === 'function');
+    callback?.();
+    return true;
+  };
+
+  try {
+    const exitCode = await runWriteGateEvidenceCommand(argv, options);
+    return {
+      exitCode,
+      stdout: stdout.join(''),
+      stderr: stderr.join('')
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+afterEach(async () => {
+  while (tempRoots.length > 0) {
+    await rm(tempRoots.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('write-gate-evidence helper', () => {
+  it('exports the required public functions and parses supported arguments', () => {
+    assert.equal(typeof parseWriteGateEvidenceArgs, 'function');
+    assert.equal(typeof writeGateEvidence, 'function');
+    assert.equal(typeof runWriteGateEvidenceCommand, 'function');
+
+    assert.deepEqual(parseWriteGateEvidenceArgs([
+      '--change', 'add-oauth-login',
+      '--gate', 'rules',
+      '--from', 'gate.md',
+      '--json',
+      '--force'
+    ]), {
+      ok: true,
+      changeId: 'add-oauth-login',
+      gate: 'rules',
+      from: 'gate.md',
+      json: true,
+      force: true,
+      help: false,
+      errors: []
+    });
+  });
+
+  it('writes valid rules gate markdown to the durable QA path', async () => {
+    const rootDir = await createTempRoot();
+    const markdown = gateMarkdown('rules');
+
+    const result = await writeGateEvidence({
+      rootDir,
+      changeId: 'add-oauth-login',
+      gate: 'rules',
+      markdown
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.path, '.ai-factory/qa/add-oauth-login/rules.md');
+    assert.equal(result.status, 'pass');
+    assert.equal(await readFile(evidencePath(rootDir, 'add-oauth-login', 'rules'), 'utf8'), markdown);
+  });
+
+  it('rejects missing, invalid, and wrong-gate evidence before creating files', async () => {
+    const rootDir = await createTempRoot();
+
+    for (const [label, markdown] of [
+      ['missing', '# Rules\n\nNo machine-readable gate.\n'],
+      ['invalid', ['```aif-gate-result', '{"schema_version":1,"gate":"rules"', '```'].join('\n')],
+      ['wrong gate', gateMarkdown('review')]
+    ]) {
+      const result = await writeGateEvidence({
+        rootDir,
+        changeId: `reject-${label.replace(/\s+/g, '-')}`,
+        gate: 'rules',
+        markdown
+      });
+
+      assert.equal(result.ok, false, `${label} evidence should be rejected`);
+      assert.equal(await pathExists(evidencePath(rootDir, `reject-${label.replace(/\s+/g, '-')}`, 'rules')), false);
+    }
+  });
+
+  it('refuses unsafe change ids before filesystem writes', async () => {
+    const rootDir = await createTempRoot();
+
+    for (const changeId of ['../escape', 'nested/change', 'nested\\change', '/absolute', 'safe..unsafe']) {
+      const result = await writeGateEvidence({
+        rootDir,
+        changeId,
+        gate: 'rules',
+        markdown: gateMarkdown('rules')
+      });
+
+      assert.equal(result.ok, false, `${changeId} should be rejected`);
+    }
+
+    assert.equal(await pathExists(path.join(rootDir, '.ai-factory')), false);
+  });
+
+  it('supports review, security, rules, and verify evidence files', async () => {
+    const rootDir = await createTempRoot();
+
+    for (const gate of ['review', 'security', 'rules', 'verify']) {
+      const result = await writeGateEvidence({
+        rootDir,
+        changeId: 'add-oauth-login',
+        gate,
+        markdown: gateMarkdown(gate)
+      });
+
+      assert.equal(result.ok, true, `${gate} should be written`);
+      assert.equal(result.path, `.ai-factory/qa/add-oauth-login/${gate}.md`);
+      assert.equal(await pathExists(evidencePath(rootDir, 'add-oauth-login', gate)), true);
+    }
+  });
+
+  it('reads markdown from --from files and stdin CLI input', async () => {
+    const fromRoot = await createTempRoot();
+    await writeFixture(fromRoot, 'tmp/rules-output.md', gateMarkdown('rules'));
+
+    const fromResult = await writeGateEvidence({
+      rootDir: fromRoot,
+      changeId: 'from-file',
+      gate: 'rules',
+      from: 'tmp/rules-output.md'
+    });
+    assert.equal(fromResult.ok, true);
+    assert.equal(await pathExists(evidencePath(fromRoot, 'from-file', 'rules')), true);
+
+    const stdinRoot = await createTempRoot();
+    const captured = await captureCommand([
+      '--change', 'from-stdin',
+      '--gate', 'rules',
+      '--json'
+    ], {
+      rootDir: stdinRoot,
+      stdin: Readable.from([gateMarkdown('rules')])
+    });
+
+    assert.equal(captured.exitCode, 0);
+    assert.equal(captured.stderr, '');
+    assert.equal(JSON.parse(captured.stdout).path, '.ai-factory/qa/from-stdin/rules.md');
+    assert.equal(await pathExists(evidencePath(stdinRoot, 'from-stdin', 'rules')), true);
+  });
+
+  it('does not fall back when the latest matching gate block is invalid', async () => {
+    const rootDir = await createTempRoot();
+    const markdown = [
+      gateMarkdown('rules'),
+      '```aif-gate-result',
+      '{"schema_version":1,"gate":"rules"',
+      '```'
+    ].join('\n');
+
+    const result = await writeGateEvidence({
+      rootDir,
+      changeId: 'invalid-latest',
+      gate: 'rules',
+      markdown
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errors[0].code, 'invalid-gate-evidence');
+    assert.equal(await pathExists(evidencePath(rootDir, 'invalid-latest', 'rules')), false);
+  });
+
+  it('protects existing evidence unless --force is provided and validates forced replacements first', async () => {
+    const rootDir = await createTempRoot();
+    const original = gateMarkdown('rules', 'pass');
+    const replacement = gateMarkdown('rules', 'warn');
+
+    assert.equal((await writeGateEvidence({
+      rootDir,
+      changeId: 'overwrite',
+      gate: 'rules',
+      markdown: original
+    })).ok, true);
+
+    const refused = await writeGateEvidence({
+      rootDir,
+      changeId: 'overwrite',
+      gate: 'rules',
+      markdown: replacement
+    });
+    assert.equal(refused.ok, false);
+    assert.equal(refused.errors[0].code, 'evidence-exists');
+    assert.equal(await readFile(evidencePath(rootDir, 'overwrite', 'rules'), 'utf8'), original);
+
+    const invalidForced = await writeGateEvidence({
+      rootDir,
+      changeId: 'overwrite',
+      gate: 'rules',
+      force: true,
+      markdown: '# invalid replacement\n'
+    });
+    assert.equal(invalidForced.ok, false);
+    assert.equal(await readFile(evidencePath(rootDir, 'overwrite', 'rules'), 'utf8'), original);
+
+    const forced = await writeGateEvidence({
+      rootDir,
+      changeId: 'overwrite',
+      gate: 'rules',
+      force: true,
+      markdown: replacement
+    });
+    assert.equal(forced.ok, true);
+    assert.equal(forced.status, 'warn');
+    assert.equal(await readFile(evidencePath(rootDir, 'overwrite', 'rules'), 'utf8'), replacement);
+  });
+
+  it('returns deterministic CLI exit codes for success, invalid args, invalid evidence, and overwrite refusal', async () => {
+    const rootDir = await createTempRoot();
+    const success = await captureCommand([
+      '--change', 'cli-success',
+      '--gate', 'rules'
+    ], {
+      rootDir,
+      stdin: Readable.from([gateMarkdown('rules')])
+    });
+    assert.equal(success.exitCode, 0);
+    assert.match(success.stdout, /Wrote rules gate evidence to \.ai-factory\/qa\/cli-success\/rules\.md/);
+
+    const invalidArgs = await captureCommand(['--change', 'cli-bad', '--gate', 'unknown'], {
+      rootDir,
+      stdin: Readable.from([gateMarkdown('rules')])
+    });
+    assert.equal(invalidArgs.exitCode, 2);
+    assert.match(invalidArgs.stderr, /Invalid --gate/);
+
+    const invalidEvidence = await captureCommand(['--change', 'cli-invalid', '--gate', 'rules'], {
+      rootDir,
+      stdin: Readable.from(['# no gate\n'])
+    });
+    assert.equal(invalidEvidence.exitCode, 2);
+    assert.match(invalidEvidence.stderr, /No valid aif-gate-result block/);
+
+    const overwriteRefused = await captureCommand(['--change', 'cli-success', '--gate', 'rules'], {
+      rootDir,
+      stdin: Readable.from([gateMarkdown('rules')])
+    });
+    assert.equal(overwriteRefused.exitCode, 2);
+    assert.match(overwriteRefused.stderr, /already exists/);
+  });
+});


### PR DESCRIPTION
## Summary

- Clarifies the core AI Factory workflow versus the OpenSpec validation overlay in README.
- Documents durable rules gate evidence persistence for strict `/aif-done` readiness in `docs/usage.md` and `docs/openspec-validation.md`.
- Adds `scripts/write-gate-evidence.mjs` with focused tests for validated gate evidence persistence across `rules`, `review`, `security`, and `verify` gates.

## Validation

- `npm run validate`
- `npm test` (358 passed)
- `git diff --check`
- `openspec validate clarify-durable-rules-gate-evidence --type change --strict --no-interactive --no-color`
- `node scripts/openspec-artifact-validator.mjs --change clarify-durable-rules-gate-evidence --json`
- `/aif-verify clarify-durable-rules-gate-evidence` returned `warn` only because durable rules evidence is intentionally read-only until persisted
- `/aif-rules-check` returned `pass`
