### PR TITLE
Prompt for first-bootstrap artifact protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ aifhub:
   artifactProtocol: openspec
 ```
 
+On first bootstrap, when `.ai-factory/config.yaml` is missing and you did not explicitly ask for OpenSpec-native mode, `/aif-analyze` asks which artifact protocol to use: `legacy AI Factory-only` or `OpenSpec-native`. Existing configs are preserved without that question. If the run is autonomous and cannot ask, it defaults to legacy AI Factory-only and reports OpenSpec-native mode as an open question.
+
 Create and refine a change:
 
 ```text
@@ -234,6 +236,8 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec skills/commands | Not installed by this extension |
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
+
+If the OpenSpec CLI is present but outside `>=1.3.1 <2.0.0`, update or reinstall the CLI before relying on validation/archive. The bootstrap still reports this as degraded capability rather than an install failure.
 
 OpenSpec CLI integration is adapter-only: users keep calling `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-done`, and `/aif-mode`; the extension never installs OpenSpec command skills.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -83,6 +83,10 @@ paths:
 
 `installSkills: false` is intentional. AIFHub Extension uses OpenSpec artifacts and `scripts/openspec-runner.mjs` as the optional CLI adapter, not OpenSpec-installed skills or slash commands.
 
+On first bootstrap, `/aif-analyze` may create the OpenSpec marker after asking for the artifact protocol. If `.ai-factory/config.yaml` is missing and the user did not explicitly request OpenSpec-native mode, interactive runtimes ask the user to choose `legacy AI Factory-only` or `OpenSpec-native` before writing the config. Existing configs are preserved without prompting. Autonomous/subagent runs do not ask; they default to legacy AI Factory-only and report OpenSpec-native mode as an open question.
+
+Localization preferences collected before this choice are carried as pending config values and written only after the artifact protocol is resolved.
+
 Action toggles such as `validateOnPlan`, `validateOnImprove`, `validateOnVerify`, `statusOnVerify`, `archiveOnDone`, `compileRulesOnSync`, and `validateOnSync` decide which operations are attempted. Policy flags such as `require*` and `allowWarnOnDone` decide whether missing, stale, failed, or warning-only evidence blocks a command.
 
 The defaults keep planning and verification degraded-friendly while making `/aif-done` strict: verify can warn on missing CLI, generated rules, rules gate evidence, or coverage evidence; done requires current generated rules, a passing durable rules gate, current passing coverage, and archive-capable CLI unless config relaxes those requirements.
@@ -240,6 +244,8 @@ When the OpenSpec CLI is missing or unsupported:
 - `/aif-done` fails archive-required finalization because archive requires a compatible CLI
 
 When Node is below `>=20.19.0`, the CLI is treated as unavailable for validate/archive capabilities even if an `openspec` command exists.
