### PR TITLE
fix issue 93 artifact protocol config

### DIFF
--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -40,6 +40,22 @@ OpenSpec skills and slash commands are not installed by this extension.
 
 This initialization is for user projects. The `aifhub-extension` package repository does not ship root `openspec/` or root `.ai-factory/rules/generated/` content; generated rules are derived in user projects and safe to regenerate. OpenSpec examples in this repo belong only under fixture paths, and extension behavior requirements are validated by prompt contracts and tests instead of committed root OpenSpec specs.
 
+## Artifact Protocol Profiles
+
+The selected `aifhub.artifactProtocol` owns its active config profile. Legacy AI Factory-only mode does not add OpenSpec settings or OpenSpec runtime paths:
+
+```yaml
+aifhub:
+  artifactProtocol: ai-factory
+
+paths:
+  plans: .ai-factory/plans
+  specs: .ai-factory/specs
+  rules: .ai-factory/rules
+```
+
+OpenSpec-native mode adds the OpenSpec settings and runtime path profile shown below.
+
 ## OpenSpec-Native Config
 
 OpenSpec-native mode is selected through `.ai-factory/config.yaml`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -195,6 +195,8 @@ Existing configs are not prompted again. Codex Default mode asks this as plain t
 
 If localization questions run first, `/aif-analyze` carries those answers forward and writes them only after the artifact protocol is selected, so language persistence does not accidentally lock in the legacy default.
 
+The selected artifact protocol owns its config profile. Legacy `artifactProtocol: ai-factory` configs do not include `aifhub.openspec` settings or OpenSpec runtime path defaults; OpenSpec-native `artifactProtocol: openspec` configs include those settings and paths explicitly.
+
 ### `/aif-plan full`
 
 Reads:

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -38,6 +38,43 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
     assertIncludes(template, 'artifactProtocol: ai-factory', 'skills/aif-analyze/references/config-template.yaml');
   });
 
+  it('keeps the legacy default template exclusive to the selected protocol', async () => {
+    const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
+
+    assertIncludes(template, 'artifactProtocol: ai-factory', 'skills/aif-analyze/references/config-template.yaml');
+    assert.doesNotMatch(
+      template,
+      /^  openspec:\s*$/m,
+      'skills/aif-analyze/references/config-template.yaml should not include active aifhub.openspec in the legacy profile'
+    );
+
+    for (const unexpected of [
+      'requireGeneratedRulesForDone',
+      'requireRulesPassForDone',
+      'requireSpecCoverageForDone',
+      'allowWarnOnDone:',
+      'useInstructionsApply'
+    ]) {
+      assertNotIncludes(
+        template,
+        unexpected,
+        'skills/aif-analyze/references/config-template.yaml legacy profile'
+      );
+    }
+
+    for (const pattern of [
+      /^  state:\s*\.ai-factory\/state\s*$/m,
+      /^  qa:\s*\.ai-factory\/qa\s*$/m,
+      /^  generated_rules:\s*\.ai-factory\/rules\/generated\s*$/m
+    ]) {
+      assert.doesNotMatch(
+        template,
+        pattern,
+        `skills/aif-analyze/references/config-template.yaml should not include active OpenSpec path key ${pattern}`
+      );
+    }
+  });
+
   it('documents first-bootstrap artifact protocol prompts without preselecting mode', async () => {
     const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
     const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
@@ -62,10 +99,7 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
   });
 
   it('defines the OpenSpec-native config shape and canonical runtime paths', async () => {
-    const combined = [
-      await readRepoFile('skills/aif-analyze/SKILL.md'),
-      await readRepoFile('skills/aif-analyze/references/config-template.yaml')
-    ].join('\n');
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
 
     for (const expected of [
       'artifactProtocol: openspec',
@@ -96,7 +130,7 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       '.ai-factory/qa',
       '.ai-factory/rules/generated'
     ]) {
-      assertIncludes(combined, expected, 'aif-analyze OpenSpec bootstrap artifacts');
+      assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md OpenSpec bootstrap artifacts');
     }
   });
 

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -359,7 +359,12 @@ describe('mode switching', () => {
     });
 
     assert.equal(result.ok, true);
