### PR TITLE
Fix coverage matrix tooling config evidence

### DIFF
--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -108,6 +108,8 @@ The matrix uses:
 - generated rules state from `.ai-factory/rules/generated/`
 - optional existing verification evidence under `.ai-factory/qa/<change-id>/verify.md`
 
+Implementation evidence is extracted from explicit path references in those sources. It includes source files, active prompt source assets, and root-level or nested tooling/config files such as `composer.json`, `testo.php`, `.github/workflows/tests.yml`, `*.toml`, and `*.xml` when they are directly referenced. Test paths are recorded as `test_evidence`; docs paths, canonical OpenSpec artifacts, and `.ai-factory` runtime/QA artifacts are not counted as implementation evidence.
+
 Coverage includes a `rules_gate` field, but finalization policy still treats durable rules gate evidence separately. A passing generated-rules state or coverage-inferred rules status does not replace `.ai-factory/qa/<change-id>/rules.md` when `requireRulesPassForDone` is true.
 
 Each material source gets a SHA-256 fingerprint. If any fingerprint changes, the matrix is stale and `/aif-done` requires rerunning `/aif-verify <change-id>`.

--- a/scripts/openspec-coverage-matrix.mjs
+++ b/scripts/openspec-coverage-matrix.mjs
@@ -1034,7 +1034,7 @@ function isWithinDirectory(targetPath, directoryPath) {
 function extractEvidencePaths(text) {
   const paths = new Set();
   const source = String(text ?? '');
-  const pathPattern = /(?:^|[\s`"'(])((?:(?:\.?[A-Za-z0-9_@-]+[\\/])+)?\.?[A-Za-z0-9_@()-][A-Za-z0-9_.@()-]*\.[A-Za-z][A-Za-z0-9]{1,})(?=$|[\s`"',).:\]])/g;
+  const pathPattern = /(?:^|[\s`"'(])((?:(?:\.?[A-Za-z0-9_.@-]+[\\/])+)?\.?[A-Za-z0-9_@()-][A-Za-z0-9_.@()-]*\.[A-Za-z][A-Za-z0-9]{1,})(?=$|[\s`"',).:\]])/g;
   for (const match of source.matchAll(pathPattern)) {
     const normalized = normalizeEvidencePath(match[1]);
     if (normalized) {

--- a/scripts/openspec-coverage-matrix.mjs
+++ b/scripts/openspec-coverage-matrix.mjs
@@ -24,6 +24,7 @@ const POLICIES = new Set(['strict', 'normal']);
 const REQUIREMENT_STATUS_ORDER = ['covered', 'partial', 'missing', 'not-applicable'];
 const TEST_PATH_PATTERN = /(^|\/)(test|tests|__tests__)\/|[._-](test|spec)\.[A-Za-z0-9]+$/i;
 const SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$|\.mjs$|\.cjs$|\.py$|\.go$|\.rs$|\.java$|\.kt$|\.cs$|\.php$|\.rb$|\.sh$|\.ps1$/i;
+const TOOLING_CONFIG_FILE_PATTERN = /\.(?:json|ya?ml|toml|xml)$/i;
 const PROMPT_SOURCE_FILE_PATTERN = /^(?:skills\/(?:[^/]+\/SKILL\.md|shared\/[A-Z0-9_-]+\.md)|injections\/(?:core|handoff)\/[^/]+\.md|agent-files\/(?:codex\/[^/]+\.toml|claude\/[^/]+\.md))$/i;
 const DOC_PATH_PATTERN = /(^|\/)(docs|documentation)\//i;
 const INTERNAL_ARTIFACT_PATTERN = /^(openspec|\.ai-factory)\//i;
@@ -726,12 +727,6 @@ function classifyEvidencePaths(paths) {
 }
 
 function isImplementationEvidencePath(evidencePath) {
-  if (PROMPT_SOURCE_FILE_PATTERN.test(evidencePath)) {
-    return true;
-  }
-  if (!SOURCE_FILE_PATTERN.test(evidencePath)) {
-    return false;
-  }
   if (TEST_PATH_PATTERN.test(evidencePath)) {
     return false;
   }
@@ -741,7 +736,9 @@ function isImplementationEvidencePath(evidencePath) {
   if (INTERNAL_ARTIFACT_PATTERN.test(evidencePath)) {
     return false;
   }
-  return true;
+  return PROMPT_SOURCE_FILE_PATTERN.test(evidencePath)
+    || SOURCE_FILE_PATTERN.test(evidencePath)
+    || TOOLING_CONFIG_FILE_PATTERN.test(evidencePath);
 }
 
 function matchEvidencePaths(requirement, paths, matchingTasks) {
@@ -1037,7 +1034,7 @@ function isWithinDirectory(targetPath, directoryPath) {
 function extractEvidencePaths(text) {
   const paths = new Set();
   const source = String(text ?? '');
-  const pathPattern = /(?:^|[\s`"'(])((?:[A-Za-z0-9_.@-]+[\\/])+[A-Za-z0-9_.@()-]+(?:\.[A-Za-z0-9]+)+)(?=$|[\s`"',).:\]])/g;
+  const pathPattern = /(?:^|[\s`"'(])((?:(?:\.?[A-Za-z0-9_@-]+[\\/])+)?\.?[A-Za-z0-9_@()-][A-Za-z0-9_.@()-]*\.[A-Za-z][A-Za-z0-9]{1,})(?=$|[\s`"',).:\]])/g;
   for (const match of source.matchAll(pathPattern)) {
     const normalized = normalizeEvidencePath(match[1]);
     if (normalized) {
@@ -1050,7 +1047,7 @@ function extractEvidencePaths(text) {
 function normalizeEvidencePath(value) {
   let normalized = String(value ?? '').trim()
     .replace(/\\/g, '/')
-    .replace(/^[./]+/, '')
+    .replace(/^(?:\.\/|\/)+/, '')
     .replace(/[.,;:)]+$/g, '');
   if (!normalized || /^[a-z]+:\/\//i.test(normalized)) {
     return null;

--- a/scripts/openspec-coverage-matrix.test.mjs
+++ b/scripts/openspec-coverage-matrix.test.mjs
@@ -220,6 +220,73 @@ describe('OpenSpec coverage matrix', () => {
     ]);
   });
 
+  it('counts root-level tooling and config paths as implementation evidence', async () => {
+    const rootDir = await createTempRoot();
+    const changeId = 'tooling-config-evidence';
+    await writeFixture(rootDir, `openspec/changes/${changeId}/proposal.md`, '# Proposal\n');
+    await writeFixture(rootDir, `openspec/changes/${changeId}/design.md`, '# Design\n');
+    await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, [
+      '# Tasks',
+      '',
+      '- [x] 1.1 Configure Testo PHP tooling in composer.json, testo.php, and .github/workflows/tests.yml.',
+      '- [x] 1.2 Keep non-implementation references out of implementation evidence: docs/testo.md, openspec/changes/tooling-config-evidence/tasks.md, and .ai-factory/state/tooling-config-evidence/implementation/run-001.md.',
+      '- [x] 1.3 Add regression coverage in tests/Testo/SmokeTest.php.',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, `openspec/changes/${changeId}/specs/testo/spec.md`, [
+      '# Testo Delta',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Testo PHP tooling config',
+      '',
+      'The system MUST provide Testo PHP tooling config.',
+      '',
+      '#### Scenario: Tooling config is covered',
+      '',
+      '- GIVEN the change configures Testo PHP tooling',
+      '- WHEN the coverage matrix is built',
+      '- THEN root-level and workflow config files count as implementation evidence',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, `.ai-factory/state/${changeId}/implementation/run-001.md`, [
+      '# Implementation Trace',
+      '',
+      'Changed files:',
+      '- composer.json',
+      '- testo.php',
+      '- .github/workflows/tests.yml',
+      '- docs/testo.md',
+      '- openspec/changes/tooling-config-evidence/tasks.md',
+      '- .ai-factory/state/tooling-config-evidence/implementation/run-001.md',
+      '- tests/Testo/SmokeTest.php',
+      ''
+    ].join('\n'));
+
+    const matrix = await buildOpenSpecCoverageMatrix({
+      rootDir,
+      changeId,
+      policy: 'strict',
+      generatedRules: []
+    });
+
+    assert.equal(matrix.status, 'pass');
+    assert.deepEqual(matrix.summary, {
+      covered: 1,
+      partial: 0,
+      missing: 0,
+      not_applicable: 0
+    });
+    assert.deepEqual(matrix.requirements[0].implementation_evidence, [
+      '.github/workflows/tests.yml',
+      'composer.json',
+      'testo.php'
+    ]);
+    assert.deepEqual(matrix.requirements[0].test_evidence, [
+      'tests/Testo/SmokeTest.php'
+    ]);
+  });
+
   it('fails missing requirements in strict mode and warns in normal mode', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');

--- a/scripts/openspec-coverage-matrix.test.mjs
+++ b/scripts/openspec-coverage-matrix.test.mjs
@@ -228,7 +228,7 @@ describe('OpenSpec coverage matrix', () => {
     await writeFixture(rootDir, `openspec/changes/${changeId}/tasks.md`, [
       '# Tasks',
       '',
-      '- [x] 1.1 Configure Testo PHP tooling in composer.json, testo.php, and .github/workflows/tests.yml.',
+      '- [x] 1.1 Configure Testo PHP tooling in composer.json, testo.php, .github/workflows/tests.yml, and src/v1.2/auth/login.ts.',
       '- [x] 1.2 Keep non-implementation references out of implementation evidence: docs/testo.md, openspec/changes/tooling-config-evidence/tasks.md, and .ai-factory/state/tooling-config-evidence/implementation/run-001.md.',
       '- [x] 1.3 Add regression coverage in tests/Testo/SmokeTest.php.',
       ''
@@ -256,6 +256,7 @@ describe('OpenSpec coverage matrix', () => {
       '- composer.json',
       '- testo.php',
       '- .github/workflows/tests.yml',
+      '- src/v1.2/auth/login.ts',
       '- docs/testo.md',
       '- openspec/changes/tooling-config-evidence/tasks.md',
       '- .ai-factory/state/tooling-config-evidence/implementation/run-001.md',
@@ -280,6 +281,7 @@ describe('OpenSpec coverage matrix', () => {
     assert.deepEqual(matrix.requirements[0].implementation_evidence, [
       '.github/workflows/tests.yml',
       'composer.json',
+      'src/v1.2/auth/login.ts',
       'testo.php'
     ]);
     assert.deepEqual(matrix.requirements[0].test_evidence, [


### PR DESCRIPTION
## Summary

Fixes #92 by teaching the OpenSpec coverage matrix to treat explicitly referenced root-level and nested tooling/config files as implementation evidence when they are not tests, docs, canonical OpenSpec artifacts, or `.ai-factory` runtime artifacts.

## What changed

- Extract root-level path tokens such as `composer.json` and `testo.php` from OpenSpec tasks and runtime traces.
- Classify referenced JSON, YAML, TOML, and XML tooling/config files as implementation evidence after exclusion checks.
- Preserve hidden directory prefixes such as `.github/workflows/tests.yml` during path normalization.
- Add regression coverage and document the evidence classification behavior.

## Validation

- `node --test scripts\openspec-coverage-matrix.test.mjs`
- `git diff --check`
- `npm run validate`
- `npm test`