+
+When `detectOpenSpec()` reports `reason: unsupported-version`, update or reinstall OpenSpec CLI to `>=1.3.1 <2.0.0`. This remains degraded capability for bootstrap and planning unless a command-specific policy requires CLI availability.
 
 ## Prompt Assets and Runtime Integration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,6 +186,15 @@ aifhub:
   artifactProtocol: openspec
 ```
 
+When `.ai-factory/config.yaml` is missing and the user did not explicitly ask for a protocol, `/aif-analyze` asks one artifact protocol question before writing config or creating mode-specific directories:
+
+- `legacy AI Factory-only`
+- `OpenSpec-native`
+
+Existing configs are not prompted again. Codex Default mode asks this as plain text; Codex Plan mode may use `request_user_input`; autonomous/subagent runs default to legacy AI Factory-only and report OpenSpec-native mode as an open question.
+
+If localization questions run first, `/aif-analyze` carries those answers forward and writes them only after the artifact protocol is selected, so language persistence does not accidentally lock in the legacy default.
+
 ### `/aif-plan full`
 
 Reads:

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -38,6 +38,29 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
     assertIncludes(template, 'artifactProtocol: ai-factory', 'skills/aif-analyze/references/config-template.yaml');
   });
 
+  it('documents first-bootstrap artifact protocol prompts without preselecting mode', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+    const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
+
+    for (const expected of [
+      'If `.ai-factory/config.yaml` is missing and no artifact protocol was explicitly requested, ask one artifact protocol question before writing config or creating mode-specific directories.',
+      '`legacy AI Factory-only`',
+      '`OpenSpec-native`',
+      'Codex Default mode: ask a short plain-text artifact protocol question; do not use `question(...)`, `questionnaire(...)`, or `request_user_input`.',
+      'Codex Plan mode: use one `request_user_input` question only when the user already switched the session into Plan mode.',
+      'Autonomous / subagent mode: do not ask; choose legacy `ai-factory` mode by default and report OpenSpec-native mode as an open question/blocker.',
+      'Keep localization answers as pending config values until bootstrap mode is resolved.'
+    ]) {
+      assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md first-bootstrap prompt contract');
+    }
+
+    assertIncludes(
+      template,
+      'First bootstrap may ask for artifact protocol before this value is written.',
+      'skills/aif-analyze/references/config-template.yaml'
+    );
+  });
+
   it('defines the OpenSpec-native config shape and canonical runtime paths', async () => {
     const combined = [
       await readRepoFile('skills/aif-analyze/SKILL.md'),
@@ -91,7 +114,8 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       'requiresNode: ">=20.19.0"',
       'nodeSupported: boolean',
       'versionSupported: boolean',
-      'Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure'
+      'Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure',
+      'If `reason` is `unsupported-version`, recommend installing or updating OpenSpec CLI to `>=1.3.1 <2.0.0`.'
     ]) {
       assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md');
     }

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -39,6 +39,7 @@ Bootstrap project context for AI Factory. This skill prepares configuration and 
 - Add one context-derived language option only when strong evidence exists.
 - Ask question 2 exactly as the translation-scope selector with these options: `communication only`, `communication and artifacts`, `artifacts only`.
 - Persist answers to config.yaml (preferred) or bridge file if present.
+- If `.ai-factory/config.yaml` is missing, do not create a full config only to persist localization answers before bootstrap mode is resolved. Keep localization answers as pending config values until bootstrap mode is resolved.
 - If the translation scope excludes artifacts, keep generated artifacts in the original project language.
 - If the translation scope includes artifacts, generate them in the preferred language.
 - Keep file names, commands, and identifiers in English.
@@ -107,16 +108,24 @@ Resolve the bootstrap/config mode before creating directories:
 
 - Use `openspec-native` mode when the user explicitly asks for `openspec-native`, `OpenSpec-native`, or OpenSpec artifact protocol bootstrap.
 - Use `openspec-native` mode when an existing `.ai-factory/config.yaml` has `aifhub.artifactProtocol: openspec`.
-- Otherwise use legacy `ai-factory` mode.
+- Preserve legacy `ai-factory` mode when an existing `.ai-factory/config.yaml` does not declare `aifhub.artifactProtocol: openspec`.
+- If `.ai-factory/config.yaml` is missing and no artifact protocol was explicitly requested, ask one artifact protocol question before writing config or creating mode-specific directories.
+  - Options must be exactly `legacy AI Factory-only` and `OpenSpec-native`.
+  - Codex Default mode: ask a short plain-text artifact protocol question; do not use `question(...)`, `questionnaire(...)`, or `request_user_input`.
+  - Codex Plan mode: use one `request_user_input` question only when the user already switched the session into Plan mode.
+  - Claude Code / Kilo CLI / OpenCode: use `question(questions: [...])`.
+  - Autonomous / subagent mode: do not ask; choose legacy `ai-factory` mode by default and report OpenSpec-native mode as an open question/blocker.
+- Use the selected first-bootstrap answer to choose legacy `ai-factory` mode or `openspec-native` mode.
 - Do not silently migrate a legacy AI Factory-only project to OpenSpec-native mode.
 - Preserve existing config values. Add only missing keys required by the resolved mode.
-- Record the resolved mode for the final handoff.
+- Record the resolved mode and selection source for the final handoff: existing config, explicit user request, first-bootstrap answer, or autonomous default.
 
 ### Step 3: Create or Update config.yaml
 
-- If config.yaml is missing, create it with v1 schema.
+- If config.yaml is missing, create it with v1 schema only after bootstrap mode is resolved.
 - If config.yaml exists, preserve existing values and add missing fields.
 - Preserve existing `language.ui`, `language.artifacts`, and `language.technical_terms` values. If `language.technical_terms` is missing, default it to `keep`; accepted values are `keep | translate | mixed`.
+- If localization answers were collected while config was missing, write those pending config values into the selected legacy `ai-factory` or `openspec-native` config shape.
 - Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `rules`, `workflow`.
 - In legacy `ai-factory` mode:
   - Preserve the existing AI Factory-only path defaults.
@@ -201,6 +210,8 @@ openspec:
 - If the OpenSpec CLI is compatible, prefer or recommend `openspec init --tools none`.
 - If the OpenSpec CLI is missing or unsupported, continue bootstrap with `canValidate: false` and `canArchive: false`.
 - Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure.
+- If `reason` is `unsupported-version`, recommend installing or updating OpenSpec CLI to `>=1.3.1 <2.0.0`.
+- If `reason` is `unsupported-node`, recommend using Node `>=20.19.0` for OpenSpec validation/archive.
 - If `scripts/openspec-runner.mjs` is missing, report that capability detection is unavailable and continue with degraded capability values.
 
 ### Step 4: Create rules/base.md
@@ -256,7 +267,9 @@ openspec init --tools none
 - Use the saved scope plus preferred language for the reply.
 - Mention created/updated files: `config.yaml`, `rules/base.md`, and artifact status (`DESCRIPTION.md`, `ARCHITECTURE.md`, `ROADMAP.md`).
 - Report the resolved bootstrap mode.
+- Report the bootstrap mode selection source: existing config, explicit user request, first-bootstrap answer, or autonomous default.
 - Report whether config values were created or preserved.
+- If autonomous/subagent mode defaulted to legacy `ai-factory` because the artifact protocol question could not be asked, report OpenSpec-native mode selection as an open question/blocker.
 - Report the active path set.
 - In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.
 - In `openspec-native` mode, explicitly report whether `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated` were created or preserved.
@@ -338,7 +351,8 @@ agent_profile: default
 
 - Use evidence over assumptions.
 - Create/update `config.yaml` and `rules/base.md` first.
-- Use OpenSpec-native mode only when explicitly requested or when existing config has `aifhub.artifactProtocol: openspec`.
+- Use OpenSpec-native mode only when explicitly requested, when existing config has `aifhub.artifactProtocol: openspec`, or when the user selects `OpenSpec-native` in the first-bootstrap artifact protocol question.
+- Do not write a missing config with a default artifact protocol before first-bootstrap artifact protocol resolution completes.
 - In OpenSpec-native mode, use `detectOpenSpec()` from `scripts/openspec-runner.mjs` when available and treat missing or unsupported CLI as degraded capability, not failure.
 - In OpenSpec-native mode, AIFHub skills may request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs`; never install or depend on OpenSpec slash commands.
 - In OpenSpec-native mode, use or recommend `openspec init --tools none` only for compatible CLI environments.

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -17,9 +17,11 @@ language:
 # ============================================================================
 # AIFHUB ARTIFACT PROTOCOL
 # ============================================================================
-# Legacy default is AI Factory-only. Use artifactProtocol: openspec only when
-# the user explicitly requests OpenSpec-native mode or existing config already
-# uses aifhub.artifactProtocol: openspec.
+# Legacy default is AI Factory-only.
+# First bootstrap may ask for artifact protocol before this value is written.
+# Use artifactProtocol: openspec only when the user explicitly requests or
+# selects OpenSpec-native mode, or existing config already uses
+# aifhub.artifactProtocol: openspec.
 aifhub:
   # ai-factory | openspec
   artifactProtocol: ai-factory


### PR DESCRIPTION
## Summary
- Document the first-bootstrap artifact protocol choice for `/aif-analyze`.
- Add the contract that missing config prompts for legacy AI Factory-only vs OpenSpec-native mode before writing config.
- Update the bootstrap contract test and config template comments to preserve localization answers until the protocol is resolved.

## Impact
Users starting a fresh bootstrap get an explicit artifact protocol choice instead of silently locking in the legacy default before mode resolution. Autonomous runs still default to legacy AI Factory-only and report OpenSpec-native selection as an open question.

## Validation
- `npm test`
- `npm run validate`