### PR TITLE
Harden installed helper command paths

### DIFF
--- a/agent-files/claude/aifhub-plan-polisher.md
+++ b/agent-files/claude/aifhub-plan-polisher.md
@@ -20,7 +20,7 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present.
 - Allowed write scope: canonical artifacts inside the selected OpenSpec change and runtime state under `.ai-factory/state/<change-id>/`.
-- Resolve effective policy with `node scripts/openspec-policy.mjs --json` before validation.
+- Resolve effective policy with `ai-factory aifhub-mode status --json` before validation.
 - After touching `proposal.md`, `design.md`, `tasks.md`, or `specs/**/spec.md`, validate through `scripts/openspec-runner.mjs` using `validateOpenSpecChange(changeId)` when available. If the OpenSpec CLI is unavailable, report degraded validation unless `requireCliForImprove` is true; when required, return a policy-blocked refinement result.
 - Do not write QA evidence except to name `.ai-factory/qa/<change-id>/` in the final report.
 - Do not create legacy plan artifacts in OpenSpec-native mode.

--- a/agent-files/codex/aifhub-plan-polisher.toml
+++ b/agent-files/codex/aifhub-plan-polisher.toml
@@ -17,7 +17,7 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present.
 - Allowed write scope: canonical artifacts inside the selected OpenSpec change and runtime state under .ai-factory/state/<change-id>/.
-- Resolve effective policy with node scripts/openspec-policy.mjs --json before validation.
+- Resolve effective policy with ai-factory aifhub-mode status --json before validation.
 - After touching proposal.md, design.md, tasks.md, or specs/**/spec.md, validate through scripts/openspec-runner.mjs using validateOpenSpecChange(changeId) when available. If the OpenSpec CLI is unavailable, report degraded validation unless requireCliForImprove is true; when required, return a policy-blocked refinement result.
 - Do not write QA evidence except to name .ai-factory/qa/<change-id>/ in the final report.
 - Do not create legacy plan artifacts in OpenSpec-native mode.

--- a/commands/aifhub-handoff-gate-summary.mjs
+++ b/commands/aifhub-handoff-gate-summary.mjs
@@ -1,0 +1,16 @@
+// aifhub-handoff-gate-summary.mjs - installed-project wrapper for Handoff gate summary diagnostics
+import { normalizeWrapperArgs, runInstalledScript } from './run-installed-script.mjs';
+
+const DESCRIPTION = 'Run AIFHub Handoff gate summary diagnostics.';
+
+export function register(program) {
+  program
+    .command('aifhub-handoff-gate-summary')
+    .description(DESCRIPTION)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument('[args...]')
+    .action(async (args, command) => {
+      await runInstalledScript('../scripts/handoff-gate-summary.mjs', normalizeWrapperArgs(args, command), import.meta.url);
+    });
+}

--- a/commands/aifhub-validate-artifacts.mjs
+++ b/commands/aifhub-validate-artifacts.mjs
@@ -1,0 +1,16 @@
+// aifhub-validate-artifacts.mjs - installed-project wrapper for OpenSpec artifact validation
+import { normalizeWrapperArgs, runInstalledScript } from './run-installed-script.mjs';
+
+const DESCRIPTION = 'Run AIFHub OpenSpec artifact contract validation.';
+
+export function register(program) {
+  program
+    .command('aifhub-validate-artifacts')
+    .description(DESCRIPTION)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument('[args...]')
+    .action(async (args, command) => {
+      await runInstalledScript('../scripts/openspec-artifact-validator.mjs', normalizeWrapperArgs(args, command), import.meta.url);
+    });
+}

--- a/docs/handoff-validation-profile.md
+++ b/docs/handoff-validation-profile.md
@@ -11,7 +11,7 @@ It lets a Handoff orchestrator read one JSON summary instead of parsing every ga
 The profile is produced by:
 
 ```bash
-node scripts/handoff-gate-summary.mjs --change <change-id> --stage review --json
+ai-factory aifhub-handoff-gate-summary --change <change-id> --stage review --json
 ```
 
 ## JSON Contract

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -8,16 +8,16 @@ It does not replace the OpenSpec CLI. The OpenSpec CLI validates OpenSpec syntax
 
 ## Usage
 