-    assert.match(await readFixture(rootDir, '.ai-factory/config.yaml'), /artifactProtocol: ai-factory/);
+    const config = await readFixture(rootDir, '.ai-factory/config.yaml');
+    assert.match(config, /artifactProtocol: ai-factory/);
+    assert.doesNotMatch(config, /^  openspec:\s*$/m);
+    assert.doesNotMatch(config, /^  state:\s*\.ai-factory\/state\s*$/m);
+    assert.doesNotMatch(config, /^  qa:\s*\.ai-factory\/qa\s*$/m);
+    assert.doesNotMatch(config, /^  generated_rules:\s*\.ai-factory\/rules\/generated\s*$/m);
     assert.equal(await pathExists(rootDir, '.ai-factory/plans'), true);
     assert.equal(await pathExists(rootDir, '.ai-factory/specs'), true);
     assert.equal(await pathExists(rootDir, '.ai-factory/rules'), true);

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -128,9 +128,18 @@ Resolve the bootstrap/config mode before creating directories:
 - If localization answers were collected while config was missing, write those pending config values into the selected legacy `ai-factory` or `openspec-native` config shape.
 - Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `rules`, `workflow`.
 - In legacy `ai-factory` mode:
+  - Ensure this selected-protocol profile is present:
+
+```yaml
+aifhub:
+  artifactProtocol: ai-factory
+```
+
   - Preserve the existing AI Factory-only path defaults.
   - Keep `paths.plans` at `.ai-factory/plans` unless an existing value says otherwise.
   - Keep `paths.specs` at `.ai-factory/specs` unless an existing value says otherwise.
+  - Do not add `aifhub.openspec`, OpenSpec policy defaults, or OpenSpec runtime path defaults (`paths.state`, `paths.qa`, `paths.generated_rules`) unless OpenSpec-native mode is selected.
+  - Preserve existing user-authored config values unless the user explicitly requests mode cleanup or `/aif-mode` switching.
 - In `openspec-native` mode:
   - Ensure this config shape is present:
 
@@ -291,14 +300,49 @@ openspec init --tools none
 
 ## Config v1 Schema
 
+Common fields:
+
 ```yaml
 language:
   ui: russian                    # Communication language
   artifacts: russian             # Generated artifacts language
   technical_terms: keep          # keep | translate | mixed
 
+workflow:
+  auto_create_dirs: true
+  plan_id_format: slug
+  analyze_updates_architecture: true
+  architecture_updates_roadmap: true
+  verify_mode: normal
+
+rules:
+  base: .ai-factory/rules/base.md
+  # area rules added by planning when needed
+
+agent_profile: default
+```
+
+Legacy AI Factory-only profile:
+
+```yaml
 aifhub:
-  artifactProtocol: ai-factory   # ai-factory | openspec
+  artifactProtocol: ai-factory
+
+paths:
+  description: .ai-factory/DESCRIPTION.md
+  architecture: .ai-factory/ARCHITECTURE.md
+  roadmap: .ai-factory/ROADMAP.md
+  research: .ai-factory/RESEARCH.md
+  plans: .ai-factory/plans
+  specs: .ai-factory/specs
+  rules: .ai-factory/rules
+```
+
+OpenSpec-native profile:
+
+```yaml
+aifhub:
+  artifactProtocol: openspec
   openspec:
     root: openspec
     installSkills: false
@@ -330,29 +374,12 @@ paths:
   architecture: .ai-factory/ARCHITECTURE.md
   roadmap: .ai-factory/ROADMAP.md
   research: .ai-factory/RESEARCH.md
-  plans: .ai-factory/plans
-  specs: .ai-factory/specs
+  plans: openspec/changes
+  specs: openspec/specs
   rules: .ai-factory/rules
   state: .ai-factory/state
   qa: .ai-factory/qa
   generated_rules: .ai-factory/rules/generated
-
-# OpenSpec-native path profile:
-# paths.plans: openspec/changes
-# paths.specs: openspec/specs
-
-workflow:
-  auto_create_dirs: true
-  plan_id_format: slug
-  analyze_updates_architecture: true
-  architecture_updates_roadmap: true
-  verify_mode: normal
-
-rules:
-  base: .ai-factory/rules/base.md
-  # area rules added by planning when needed
-
-agent_profile: default
 ```
 
 ## Rules

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -25,35 +25,8 @@ language:
 aifhub:
   # ai-factory | openspec
   artifactProtocol: ai-factory
