### PR TITLE
[codex] sync AI Factory baseline 2.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AI Factory UX + OpenSpec artifact protocol
 - Keeps AI Factory runtime state, verification evidence, finalization evidence, and generated rules outside canonical OpenSpec changes.
 - Requests OpenSpec validation, status, instructions, and archive through the AIFHub wrapper and `scripts/openspec-runner.mjs` when a compatible CLI is available.
 - Preserves legacy AI Factory-only plan folders as compatibility and migration input only.
-- Publishes namespaced Codex and Claude agent files through the extension manifest for explicit user or orchestrator invocation.
+- Publishes namespaced Codex CLI and Claude agent files through the extension manifest for explicit user or orchestrator invocation.
 - Publishes an optional `aifhub` MCP server whose settings are rendered by AI Factory per runtime.
 - Does not install OpenSpec skills or slash commands.
 
@@ -303,7 +303,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Active Change Resolver](docs/active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](docs/adr/0001-openspec-native-artifact-protocol.md) | v1 artifact ownership decision |
 | [AIFHub MCP](docs/aifhub-mcp.md) | Optional MCP server tools and runtime-specific settings shapes |
-| [Codex Agents](docs/codex-agents.md) | Namespaced Codex agent files |
+| [Codex Agents](docs/codex-agents.md) | Namespaced Codex CLI agent files |
 | [Claude Agents](docs/claude-agents.md) | Namespaced Claude agent files |
 
 ## Validation

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -6,10 +6,10 @@
   "sources": {
     "ai-factory": {
       "url": "https://github.com/lee-to/ai-factory",
-      "version": "2.11.0",
-      "baselineVersion": "2.11.0",
-      "lastSync": "2026-05-01",
-      "notes": "Validated against upstream 2.11.0 on the 2.x branch. AI Factory 2.11.0 bundles the native aif-rules-check skill and extension manifest schema, so AIFHub keeps only the OpenSpec generated-rules injection."
+      "version": "2.12.0",
+      "baselineVersion": "2.12.0",
+      "lastSync": "2026-05-15",
+      "notes": "Validated against upstream 2.12.0 on the 2.x branch. AI Factory 2.12.0 adds the codex-app runtime, bundled Codex CLI native agents, audit-artifacts, sequential plan IDs, and language.technical_terms policy."
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",

--- a/docs/codex-agents.md
+++ b/docs/codex-agents.md
@@ -2,6 +2,17 @@
 
 # Codex Agents
 
+## Codex Runtime Matrix
+
+| Runtime | Skills path | Agent files | MCP/config path | AI Factory invocation |
+|---|---|---|---|---|
+| Codex CLI (`codex`) | `.codex/skills` | `.codex/agents` installed from extension `agentFiles` entries with `runtime: "codex"` | `.codex/config.toml` | `$aif-*` |
+| Codex app (`codex-app`) | `.agents/skills` | no extension `agentFiles` target yet | `.codex/config.toml` | `$aif-*` |
+
+The extension `agentFiles` cannot target `codex-app` yet. Codex app receives skills under `.agents/skills` and MCP config through `.codex/config.toml`; it does not receive AIFHub Codex CLI agent TOML files through the extension manifest.
+
+The `aifhub-*` Codex agents are extension helpers for bounded planning, implementation, review, verification, fixes, and finalization. They are not replacements for upstream bundled Codex CLI agents such as `plan-coordinator`, `implement-coordinator`, and `review-sidecar`.
+
 Эта страница описывает bundled Codex agents, которые extension публикует через `extension.json -> agentFiles`.
 
 ## Что именно ставится

--- a/docs/codex-plan-mode.md
+++ b/docs/codex-plan-mode.md
@@ -18,19 +18,21 @@ The extension does not switch modes automatically. The user controls the mode, a
 /plan-mode
 
 # 2. Planning and refinement (Plan mode)
-/aif-explore "task description"
-/aif-plan full "task description"
-/aif-improve
+$aif-explore "task description"
+$aif-plan full "task description"
+$aif-improve
 
 # 3. Exit Plan mode (user action)
 exit plan mode
 
 # 4. Execution and verification (Default mode)
-/aif-implement
-/aif-verify
+$aif-implement
+$aif-verify
 ```
 
-During `/aif-implement`, the OpenSpec `tasks.md` checklist remains canonical. Codex should mirror that checklist into runtime todo state with `update_plan` when available; otherwise it should show a task snapshot and continue from `tasks.md`.
+`/plan-mode` is a client-owned mode command, not an AI Factory skill invocation. In Codex app, AI Factory skills use `$aif-*`; slash-command runtimes keep `/aif-*`.
+
+During `$aif-implement`, the OpenSpec `tasks.md` checklist remains canonical. Codex should mirror that checklist into runtime todo state with `update_plan` when available; otherwise it should show a task snapshot and continue from `tasks.md`.
 
 ## Question Format by Mode
 
@@ -88,11 +90,11 @@ Open questions (parent to resolve):
 
 The extension prompts (`injections/core/aif-*-plan-folder.md`) include Codex runtime guidance that:
 
-- Recommends Plan mode specifically for `/aif-explore`, `/aif-plan full`, and `/aif-improve` when structured planning questions are needed.
+- Recommends Plan mode specifically for `$aif-explore`, `$aif-plan full`, and `$aif-improve` in Codex app when structured planning questions are needed.
 - Does not attempt or promise to switch the session mode.
 - Falls back to plain-text questions in Default mode and does not require `question(...)` or `questionnaire(...)` in Codex.
 - Avoids interactive questions in subagent context.
-- Hydrates `/aif-implement` runtime todo state from OpenSpec `tasks.md` when a todo or plan tool is available, or reports a task snapshot capability fallback.
+- Hydrates `$aif-implement` runtime todo state from OpenSpec `tasks.md` when a todo or plan tool is available, or reports a task snapshot capability fallback.
 
 This means the issue of automatic mode switching is **documented + prompt-safe**, not implemented as client automation.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -87,6 +87,12 @@ Action toggles such as `validateOnPlan`, `validateOnImprove`, `validateOnVerify`
 
 The defaults keep planning and verification degraded-friendly while making `/aif-done` strict: verify can warn on missing CLI, generated rules, rules gate evidence, or coverage evidence; done requires current generated rules, a passing durable rules gate, current passing coverage, and archive-capable CLI unless config relaxes those requirements.
 
+## Workflow Plan ID Policy
+
+OpenSpec-native mode uses OpenSpec `change-id` values and ignores AI Factory `workflow.plan_id_format` for canonical artifact names. The active change directory stays `openspec/changes/<change-id>/` whether upstream AI Factory is configured for `slug` or `sequential` legacy plan IDs.
+
+Legacy AI Factory-only mode follows upstream `workflow.plan_id_format`. Use `slug` for slug-named plan files, or `sequential` for upstream sequential filenames under `paths.plans`.
+
 ## AIFHub Wrapper Behavior
 
 | AIFHub command | OpenSpec CLI feature |
@@ -102,6 +108,16 @@ The defaults keep planning and verification degraded-friendly while making `/aif
 | `/aif-mode doctor` | CLI, Node, active change, effective policy, generated rules, latest verify gate, rules gate, coverage, AIFHub artifact contract, and archive readiness diagnostics |
 
 Do not route users to OpenSpec slash commands such as `/opsx:propose`, `/opsx:apply`, or `/opsx:archive`.
+
+## AI Factory 2.12 Optional Artifact Audit Bridge
+
+AI Factory 2.12+ provides an optional read-only artifact audit command that can inspect OpenSpec and AIFHub runtime evidence together:
+
+```bash
+ai-factory audit-artifacts openspec .ai-factory/qa .ai-factory/state --json
+```
+
+This audit bridge is diagnostic-only for AIFHub Extension. It may supplement `/aif-mode doctor` output when available, but it is not mandatory, not archive-blocking, and not a replacement for AIFHub generated rules, coverage, rules gate, verify gate, or OpenSpec archive readiness checks.
 
 ## Artifact Sync Points
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,7 +47,7 @@ OpenSpec-native mode uses OpenSpec artifacts as canonical planning/spec artifact
 
 The `aifhub-extension` package repository stays artifact-light: root `openspec/`, `.ai-factory/state/`, `.ai-factory/qa/`, `.ai-factory/plans/`, and `.ai-factory/rules/generated/` are not extension package source. Root `.ai-factory/rules/generated/` is derived in user projects and safe to regenerate. OpenSpec examples may be committed only under fixture paths such as `test/fixtures/` or `scripts/fixtures/`.
 
-AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Users should keep using `/aif-*` commands; this extension does not install or rely on OpenSpec slash commands.
+AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
 
 ## Bug Fix Workflows
 
@@ -646,19 +646,21 @@ Codex cannot switch modes from extension prompts. The user controls the mode man
 
 ```text
 # Plan mode, user action
-/aif-explore "task description"
-/aif-plan full "task description"
-/aif-improve <change-id>
-/aif-mode sync --change <change-id>
+$aif-explore "task description"
+$aif-plan full "task description"
+$aif-improve <change-id>
+$aif-mode sync --change <change-id>
 
 # Default mode, user action
-/aif-implement <change-id>
-/aif-rules-check
-/aif-verify <change-id>
-/aif-done <change-id>
-/aif-mode sync
-/aif-commit
+$aif-implement <change-id>
+$aif-rules-check
+$aif-verify <change-id>
+$aif-done <change-id>
+$aif-mode sync
+$aif-commit
 ```
+
+Slash-command runtimes use the same workflow with `/aif-*` commands.
 
 In Codex Default mode, prompts must ask plain-text questions rather than using `request_user_input`.
 

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -19,6 +19,13 @@ function assertIncludes(source, expected, filePath) {
   );
 }
 
+function assertNotIncludes(source, unexpected, filePath) {
+  assert.ok(
+    !source.includes(unexpected),
+    `${filePath} should not include ${JSON.stringify(unexpected)}`
+  );
+}
+
 describe('aif-analyze OpenSpec-native bootstrap contract', () => {
   it('documents explicit mode selection and preserves legacy default config', async () => {
     const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
@@ -108,6 +115,62 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       'OpenSpec skills and slash commands are not installed by this extension'
     ]) {
       assertIncludes(combined, expected, 'OpenSpec bootstrap docs');
+    }
+  });
+
+  it('documents language technical terms policy and runtime-specific invocations', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+    const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
+    const combined = [skill, template].join('\n');
+
+    for (const expected of [
+      'language.ui',
+      'language.artifacts',
+      'language.technical_terms',
+      'default it to `keep`',
+      'keep | translate | mixed',
+      'technical_terms: keep',
+      'first recommended command must use the selected runtime invocation style',
+      '$aif` for `codex-app`',
+      'codex-app',
+      '$aif-explore',
+      '$aif-plan full',
+      '$aif-verify',
+      '$aif-*',
+      'slash-command runtimes',
+      '/aif-explore',
+      '/aif-plan full',
+      '/aif-verify',
+      '/aif-*',
+      'runtime-specific plan command',
+      'selected runtime invocation for `aif-architecture` and `aif-roadmap`',
+      'suggest the selected runtime invocation for `aif` first',
+      'suggest or initiate the selected runtime invocation for `aif-architecture`',
+      'suggest or initiate the selected runtime invocation for `aif-roadmap`',
+      'core `aif`',
+      'suggests the selected runtime invocation (`$aif` for `codex-app`, `/aif` for slash-command runtimes) if missing',
+      'Canonical workflow entries are runtime-specific',
+      'codex-app: `$aif-explore`, `$aif-plan full`, `$aif-improve`, `$aif-implement`, `$aif-verify`, `$aif-fix`',
+      'slash-command runtimes: `/aif-explore`, `/aif-plan full`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-fix`',
+      'using the selected runtime invocation style'
+    ]) {
+      assertIncludes(combined, expected, 'aif-analyze language/runtime policy');
+    }
+
+    for (const stale of [
+      'first recommended command must be `/aif`',
+      'After bootstrap describe the current public workflow as starting with `/aif-explore`',
+      'If DESCRIPTION is missing, suggest `/aif` first.',
+      'suggest running `/aif`',
+      'suggest or initiate `/aif-architecture`',
+      'suggest or initiate `/aif-roadmap`',
+      'core `/aif`',
+      'suggests `/aif` if missing',
+      'Canonical commands are now:',
+      '- /aif-explore\n- /aif-plan full',
+      '`/aif-done`'
+    ]) {
+      assertNotIncludes(skill, stale, 'skills/aif-analyze/SKILL.md');
     }
   });
 });

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -37,8 +37,18 @@ function extractSection(markdown, heading) {
   assert.notEqual(startIndex, -1, `Expected heading ${heading}`);
   const level = heading.match(/^#+/)?.[0].length ?? 1;
   let endIndex = lines.length;
+  let inFence = false;
 
   for (let index = startIndex + 1; index < lines.length; index += 1) {
+    if (lines[index].trim().startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+
+    if (inFence) {
+      continue;
+    }
+
     const match = lines[index].match(/^(#{1,6})\s+/);
     if (match && match[1].length <= level) {
       endIndex = index;
@@ -190,5 +200,127 @@ describe('complete OpenSpec workflow documentation contract', () => {
 
     assertNotIncludes(readmeBugFixes, '.ai-factory/plans/<id>/task.md', 'README.md Bug Fix Workflows');
     assertNotIncludes(usageBugFixes, '.ai-factory/plans/<id>/task.md', 'docs/usage.md Bug Fix Workflows');
+  });
+
+  it('documents the AI Factory 2.12.0 baseline and Codex runtime split', async () => {
+    const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
+    const readme = await readRepoFile('README.md');
+    const codexAgents = await readRepoFile('docs/codex-agents.md');
+
+    assert.equal(metadata.compat['ai-factory'], '>=2.11.0 <3.0.0');
+    assert.equal(metadata.sources['ai-factory'].version, '2.12.0');
+    assert.equal(metadata.sources['ai-factory'].baselineVersion, '2.12.0');
+    assert.equal(metadata.sources['ai-factory'].lastSync, '2026-05-15');
+    assertIncludes(metadata.sources['ai-factory'].notes, 'AI Factory 2.12.0', 'aifhub-extension.json');
+    assertIncludes(metadata.sources['ai-factory'].notes, 'codex-app runtime', 'aifhub-extension.json');
+    assertIncludes(metadata.sources['ai-factory'].notes, 'audit-artifacts', 'aifhub-extension.json');
+
+    assertIncludes(readme, 'Codex CLI and Claude agent files', 'README.md');
+    assertIncludes(readme, 'Namespaced Codex CLI agent files', 'README.md');
+
+    for (const expected of [
+      'Codex CLI (`codex`)',
+      '.codex/skills',
+      '.codex/agents',
+      'runtime: "codex"',
+      'Codex app (`codex-app`)',
+      '.agents/skills',
+      'no extension `agentFiles` target yet',
+      '.codex/config.toml',
+      '$aif-*',
+      'The extension `agentFiles` cannot target `codex-app` yet',
+      'extension helpers',
+      'not replacements for upstream bundled Codex CLI agents',
+      'plan-coordinator',
+      'implement-coordinator',
+      'review-sidecar'
+    ]) {
+      assertIncludes(codexAgents, expected, 'docs/codex-agents.md');
+    }
+  });
+
+  it('documents Codex app flows with skill invocations and keeps slash commands runtime-specific', async () => {
+    const usage = await readRepoFile('docs/usage.md');
+    const planMode = await readRepoFile('docs/codex-plan-mode.md');
+    const usageCodexFlow = extractSection(usage, '## Recommended Codex App Flow');
+    const planModeCodexFlow = extractSection(planMode, '## Recommended Codex App Flow');
+
+    for (const expected of [
+      '$aif-explore "task description"',
+      '$aif-plan full "task description"',
+      '$aif-improve <change-id>',
+      '$aif-mode sync --change <change-id>',
+      '$aif-implement <change-id>',
+      '$aif-rules-check',
+      '$aif-verify <change-id>',
+      '$aif-done <change-id>',
+      '$aif-mode sync',
+      '$aif-commit'
+    ]) {
+      assertIncludes(usageCodexFlow, expected, 'docs/usage.md Recommended Codex App Flow');
+    }
+
+    for (const stale of [
+      '/aif-explore "task description"',
+      '/aif-plan full "task description"',
+      '/aif-improve <change-id>',
+      '/aif-mode sync --change <change-id>',
+      '/aif-implement <change-id>',
+      '/aif-verify <change-id>'
+    ]) {
+      assertNotIncludes(usageCodexFlow, stale, 'docs/usage.md Recommended Codex App Flow');
+    }
+
+    for (const expected of [
+      '/plan-mode',
+      '$aif-explore "task description"',
+      '$aif-plan full "task description"',
+      '$aif-improve',
+      '$aif-implement',
+      '$aif-verify',
+      'client-owned mode command',
+      'AI Factory skills use `$aif-*`',
+      'slash-command runtimes keep `/aif-*`'
+    ]) {
+      assertIncludes(planModeCodexFlow, expected, 'docs/codex-plan-mode.md Recommended Codex App Flow');
+    }
+
+    for (const stale of [
+      '/aif-explore "task description"',
+      '/aif-plan full "task description"',
+      '/aif-implement',
+      '/aif-verify'
+    ]) {
+      assertNotIncludes(planModeCodexFlow, stale, 'docs/codex-plan-mode.md Recommended Codex App Flow');
+    }
+  });
+
+  it('documents OpenSpec plan IDs and optional audit-artifacts bridge', async () => {
+    const compatibility = await readRepoFile('docs/openspec-compatibility.md');
+    const aifMode = await readRepoFile('skills/aif-mode/SKILL.md');
+
+    for (const expected of [
+      'OpenSpec-native mode uses OpenSpec `change-id` values and ignores AI Factory `workflow.plan_id_format`',
+      'Legacy AI Factory-only mode follows upstream `workflow.plan_id_format`',
+      'ai-factory audit-artifacts openspec .ai-factory/qa .ai-factory/state --json',
+      'optional read-only artifact audit command',
+      'diagnostic-only',
+      'not mandatory, not archive-blocking'
+    ]) {
+      assertIncludes(compatibility, expected, 'docs/openspec-compatibility.md');
+    }
+
+    for (const expected of [
+      'selected `codex-app` runtime uses `$aif-mode`',
+      'slash-command runtimes use `/aif-mode`',
+      'Read-only diagnostics',
+      'ai-factory audit-artifacts openspec .ai-factory/qa .ai-factory/state --json',
+      'optional',
+      'not mandatory',
+      'not archive-blocking',
+      'hard dependency'
+    ]) {
+      assertIncludes(aifMode, expected, 'skills/aif-mode/SKILL.md');
+    }
   });
 });

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -15,9 +15,9 @@ Bootstrap project context for AI Factory. This skill prepares configuration and 
 |----------|-------|------------|
 | `config.yaml` | **aif-analyze** | Creates/updates |
 | `rules/base.md` | **aif-analyze** | Creates if missing |
-| `DESCRIPTION.md` | core `/aif` | Checks existence, suggests `/aif` if missing |
-| `ARCHITECTURE.md` | core `/aif-architecture` | Initiates based on workflow flag |
-| `ROADMAP.md` | core `/aif-roadmap` | Initiates based on workflow flag |
+| `DESCRIPTION.md` | core `aif` | Checks existence, suggests the selected runtime invocation (`$aif` for `codex-app`, `/aif` for slash-command runtimes) if missing |
+| `ARCHITECTURE.md` | core `aif-architecture` | Initiates the selected runtime invocation based on workflow flag |
+| `ROADMAP.md` | core `aif-roadmap` | Initiates the selected runtime invocation based on workflow flag |
 
 ## Workflow
 
@@ -80,17 +80,13 @@ then emit a non-blocking migration note:
 ℹ️ Legacy Workflow Compatibility
 
 This project still contains legacy skill-context for `aif-*-plus`.
-Canonical commands are now:
-- /aif-explore
-- /aif-plan full
-- /aif-improve
-- /aif-implement
-- /aif-verify
-- /aif-fix
+Canonical workflow entries are runtime-specific:
+- codex-app: `$aif-explore`, `$aif-plan full`, `$aif-improve`, `$aif-implement`, `$aif-verify`, `$aif-fix`
+- slash-command runtimes: `/aif-explore`, `/aif-plan full`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-fix`
 
-Если docs или handoff notes упоминают `Explore`, `New`, `Apply` или `Done`, трактуй их только как названия стадий.
-Не подавай `/aif-new` или `/aif-apply` как текущие public commands.
-`/aif-done` упоминай только как explicit post-verify AIFHub finalizer, а не как legacy alias или часть canonical public workflow.
+If docs or handoff notes mention `Explore`, `New`, `Apply`, or `Done`, treat them only as stage names.
+Do not present `/aif-new` or `/aif-apply` as current public commands.
+Mention `aif-done` only as the explicit post-verify AIFHub finalizer using the selected runtime invocation style, not as a legacy alias or part of the canonical public workflow.
 
 Backward-compatible fallback is still supported, but renaming the skill-context folders is recommended.
 ```
@@ -119,6 +115,7 @@ Resolve the bootstrap/config mode before creating directories:
 
 - If config.yaml is missing, create it with v1 schema.
 - If config.yaml exists, preserve existing values and add missing fields.
+- Preserve existing `language.ui`, `language.artifacts`, and `language.technical_terms` values. If `language.technical_terms` is missing, default it to `keep`; accepted values are `keep | translate | mixed`.
 - Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `rules`, `workflow`.
 - In legacy `ai-factory` mode:
   - Preserve the existing AI Factory-only path defaults.
@@ -248,9 +245,9 @@ openspec init --tools none
 ### Step 6: Check DESCRIPTION and Guide Core Skills
 
 - Check if `.ai-factory/DESCRIPTION.md` exists.
-- If missing: do not generate DESCRIPTION content in this skill; suggest running `/aif`.
-- If DESCRIPTION exists and `workflow.analyze_updates_architecture: true`, suggest or initiate `/aif-architecture`.
-- If `workflow.architecture_updates_roadmap: true`, suggest or initiate `/aif-roadmap`.
+- If missing: do not generate DESCRIPTION content in this skill; suggest the selected runtime invocation for `aif` first (`$aif` for `codex-app`, `/aif` for slash-command runtimes).
+- If DESCRIPTION exists and `workflow.analyze_updates_architecture: true`, suggest or initiate the selected runtime invocation for `aif-architecture`.
+- If `workflow.architecture_updates_roadmap: true`, suggest or initiate the selected runtime invocation for `aif-roadmap`.
 - If automatic invocation is not available in the current runtime, provide explicit next commands to the user in order.
 
 ### Step 7: Finish with Guided Handoff
@@ -263,11 +260,12 @@ openspec init --tools none
 - In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.
 - In `openspec-native` mode, explicitly report whether `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated` were created or preserved.
 - Report what was invoked automatically versus what remains as manual next command.
-- If DESCRIPTION is missing, first recommended command must be `/aif`.
-- После bootstrap описывай текущий public workflow как начинающийся с `/aif-explore` или `/aif-plan full`, а не с `/aif-new`.
-- Если нужен новый plan, рекомендуй `/aif-plan full` как canonical entrypoint.
-- Если упоминается handoff stage vocabulary, явно помечай её как naming layer, а не как slash commands.
-- Если упоминается `/aif-done`, явно описывай его как explicit post-verify finalizer, а не как legacy workflow alias.
+- If DESCRIPTION is missing, first recommended command must use the selected runtime invocation style: `$aif` for `codex-app`, `/aif` for slash-command runtimes.
+- When reporting next commands, use the selected runtime invocation style: `codex-app` runtime uses `$aif-explore`, `$aif-plan full`, `$aif-verify`, and other `$aif-*` skills; slash-command runtimes use `/aif-explore`, `/aif-plan full`, `/aif-verify`, and other `/aif-*` commands.
+- After bootstrap, describe the current public workflow as starting with the runtime-specific explore or plan invocation, not legacy `/aif-new`.
+- If a new plan is needed, recommend the runtime-specific plan command (`$aif-plan full` for `codex-app`, `/aif-plan full` for slash-command runtimes) as the canonical entrypoint.
+- If handoff stage vocabulary is mentioned, explicitly mark it as a naming layer, not as slash commands.
+- If `aif-done` is mentioned, describe it as the explicit post-verify finalizer using the selected runtime invocation style, not as a legacy workflow alias.
 
 ## Config v1 Schema
 
@@ -275,7 +273,7 @@ openspec init --tools none
 language:
   ui: russian                    # Communication language
   artifacts: russian             # Generated artifacts language
-  technical_terms: english       # Technical terms (always english)
+  technical_terms: keep          # keep | translate | mixed
 
 aifhub:
   artifactProtocol: ai-factory   # ai-factory | openspec
@@ -346,8 +344,8 @@ agent_profile: default
 - Never install OpenSpec skills, slash commands, dependencies, or manifest entries.
 - Never treat missing OpenSpec validate/archive capability as bootstrap failure; report it as degraded OpenSpec capability and continue with the configured runtime/generated path layout.
 - Never generate DESCRIPTION directly in this skill.
-- If DESCRIPTION is missing, suggest `/aif` first.
-- Follow workflow flags to suggest or initiate `/aif-architecture` and `/aif-roadmap`.
+- If DESCRIPTION is missing, suggest the selected runtime invocation for `aif` first (`$aif` for `codex-app`, `/aif` for slash-command runtimes).
+- Follow workflow flags to suggest or initiate the selected runtime invocation for `aif-architecture` and `aif-roadmap`.
 - Create `rules/base.md` with project-specific rules, not generic advice.
 - Do NOT create optional area rules — planning owns those when needed.
 - Ensure all directories from config paths exist.

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -12,7 +12,7 @@ language:
   # Language for generated artifacts (DESCRIPTION.md, ARCHITECTURE.md, plans, etc.)
   artifacts: {{language_artifacts}}
   # Language for technical terms (usually english for consistency)
-  technical_terms: english
+  technical_terms: keep # keep | translate | mixed
 
 # ============================================================================
 # AIFHUB ARTIFACT PROTOCOL

--- a/skills/aif-mode/SKILL.md
+++ b/skills/aif-mode/SKILL.md
@@ -28,6 +28,10 @@ node scripts/aif-mode.mjs doctor
 
 Use `--dry-run` before any switching or sync command when reviewing planned writes. Use `--json` when another tool needs structured output.
 
+## Invocation Style
+
+Use runtime-specific public invocations when instructing the user: selected `codex-app` runtime uses `$aif-mode` and other `$aif-*` skills, while slash-command runtimes use `/aif-mode` and other `/aif-*` commands.
+
 ## Workflow
 
 1. Read `.ai-factory/config.yaml` and resolve `aifhub.artifactProtocol`.
@@ -110,6 +114,14 @@ Refresh derived or compatibility artifacts without changing mode.
 ### `doctor`
 
 Read-only diagnostics for config marker, configured paths, OpenSpec CLI capability, Node compatibility, active change ambiguity, generated rules, coverage matrix status, legacy artifacts in OpenSpec-native mode, OpenSpec validation when available, and archive readiness for `/aif-done`.
+
+AI Factory 2.12+ also exposes an optional read-only artifact audit bridge:
+
+```bash
+ai-factory audit-artifacts openspec .ai-factory/qa .ai-factory/state --json
+```
+
+Use this only as supplemental diagnostic context when available. It is optional, not mandatory, not archive-blocking, and must not turn `/aif-mode doctor` into a write operation or a hard dependency on upstream AI Factory 2.12+.
 
 ## References
 


### PR DESCRIPTION
## What changed

This updates the AIFHub extension documentation and configuration for the AI Factory 2.12.0 baseline. It adds runtime-specific Codex guidance, OpenSpec compatibility notes, optional audit-artifacts bridge documentation, and tests that lock the expected workflow contracts.

## Why

The extension needs its docs, manifest metadata, skill guidance, and contract tests aligned with the AI Factory 2.12.0 baseline and Codex runtime split so users get the correct workflow instructions.

## Impact

Users get clearer runtime-specific commands and compatibility guidance. Maintainers get regression coverage for the documented OpenSpec workflow, Codex app flow, plan IDs, audit-artifacts bridge, and baseline documentation.

## Validation

- `npm test`
- `npm run validate`