-Run the validator directly:
+Run the validator from an installed project:
 
 ```bash
-node scripts/openspec-artifact-validator.mjs --change <change-id> --json
+ai-factory aifhub-validate-artifacts --change <change-id> --json
 ```
 
 Require verification evidence for finalization readiness:
 
 ```bash
-node scripts/openspec-artifact-validator.mjs --change <change-id> --require-verification-evidence --json
+ai-factory aifhub-validate-artifacts --change <change-id> --require-verification-evidence --json
 ```
 
 Exit codes:

--- a/extension.json
+++ b/extension.json
@@ -33,6 +33,16 @@
       "name": "aifhub-done-readiness",
       "description": "Run AIFHub OpenSpec done-readiness diagnostics.",
       "module": "./commands/aifhub-done-readiness.mjs"
+    },
+    {
+      "name": "aifhub-validate-artifacts",
+      "description": "Run AIFHub OpenSpec artifact contract validation.",
+      "module": "./commands/aifhub-validate-artifacts.mjs"
+    },
+    {
+      "name": "aifhub-handoff-gate-summary",
+      "description": "Run AIFHub Handoff gate summary diagnostics.",
+      "module": "./commands/aifhub-handoff-gate-summary.mjs"
     }
   ],
   "skills": [

--- a/injections/core/aif-improve-plan-folder.md
+++ b/injections/core/aif-improve-plan-folder.md
@@ -68,7 +68,7 @@ Preservation rules:
 Validation and runtime state:
 
 - Read base specs from `openspec/specs/**` and generated rules from `.ai-factory/rules/generated/` when they are needed to preserve canonical requirement intent.
-- Before validation, resolve the effective OpenSpec policy through `node scripts/openspec-policy.mjs --json`.
+- Before validation, resolve the effective OpenSpec policy through `ai-factory aifhub-mode status --json`.
 - Run or recommend OpenSpec validation through `validateOpenSpecChange(changeId)` from `scripts/openspec-runner.mjs`, or equivalent shared-runner behavior.
 - Validation should correspond to `openspec validate <change-id> --type change --strict --json --no-interactive --no-color`.
 - Missing or unsupported OpenSpec CLI is degraded validation unless the effective policy has `requireCliForImprove: true`; when required, treat the missing CLI as a refinement blocker and do not report the change as validation-ready.

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -144,10 +144,10 @@ Runtime QA output belongs under `.ai-factory/qa/<change-id>/`.
 Before validation, resolve the effective OpenSpec policy through:
 
 ```bash
-node scripts/openspec-policy.mjs --json
+ai-factory aifhub-mode status --json
 ```
 
-When a compatible OpenSpec CLI is available, validate through `scripts/openspec-runner.mjs` using `validateOpenSpecChange(changeId)` or equivalent runner behavior.
+Read `effectivePolicy` from the JSON output. When a compatible OpenSpec CLI is available, validate through `scripts/openspec-runner.mjs` using `validateOpenSpecChange(changeId)` or equivalent runner behavior.
 
 The runner command corresponds to:
 

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -114,6 +114,9 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       'requiresNode: ">=20.19.0"',
       'nodeSupported: boolean',
       'versionSupported: boolean',
+      'ai-factory aifhub-mode status --json',
+      'Installed-project capability reads should prefer the AIFHub mode wrapper',
+      'Source-repo direct runner detection is allowed only when working inside the extension package source tree',
       'Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure',
       'If `reason` is `unsupported-version`, recommend installing or updating OpenSpec CLI to `>=1.3.1 <2.0.0`.'
     ]) {

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -910,14 +910,24 @@ async function validateOpenSpecChanges(options = {}) {
     const status = validation.ok
       ? await getOpenSpecStatus(changeId, createRunOptions(rootDir, options))
       : null;
+    const statusWarning = isUnsupportedOpenSpecStatusChangeId(status, changeId)
+      ? {
+        code: 'openspec-status-unsupported-change-id',
+        message: `OpenSpec status skipped because the OpenSpec CLI rejects numeric-leading change id '${changeId}' while validation accepts it.`
+      }
+      : null;
 
     results.push({
       changeId,
       validation,
       status,
-      ok: Boolean(validation.ok && (status === null || status.ok))
+      statusWarning,
+      ok: Boolean(validation.ok && (status === null || status.ok || statusWarning !== null))
     });
   }
+  const statusWarnings = results
+    .map((result) => result.statusWarning)
+    .filter((warning) => warning !== null);
 
   return {
     ok: results.every((result) => result.ok),
@@ -925,7 +935,10 @@ async function validateOpenSpecChanges(options = {}) {
     detection: summarizeOpenSpecDetection(detection),
     results,
     skippedChanges: selected.skippedChanges,
-    warnings: selected.warnings,
+    warnings: dedupeDiagnostics([
+      ...selected.warnings,
+      ...statusWarnings
+    ]),
     errors: results
       .filter((result) => !result.ok)
       .map((result) => ({
@@ -933,6 +946,25 @@ async function validateOpenSpecChanges(options = {}) {
         message: `OpenSpec validation/status failed for '${result.changeId}'.`
       }))
   };
+}
+
+function isUnsupportedOpenSpecStatusChangeId(result, changeId) {
+  const output = normalizeCommandText(result);
+  return !result?.ok
+    && /^[0-9]/.test(String(changeId ?? ''))
+    && /Invalid change name/i.test(output)
+    && /Change name must start with a letter/i.test(output);
+}
+
+function normalizeCommandText(result) {
+  return [
+    result?.stderr,
+    result?.stdout,
+    result?.error?.message
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .map((value) => String(value))
+    .join('\n');
 }
 
 async function selectValidatableChanges(rootDir, changeIds) {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -548,6 +548,80 @@ describe('artifact sync and export', () => {
     assert.ok(result.validation.warnings.some((warning) => warning.code === 'no-delta-specs'));
   });
 
+  it('treats numeric-leading OpenSpec status rejection as non-blocking during sync', async () => {
+    const rootDir = await createTempRoot();
+    const changeId = '81-command-wrappers';
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      '  openspec:',
+      '    compileRulesOnSync: false',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+    await writeFixture(rootDir, `openspec/changes/${changeId}/specs/commands/spec.md`, [
+      '# Commands',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Command Wrappers',
+      '',
+      'The system MUST expose command wrappers.',
+      '',
+      '#### Scenario: wrapper is invoked',
+      '',
+      '- GIVEN an installed helper command',
+      '- WHEN the wrapper runs',
+      '- THEN it delegates to the helper',
+      ''
+    ].join('\n'));
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      changeId,
+      detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async () => ({
+        ok: true,
+        exitCode: 0,
+        stdout: '{"valid":true}',
+        stderr: '',
+        json: { valid: true },
+        error: null
+      }),
+      getOpenSpecStatus: async (id) => ({
+        ok: false,
+        exitCode: 1,
+        command: 'openspec',
+        args: ['status', '--change', id, '--json', '--no-color'],
+        stdout: '\n',
+        stderr: `Error: Invalid change name '${id}': Change name must start with a letter\n`,
+        json: null,
+        jsonParseError: null,
+        error: {
+          code: 'non-zero-exit',
+          message: 'OpenSpec command failed with exit code 1.'
+        }
+      }),
+      timestamp: '2026-05-17T00-00-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.validation.ok, true);
+    assert.equal(result.validation.results[0].ok, true);
+    assert.equal(result.validation.results[0].status.ok, false);
+    assert.equal(result.validation.results[0].statusWarning.code, 'openspec-status-unsupported-change-id');
+    assert.deepEqual(result.validation.errors, []);
+    assert.ok(result.validation.warnings.some((warning) => warning.code === 'openspec-status-unsupported-change-id'));
+    assert.ok(result.warnings.some((warning) => warning.code === 'openspec-status-unsupported-change-id'));
+  });
+
   it('does not skip no-delta validation for targeted sync', async () => {
     const rootDir = await createTempRoot();
     const validated = [];

--- a/scripts/aifhub-command-wrappers-contract.test.mjs
+++ b/scripts/aifhub-command-wrappers-contract.test.mjs
@@ -45,10 +45,24 @@ const WRAPPER_COMMANDS = [
     module: './commands/aifhub-done-readiness.mjs',
     script: 'openspec-done-readiness.mjs',
     args: ['--change', 'add-oauth', '--json']
+  },
+  {
+    name: 'aifhub-validate-artifacts',
+    description: 'Run AIFHub OpenSpec artifact contract validation.',
+    module: './commands/aifhub-validate-artifacts.mjs',
+    script: 'openspec-artifact-validator.mjs',
+    args: ['--change', 'add-oauth', '--json']
+  },
+  {
+    name: 'aifhub-handoff-gate-summary',
+    description: 'Run AIFHub Handoff gate summary diagnostics.',
+    module: './commands/aifhub-handoff-gate-summary.mjs',
+    script: 'handoff-gate-summary.mjs',
+    args: ['--change', 'add-oauth', '--stage', 'review', '--json']
   }
 ];
 
-const WRAPPED_ROOT_SCRIPT_RE = /\bnode\s+scripts\/(?:aif-mode|migrate-legacy-plans|write-gate-evidence|openspec-coverage-matrix|openspec-done-readiness)\.mjs\b/;
+const INSTALLED_FACING_ROOT_SCRIPT_RE = /\bnode\s+scripts\/[A-Za-z0-9_.-]+\.mjs\b/;
 
 let tmpDir;
 
@@ -268,10 +282,14 @@ describe('AIFHub wrapper guidance contract', () => {
       ]],
       ['docs/openspec-validation.md', [
         'ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules',
-        'ai-factory aifhub-done-readiness --change <change-id> --json'
+        'ai-factory aifhub-done-readiness --change <change-id> --json',
+        'ai-factory aifhub-validate-artifacts --change <change-id> --json'
       ]],
       ['docs/spec-coverage.md', [
         'ai-factory aifhub-coverage --change <change-id> --write --json'
+      ]],
+      ['docs/handoff-validation-profile.md', [
+        'ai-factory aifhub-handoff-gate-summary --change <change-id> --stage review --json'
       ]],
       ['docs/legacy-plan-migration.md', [
         'ai-factory aifhub-migrate-legacy-plans --list',
@@ -292,6 +310,15 @@ describe('AIFHub wrapper guidance contract', () => {
       ]],
       ['injections/core/aif-verify-plan-folder.md', [
         'ai-factory aifhub-migrate-legacy-plans <change-id> --dry-run'
+      ]],
+      ['injections/core/aif-plan-plan-folder.md', [
+        'ai-factory aifhub-mode status --json'
+      ]],
+      ['agent-files/codex/aifhub-plan-polisher.toml', [
+        'ai-factory aifhub-mode status --json'
+      ]],
+      ['agent-files/claude/aifhub-plan-polisher.md', [
+        'ai-factory aifhub-mode status --json'
       ]]
     ];
 
@@ -302,8 +329,8 @@ describe('AIFHub wrapper guidance contract', () => {
       }
       assert.doesNotMatch(
         source,
-        WRAPPED_ROOT_SCRIPT_RE,
-        `${relativePath} should not require root scripts for installed-project helper commands`
+        INSTALLED_FACING_ROOT_SCRIPT_RE,
+        `${relativePath} should not expose root scripts as installed-project helper commands`
       );
     }
   });

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -204,6 +204,35 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
+  it('documents installed-project helper execution through AIFHub wrappers', async () => {
+    const validation = await readRepoFile('docs/openspec-validation.md');
+    const handoffProfile = await readRepoFile('docs/handoff-validation-profile.md');
+
+    for (const expected of [
+      'ai-factory aifhub-validate-artifacts --change <change-id> --json',
+      'ai-factory aifhub-validate-artifacts --change <change-id> --require-verification-evidence --json'
+    ]) {
+      assertIncludes(validation, expected, 'docs/openspec-validation.md');
+    }
+
+    assertIncludes(
+      handoffProfile,
+      'ai-factory aifhub-handoff-gate-summary --change <change-id> --stage review --json',
+      'docs/handoff-validation-profile.md'
+    );
+
+    for (const [label, source] of [
+      ['docs/openspec-validation.md', validation],
+      ['docs/handoff-validation-profile.md', handoffProfile]
+    ]) {
+      assert.doesNotMatch(
+        source,
+        /\bnode\s+scripts\/[A-Za-z0-9_.-]+\.mjs\b/,
+        `${label} should not expose root scripts as installed-project helper commands`
+      );
+    }
+  });
+
   it('documents planned bug fixes separately from post-verify fixes', async () => {
     const readme = await readRepoFile('README.md');
     const usage = await readRepoFile('docs/usage.md');

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -233,6 +233,14 @@ function assertNoInstallGuidance(source, label) {
   );
 }
 
+function assertNoExecutableRootScriptGuidance(source, label) {
+  assert.doesNotMatch(
+    source,
+    /\bnode\s+scripts\/[A-Za-z0-9_.-]+\.mjs\b/,
+    `${label} should not expose root scripts as installed-project executable helper commands`
+  );
+}
+
 describe('OpenSpec-native prompt asset contract', () => {
   it('discovers active prompt assets from extension.json only', async () => {
     const assets = await activePromptAssets();
@@ -406,6 +414,13 @@ describe('OpenSpec-native prompt asset contract', () => {
     }
   });
 
+  it('does not expose root scripts as installed-project executable helper commands in active prompts', async () => {
+    for (const relativePath of await activePromptAssets()) {
+      const asset = await readRepoFile(relativePath);
+      assertNoExecutableRootScriptGuidance(asset, relativePath);
+    }
+  });
+
   it('requires verifier prompts to use fail-fast OpenSpec verification context', async () => {
     for (const relativePath of VERIFY_PROMPT_ASSETS) {
       const asset = stripFencedBlocks(await readRepoFile(relativePath));
@@ -478,6 +493,7 @@ describe('OpenSpec-native prompt asset contract', () => {
         'design.md',
         'tasks.md',
         'specs/**/spec.md',
+        'ai-factory aifhub-mode status --json',
         'scripts/openspec-runner.mjs',
         'validateOpenSpecChange(changeId)'
       ]) {

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -184,6 +184,14 @@ Use [references/config-template.yaml](references/config-template.yaml) as refere
 
 Run this step only in `openspec-native` mode, after config mode is resolved and before directory creation.
 
+- Installed-project capability reads should prefer the AIFHub mode wrapper:
+
+```bash
+ai-factory aifhub-mode status --json
+```
+
+- Read `openspecCli` from the JSON output and report equivalent capability fields.
+- Source-repo direct runner detection is allowed only when working inside the extension package source tree.
 - If `scripts/openspec-runner.mjs` exists, use `detectOpenSpec()` from that file.
 - In Node-capable runtimes, a valid detection command is:
 


### PR DESCRIPTION
## Summary

- Add installed-project wrappers for AIFHub artifact validation and handoff gate summaries.
- Update installed-facing docs, prompts, and contract tests to use `ai-factory aifhub-*` commands instead of source-tree scripts.
- Treat OpenSpec `status` rejection for numeric-leading change ids as a non-blocking sync warning when validation succeeds.

## Root Cause

Installed-project guidance still pointed at source checkout scripts that are not available to extension consumers. During final sync, `openspec status --change 81-command-wrappers` also rejected a valid numeric-leading change id even though `openspec validate` accepted it, causing `/aif-mode sync` to fail incorrectly.

## Validation

- `node --test scripts/aif-artifact-sync.test.mjs`
- `npm run validate`
- `npm test`
- `openspec validate 81-command-wrappers --type change --strict --json --no-interactive --no-color`
- `openspec validate --all --no-color`
- `git diff --check`
- `ai-factory aifhub-mode sync --json`
- `ai-factory aifhub-mode sync --all --json`
- `ai-factory aifhub-mode status --json`

Fixes #81