-  # OpenSpec-native settings. Keep installSkills false; this extension never
-  # installs OpenSpec skills or slash commands.
-  openspec:
-    root: openspec
-    installSkills: false
-    validateOnPlan: true
-    validateOnImprove: true
-    validateOnVerify: true
-    statusOnVerify: true
-    archiveOnDone: true
-    useInstructionsApply: true
-    compileRulesOnSync: true
-    validateOnSync: true
-    requireCliForPlan: false
-    requireCliForImprove: false
-    requireCliForVerify: false
-    # /aif-done archive-required finalization needs a compatible CLI.
-    # Do not install OpenSpec skills or silently archive through legacy specs.
-    requireCliForDone: true
-    requireGeneratedRulesForVerify: false
-    requireGeneratedRulesForDone: true
-    requireRulesPassForVerify: false
-    requireRulesPassForDone: true
-    requireSpecCoverageForVerify: false
-    requireSpecCoverageForDone: true
-    allowWarnOnDone:
-      rules: false
-      coverage: false
-      openspecStatus: true
+# OpenSpec-native mode writes its own aifhub settings profile only when
+# aifhub.artifactProtocol is openspec.
 
 # ============================================================================
 # PATH CONFIGURATION
@@ -70,14 +43,7 @@ paths:
   plans: .ai-factory/plans
   specs: .ai-factory/specs
 
-  # Runtime/generated directories used by OpenSpec-native mode
-  state: .ai-factory/state
-  qa: .ai-factory/qa
-  generated_rules: .ai-factory/rules/generated
-
-  # OpenSpec-native path profile when aifhub.artifactProtocol: openspec:
-  # plans: openspec/changes
-  # specs: openspec/specs
+  # OpenSpec-native mode writes its own path profile only when selected.
   
   # Rules directory (base.md required, area files optional)
   rules: .ai-factory/rules


### PR DESCRIPTION
## Summary

- Fixes #93 by omitting non-selected artifact protocol settings from the generated `aif-analyze` config.
- Updates the `aif-analyze` config template and workflow guidance so only the selected artifact protocol contributes protocol-specific settings.
- Adds regression coverage for OpenSpec bootstrap and artifact sync behavior, plus docs updates for usage and OpenSpec compatibility.

## Why

Issue #93 reported that the generated config could include settings for artifact protocol modes that were not selected. This made the config noisier and could imply inactive protocol behavior. The change keeps protocol-specific config scoped to the selected mode.

## Verification

- `node --test scripts/aif-analyze-openspec-bootstrap.test.mjs scripts/aif-artifact-sync.test.mjs`
- `npm run validate`
- `npm test`
- `openspec validate fix-issue-93-artifact-protocol-config --type change --strict --json --no-interactive --no-color`
- `/aif-verify fix-issue-93-artifact-protocol-config`: PASS
- `/aif-done fix-issue-93-artifact-protocol-config`: PASS

## Evidence

- `.ai-factory/qa/fix-issue-93-artifact-protocol-config/done.md`
- `.ai-factory/qa/fix-issue-93-artifact-protocol-config/done-readiness.json`
- `.ai-factory/qa/fix-issue-93-artifact-protocol-config/openspec-archive.json`

Fixes #93