### PR TITLE
Add optional Graphify context guidance and utility config

### DIFF
--- a/agent-files/claude/aifhub-review-sidecar.md
+++ b/agent-files/claude/aifhub-review-sidecar.md
@@ -21,6 +21,12 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present.
 - Read runtime state from `.ai-factory/state/<change-id>/` and QA evidence from `.ai-factory/qa/<change-id>/` when relevant.
+- May read existing reviewed Graphify outputs such as `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `.ai-factory/references/graphify/GRAPH_REPORT.md`, and `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md` as optional supporting context for dependency/impact review.
+- Missing Graphify or missing reports are degraded context, not a review failure.
+- Do not install `graphifyy`, run `graphify`, add Graphify dependencies, or start/register Graphify MCP automatically.
+- Treat extracted, inferred, ambiguous, or confidence-labeled Graphify relationships as hypotheses; findings must be grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
+- Do not treat Graphify output as canonical evidence, generated rules input, QA evidence, or roadmap completion proof.
+- Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
 - Do not edit files.
 - Return findings first, including active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, and QA evidence path.
 

--- a/agent-files/codex/aifhub-review-sidecar.toml
+++ b/agent-files/codex/aifhub-review-sidecar.toml
@@ -17,6 +17,12 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present.
 - Read runtime state from .ai-factory/state/<change-id>/ and QA evidence from .ai-factory/qa/<change-id>/ when relevant.
+- May read existing reviewed Graphify outputs such as graphify-out/GRAPH_REPORT.md, graphify-out/graph.json, .ai-factory/references/graphify/GRAPH_REPORT.md, and .ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md as optional supporting context for dependency/impact review.
+- Missing Graphify or missing reports are degraded context, not a review failure.
+- Do not install graphifyy, run graphify, add Graphify dependencies, or start/register Graphify MCP automatically.
+- Treat extracted, inferred, ambiguous, or confidence-labeled Graphify relationships as hypotheses; findings must be grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
+- Do not treat Graphify output as canonical evidence, generated rules input, QA evidence, or roadmap completion proof.
+- Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in .ai-factory/, openspec/, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
 - Do not edit files.
 - Return findings first, including active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, and QA evidence path.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 
 1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
 2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
-3. [Context Loading Policy](context-loading-policy.md) for consumer context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
+3. [Context Loading Policy](context-loading-policy.md) for consumer context, optional Graphify context guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
 4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags, and degraded mode.
 5. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
 6. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
@@ -38,8 +38,8 @@ The remaining runtime-specific guides are supporting references:
 
 | Guide | Purpose |
 |---|---|
-| [Usage](usage.md) | Full OpenSpec-native command flow, gates, finalization tail, commit, and examples |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
+| [Usage](usage.md) | Full OpenSpec-native command flow, optional Graphify context, gates, finalization tail, commit, and examples |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, validation policy flags, sync points, rules gate, version support, and degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator for canonical artifacts, runtime evidence, QA, and generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness, and integration points |
@@ -60,6 +60,7 @@ This docs set covers:
 - OpenSpec-native v1 workflow
 - artifact mode switching and sync through `/aif-mode`
 - command reads, writes, and forbidden writes
+- optional Graphify context provider guidance
 - optional rules, review, and security gates
 - verification, fix, done, post-archive sync, commit, and evolve handoff
 - OpenSpec requirement coverage evidence and policy

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -79,6 +79,8 @@ Runner output from OpenSpec CLI commands is runtime guidance or evidence. It doe
 
 Graphify is an optional context/research provider. AIFHub commands may use existing Graphify output as supporting context, but they must not make Graphify a required extension dependency, install `graphifyy`, run `graphify`, add Graphify manifest dependencies, start or register Graphify MCP automatically, or turn Graphify availability into a verification gate.
 
+Project preference is recorded in `.ai-factory/config.yaml` as `utilities.graphify.enabled`. At the beginning of the optional Graphify check, `/aif-analyze` should test `uv` availability with `uv --version`. If Graphify is missing, or if `utilities.graphify.enabled` is missing or `false`, `/aif-analyze` should report Graphify as optional and recommended for large or unfamiliar repositories, including the manual setup commands `uv tool install graphifyy` and `graphify install`. This recommendation is advisory only and must not trigger installation, execution, dependency changes, or MCP registration.
+
 Allowed Graphify inputs are existing local or copied outputs:
 
 - `graphify-out/GRAPH_REPORT.md`

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -75,6 +75,37 @@ Generated rules and generated trace metadata are derived guidance only. If gener
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
 
+## Optional Graphify Context
+
+Graphify is an optional context/research provider. AIFHub commands may use existing Graphify output as supporting context, but they must not make Graphify a required extension dependency, install `graphifyy`, run `graphify`, add Graphify manifest dependencies, start or register Graphify MCP automatically, or turn Graphify availability into a verification gate.
+
+Allowed Graphify inputs are existing local or copied outputs:
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
+- `.ai-factory/references/graphify/GRAPH_REPORT.md`
+- `.ai-factory/references/graphify/graph.json`
+- `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
+- `.ai-factory/state/<change-id>/graphify/graph.json`
+
+If Graphify is unavailable, or if no `graphify-out/GRAPH_REPORT.md` or copied report exists, commands continue normally and report Graphify context as unavailable or degraded rather than failing.
+
+Graphify output remains supporting evidence only. `GRAPH_REPORT.md` may include extracted, inferred, ambiguous, or confidence-labeled relationships; commands must treat those graph-derived claims as hypotheses for further inspection. Final requirements, plans, findings, completion status, roadmap status, generated rules, and QA verdicts must be grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, or other direct repository evidence.
+
+Allowed durable storage for reviewed Graphify context:
+
+- `.ai-factory/references/graphify/` for project-wide reference copies.
+- `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime copies.
+
+Forbidden storage for Graphify generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html`:
+
+- `openspec/changes/<change-id>/`
+- `openspec/specs/`
+- `.ai-factory/rules/generated/`
+- `.ai-factory/qa/<change-id>/`
+
+Before copying Graphify output into `.ai-factory/`, review it for sensitive information. AIFHub guidance must not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+
 ## Bug Fix Context
 
 OpenSpec-native bug fixes have two context shapes:

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -52,6 +52,14 @@ paths:
   plans: .ai-factory/plans
   specs: .ai-factory/specs
   rules: .ai-factory/rules
+
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
 ```
 
 OpenSpec-native mode adds the OpenSpec settings and runtime path profile shown below.
@@ -95,9 +103,19 @@ paths:
   state: .ai-factory/state
   qa: .ai-factory/qa
   generated_rules: .ai-factory/rules/generated
+
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
 ```
 
 `installSkills: false` is intentional. AIFHub Extension uses OpenSpec artifacts and `scripts/openspec-runner.mjs` as the optional CLI adapter, not OpenSpec-installed skills or slash commands.
+
+The `utilities` section is protocol-neutral. It records optional tool preferences only; Graphify remains manually installed, activated, and run by the user.
 
 On first bootstrap, `/aif-analyze` may create the OpenSpec marker after asking for the artifact protocol. If `.ai-factory/config.yaml` is missing and the user did not explicitly request OpenSpec-native mode, interactive runtimes ask the user to choose `legacy AI Factory-only` or `OpenSpec-native` before writing the config. Existing configs are preserved without prompting. Autonomous/subagent runs do not ask; they default to legacy AI Factory-only and report OpenSpec-native mode as an open question.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,38 @@ The `aifhub-extension` package repository stays artifact-light: root `openspec/`
 
 AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
 
+## Optional Graphify Context
+
+Graphify can be used as a manual, user-owned repository research aid before or during AIFHub work. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
+
+Manual usage, outside AIFHub command ownership:
+
+```powershell
+python -m pip install graphifyy
+graphify .
+```
+
+Use `graphify .` in PowerShell; do not prefix it as `/graphify .`.
+
+Graphify writes local outputs under `graphify-out/`, including:
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
+- `graphify-out/graph.html`
+
+Its CLI may also expose research commands such as `graphify query`, `graphify path`, and `graphify explain`.
+
+When `graphify-out/GRAPH_REPORT.md` already exists, AIFHub commands may read it as optional supporting context. To keep reviewed output for later context loading, copy it only to:
+
+- `.ai-factory/references/graphify/` for project-wide reference context.
+- `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime context.
+
+Do not store Graphify generated files under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+
+Treat Graphify findings as supporting evidence only. Reports can include extracted, inferred, ambiguous, or confidence-labeled relationships, so final plans, review findings, verification status, generated rules, and roadmap completion still need direct repository evidence from canonical OpenSpec artifacts, source files, tests, runtime state, or QA evidence.
+
+Before copying a report into `.ai-factory/`, review it for sensitive information. Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in AIFHub artifacts.
+
 ## Bug Fix Workflows
 
 OpenSpec-native mode separates new bug reports from fixes for failed verification findings.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,10 +53,26 @@ AIFHub commands request OpenSpec validation, status, instructions, and archive t
 
 Graphify can be used as a manual, user-owned repository research aid before or during AIFHub work. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
 
+`/aif-analyze` records the project preference under shared utility config. At the start of the optional Graphify check it should verify whether `uv` is available with `uv --version`. When Graphify is not enabled, analysis should show a non-blocking recommendation with the manual setup commands:
+
+```yaml
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
+```
+
+Set `utilities.graphify.enabled: true` only after the project chooses to use manually generated Graphify reports.
+
 Manual usage, outside AIFHub command ownership:
 
 ```powershell
-python -m pip install graphifyy
+uv --version
+uv tool install graphifyy
+graphify install
 graphify .
 ```
 
@@ -228,6 +244,8 @@ Existing configs are not prompted again. Codex Default mode asks this as plain t
 If localization questions run first, `/aif-analyze` carries those answers forward and writes them only after the artifact protocol is selected, so language persistence does not accidentally lock in the legacy default.
 
 The selected artifact protocol owns its config profile. Legacy `artifactProtocol: ai-factory` configs do not include `aifhub.openspec` settings or OpenSpec runtime path defaults; OpenSpec-native `artifactProtocol: openspec` configs include those settings and paths explicitly.
+
+Shared protocol-neutral settings such as `utilities.graphify.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency.
 
 ### `/aif-plan full`
 

--- a/injections/core/aif-explore-plan-folder.md
+++ b/injections/core/aif-explore-plan-folder.md
@@ -31,6 +31,18 @@ Allowed read context:
 - `openspec/specs/**`
 - `openspec/changes/<change-id>/**`
 - `.ai-factory/state/<change-id>/`
+- optional reviewed Graphify outputs such as `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `.ai-factory/references/graphify/GRAPH_REPORT.md`, and `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
+
+Optional Graphify context:
+
+- Graphify is optional supporting context for large repository architecture/relation discovery.
+- `/aif-explore` may recommend that the user run Graphify manually outside AIFHub command ownership, but it must not install `graphifyy`, run `graphify`, add Graphify dependencies, or start/register Graphify MCP automatically.
+- Missing Graphify or missing `graphify-out/GRAPH_REPORT.md` is degraded context, not an exploration failure.
+- When existing Graphify output is available, treat extracted, inferred, ambiguous, or confidence-labeled relationships as hypotheses for direct repository inspection.
+- Research conclusions must remain grounded in source files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
+- Project-wide reviewed Graphify copies belong under `.ai-factory/references/graphify/`; change-scoped reviewed copies belong under `.ai-factory/state/<change-id>/graphify/`.
+- Do not store Graphify generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html` under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
 
 Canonical OpenSpec change files under an active change are only:
 

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -31,6 +31,19 @@ Do not create legacy `.ai-factory/plans` plan files or companion folders in this
 
 If the task is docs/tooling-only and does not change product or workflow behavior, a delta spec may be omitted only when the plan explicitly explains why no delta spec is needed.
 
+#### Optional Graphify context
+
+Graphify is optional supporting context for integration discovery before creating or refining a canonical OpenSpec change.
+
+- `/aif-plan full` may read existing reviewed Graphify outputs such as `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `.ai-factory/references/graphify/GRAPH_REPORT.md`, and `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`.
+- Missing Graphify or missing reports are degraded context, not planning failure.
+- Do not install `graphifyy`, run `graphify`, add Graphify dependencies or manifest entries, or start/register Graphify MCP automatically.
+- Treat extracted, inferred, ambiguous, or confidence-labeled Graphify relationships as hypotheses for direct repository inspection.
+- Use Graphify output to identify possible integration points or impact areas only; final `proposal.md`, `design.md`, `tasks.md`, and delta specs must cite direct repository evidence and canonical OpenSpec/source context.
+- Reviewed project-wide Graphify copies belong under `.ai-factory/references/graphify/`; reviewed change-scoped copies belong under `.ai-factory/state/<change-id>/graphify/`.
+- Do not import raw Graphify output or generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html` into `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+
 #### Change ID policy
 
 - Derive a safe `<change-id>` slug from the request for new plans.

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -36,6 +36,9 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
     assertIncludes(skill, 'aifhub.artifactProtocol: openspec', 'skills/aif-analyze/SKILL.md');
     assertIncludes(skill, 'Do not silently migrate a legacy AI Factory-only project', 'skills/aif-analyze/SKILL.md');
     assertIncludes(template, 'artifactProtocol: ai-factory', 'skills/aif-analyze/references/config-template.yaml');
+    assertIncludes(template, 'utilities:', 'skills/aif-analyze/references/config-template.yaml');
+    assertIncludes(template, 'graphify:', 'skills/aif-analyze/references/config-template.yaml');
+    assertIncludes(template, 'enabled: false', 'skills/aif-analyze/references/config-template.yaml');
   });
 
   it('keeps the legacy default template exclusive to the selected protocol', async () => {
@@ -131,6 +134,31 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       '.ai-factory/rules/generated'
     ]) {
       assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md OpenSpec bootstrap artifacts');
+    }
+  });
+
+  it('documents optional Graphify utility config and analyze recommendation', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+    const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
+    const combined = [skill, template].join('\n');
+
+    for (const expected of [
+      'utilities.graphify.enabled',
+      'Graphify is recommended for large or unfamiliar repositories',
+      'uv --version',
+      'uv tool install graphifyy',
+      'graphify install',
+      'graphify .',
+      'utilities:',
+      'graphify:',
+      'enabled: false',
+      'uv_check: uv --version',
+      'install: uv tool install graphifyy',
+      'activate: graphify install',
+      'report_command: graphify .',
+      'Do not install `graphifyy`, run `graphify`'
+    ]) {
+      assertIncludes(combined, expected, 'aif-analyze Graphify utility guidance');
     }
   });
 

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -1651,6 +1651,10 @@ function renderUtilitiesBlock(blocks) {
     return fallback;
   }
 
+  if (hasTopLevelScalarValue(existing, 'utilities')) {
+    return existing;
+  }
+
   if (/^  graphify:(?:\s|$)/m.test(existing)) {
     return existing;
   }
@@ -1664,6 +1668,18 @@ function renderUtilitiesBlock(blocks) {
     '    activate: graphify install',
     '    report_command: graphify .'
   ].join('\n');
+}
+
+function hasTopLevelScalarValue(blockText, key) {
+  const firstLine = String(blockText ?? '').split('\n')[0] ?? '';
+  const match = firstLine.match(new RegExp(`^${key}:\\s*(.*?)\\s*$`));
+
+  if (!match) {
+    return false;
+  }
+
+  const value = match[1].replace(/(?:^|\s)#.*$/, '').trim();
+  return value.length > 0;
 }
 
 function renderAifhubBlock(mode) {

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -1651,7 +1651,7 @@ function renderUtilitiesBlock(blocks) {
     return fallback;
   }
 
-  if (/^  graphify:\s*$/m.test(existing)) {
+  if (/^  graphify:(?:\s|$)/m.test(existing)) {
     return existing;
   }
 

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -628,7 +628,7 @@ export function renderConfigForMode(existingRaw, mode) {
   const parsed = parseSimpleYaml(existingRaw);
   const paths = parsed.paths ?? {};
   const blocks = parseTopLevelBlocks(existingRaw);
-  const used = new Set(['config_version', 'language', 'aifhub', 'paths']);
+  const used = new Set(['config_version', 'language', 'aifhub', 'paths', 'utilities']);
   const rendered = [];
 
   rendered.push(renderScalarOrDefault(blocks, 'config_version', 'config_version: 1'));
@@ -640,6 +640,7 @@ export function renderConfigForMode(existingRaw, mode) {
   ].join('\n')));
   rendered.push(renderAifhubBlock(mode));
   rendered.push(renderPathsBlock(mode, paths));
+  rendered.push(renderUtilitiesBlock(blocks));
 
   for (const block of blocks) {
     if (!used.has(block.key)) {
@@ -1632,6 +1633,37 @@ function renderScalarOrDefault(blocks, key, fallback) {
 
 function renderBlockOrDefault(blocks, key, fallback) {
   return blocks.find((block) => block.key === key)?.text.trimEnd() || fallback;
+}
+
+function renderUtilitiesBlock(blocks) {
+  const fallback = [
+    'utilities:',
+    '  graphify:',
+    '    enabled: false',
+    '    uv_check: uv --version',
+    '    install: uv tool install graphifyy',
+    '    activate: graphify install',
+    '    report_command: graphify .'
+  ].join('\n');
+  const existing = blocks.find((block) => block.key === 'utilities')?.text.trimEnd();
+
+  if (!existing) {
+    return fallback;
+  }
+
+  if (/^  graphify:\s*$/m.test(existing)) {
+    return existing;
+  }
+
+  return [
+    existing,
+    '  graphify:',
+    '    enabled: false',
+    '    uv_check: uv --version',
+    '    install: uv tool install graphifyy',
+    '    activate: graphify install',
+    '    report_command: graphify .'
+  ].join('\n');
 }
 
 function renderAifhubBlock(mode) {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -389,6 +389,38 @@ describe('mode switching', () => {
     assert.match(config, /^    report_command: graphify \.\s*$/m);
   });
 
+  it('does not duplicate existing scalar or commented Graphify utility settings', async () => {
+    for (const graphifyLine of [
+      '  graphify: false',
+      '  graphify: # managed manually'
+    ]) {
+      const rootDir = await createTempRoot();
+      await writeFixture(rootDir, '.ai-factory/config.yaml', [
+        'aifhub:',
+        '  artifactProtocol: ai-factory',
+        'paths:',
+        '  plans: .ai-factory/plans',
+        '  specs: .ai-factory/specs',
+        '  rules: .ai-factory/rules',
+        'utilities:',
+        graphifyLine,
+        ''
+      ].join('\n'));
+
+      const result = await switchToOpenSpecMode({
+        rootDir,
+        detectOpenSpec: async () => missingCliDetection(),
+        timestamp: '2026-04-29T00-00-00-000Z'
+      });
+
+      assert.equal(result.ok, true);
+      const config = await readFixture(rootDir, '.ai-factory/config.yaml');
+      assert.equal((config.match(/^  graphify:/gm) ?? []).length, 1);
+      assert.match(config, new RegExp(graphifyLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.doesNotMatch(config, /^    install: uv tool install graphifyy\s*$/m);
+    }
+  });
+
   it('switches to AI Factory mode without deleting OpenSpec artifacts', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -421,6 +421,37 @@ describe('mode switching', () => {
     }
   });
 
+  it('preserves scalar utilities settings instead of appending an invalid child block', async () => {
+    for (const utilitiesLine of [
+      'utilities: false',
+      'utilities: disabled # managed manually'
+    ]) {
+      const rootDir = await createTempRoot();
+      await writeFixture(rootDir, '.ai-factory/config.yaml', [
+        'aifhub:',
+        '  artifactProtocol: ai-factory',
+        'paths:',
+        '  plans: .ai-factory/plans',
+        '  specs: .ai-factory/specs',
+        '  rules: .ai-factory/rules',
+        utilitiesLine,
+        ''
+      ].join('\n'));
+
+      const result = await switchToOpenSpecMode({
+        rootDir,
+        detectOpenSpec: async () => missingCliDetection(),
+        timestamp: '2026-04-29T00-00-00-000Z'
+      });
+
+      assert.equal(result.ok, true);
+      const config = await readFixture(rootDir, '.ai-factory/config.yaml');
+      assert.match(config, new RegExp(`^${utilitiesLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'));
+      assert.doesNotMatch(config, /^  graphify:\s*$/m);
+      assert.doesNotMatch(config, /^    install: uv tool install graphifyy\s*$/m);
+    }
+  });
+
   it('switches to AI Factory mode without deleting OpenSpec artifacts', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -316,7 +316,14 @@ describe('mode switching', () => {
       'allowWarnOnDone:',
       'rules: false',
       'coverage: false',
-      'openspecStatus: true'
+      'openspecStatus: true',
+      'utilities:',
+      'graphify:',
+      'enabled: false',
+      'uv_check: uv --version',
+      'install: uv tool install graphifyy',
+      'activate: graphify install',
+      'report_command: graphify .'
     ]) {
       assert.match(config, new RegExp(line), `OpenSpec config should include ${line}`);
     }
@@ -349,6 +356,39 @@ describe('mode switching', () => {
     assert.equal(await pathExists(rootDir, 'openspec/changes/add-oauth/proposal.md'), false);
   });
 
+  it('preserves existing utility settings while adding Graphify defaults', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: ai-factory',
+      'paths:',
+      '  plans: .ai-factory/plans',
+      '  specs: .ai-factory/specs',
+      '  rules: .ai-factory/rules',
+      'utilities:',
+      '  custom_tool:',
+      '    enabled: true',
+      ''
+    ].join('\n'));
+
+    const result = await switchToOpenSpecMode({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      timestamp: '2026-04-29T00-00-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    const config = await readFixture(rootDir, '.ai-factory/config.yaml');
+    assert.match(config, /^  custom_tool:\s*$/m);
+    assert.match(config, /^    enabled: true\s*$/m);
+    assert.match(config, /^  graphify:\s*$/m);
+    assert.match(config, /^    enabled: false\s*$/m);
+    assert.match(config, /^    uv_check: uv --version\s*$/m);
+    assert.match(config, /^    install: uv tool install graphifyy\s*$/m);
+    assert.match(config, /^    activate: graphify install\s*$/m);
+    assert.match(config, /^    report_command: graphify \.\s*$/m);
+  });
+
   it('switches to AI Factory mode without deleting OpenSpec artifacts', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, 'openspec/changes/add-oauth/proposal.md', '# Proposal\n');
@@ -361,6 +401,17 @@ describe('mode switching', () => {
     assert.equal(result.ok, true);
     const config = await readFixture(rootDir, '.ai-factory/config.yaml');
     assert.match(config, /artifactProtocol: ai-factory/);
+    for (const line of [
+      'utilities:',
+      'graphify:',
+      'enabled: false',
+      'uv_check: uv --version',
+      'install: uv tool install graphifyy',
+      'activate: graphify install',
+      'report_command: graphify .'
+    ]) {
+      assert.match(config, new RegExp(line), `AI Factory config should include ${line}`);
+    }
     assert.doesNotMatch(config, /^  openspec:\s*$/m);
     assert.doesNotMatch(config, /^  state:\s*\.ai-factory\/state\s*$/m);
     assert.doesNotMatch(config, /^  qa:\s*\.ai-factory\/qa\s*$/m);

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -477,13 +477,20 @@ describe('OpenSpec-native prompt asset contract', () => {
     const usage = await readRepoFile('docs/usage.md');
 
     for (const expected of [
-      'python -m pip install graphifyy',
+      'uv --version',
+      'uv tool install graphifyy',
+      'graphify install',
       'graphify .',
       'do not prefix it as `/graphify .`',
       'graphify-out/graph.html',
       'graphify query',
       'graphify path',
       'graphify explain',
+      'utilities.graphify.enabled',
+      'uv_check: uv --version',
+      'install: uv tool install graphifyy',
+      'activate: graphify install',
+      'report_command: graphify .',
       'AIFHub Extension does not require Graphify',
       'does not add Graphify to extension dependencies'
     ]) {

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -74,6 +74,19 @@ const SIDECAR_PROMPT_ASSETS = [
 const ROADMAP_PROMPT_ASSET = 'injections/core/aif-roadmap-maturity-audit.md';
 const COMMIT_PROMPT_ASSET = 'injections/core/aif-commit-roadmap-freshness.md';
 
+const GRAPHIFY_CONTEXT_DOC_ASSETS = [
+  'docs/context-loading-policy.md',
+  'docs/usage.md'
+];
+
+const GRAPHIFY_CONTEXT_PROMPT_ASSETS = [
+  'skills/aif-analyze/SKILL.md',
+  'injections/core/aif-explore-plan-folder.md',
+  'injections/core/aif-plan-plan-folder.md',
+  'agent-files/codex/aifhub-review-sidecar.toml',
+  'agent-files/claude/aifhub-review-sidecar.md'
+];
+
 const ROADMAP_REFERENCE_ASSETS = [
   'injections/references/aif-roadmap/roadmap-template.md',
   'injections/references/aif-roadmap/slice-checklist.md'
@@ -239,6 +252,34 @@ function assertNoExecutableRootScriptGuidance(source, label) {
     /\bnode\s+scripts\/[A-Za-z0-9_.-]+\.mjs\b/,
     `${label} should not expose root scripts as installed-project executable helper commands`
   );
+}
+
+function assertGraphifyOptionalContextGuidance(source, label) {
+  for (const expected of [
+    'Graphify',
+    'graphify-out/GRAPH_REPORT.md',
+    'graphify-out/graph.json',
+    '.ai-factory/references/graphify/',
+    '.ai-factory/state/<change-id>/graphify/',
+    'openspec/changes/<change-id>/',
+    'openspec/specs/',
+    '.ai-factory/rules/generated/',
+    '.ai-factory/qa/<change-id>/',
+    'supporting',
+    'degraded',
+    'extracted, inferred, ambiguous, or confidence-labeled',
+    'direct repository evidence',
+    'API keys',
+    'tokens',
+    'raw authorization headers',
+    'private backend diagnostics'
+  ]) {
+    assertIncludes(source, expected, label);
+  }
+
+  assert.match(source, /do(?:es)? not .*install `?graphifyy`?|must not .*install `?graphifyy`?/i, `${label} should forbid automatic graphifyy install`);
+  assert.match(source, /do(?:es)? not .*run `?graphify`?|must not .*run `?graphify`?/i, `${label} should forbid automatic graphify execution`);
+  assert.match(source, /Graphify MCP automatically/i, `${label} should forbid automatic Graphify MCP registration`);
 }
 
 describe('OpenSpec-native prompt asset contract', () => {
@@ -418,6 +459,35 @@ describe('OpenSpec-native prompt asset contract', () => {
     for (const relativePath of await activePromptAssets()) {
       const asset = await readRepoFile(relativePath);
       assertNoExecutableRootScriptGuidance(asset, relativePath);
+    }
+  });
+
+  it('documents Graphify as optional supporting context, not an AIFHub dependency', async () => {
+    for (const relativePath of [...GRAPHIFY_CONTEXT_DOC_ASSETS, ...GRAPHIFY_CONTEXT_PROMPT_ASSETS]) {
+      const asset = await readRepoFile(relativePath);
+      assertGraphifyOptionalContextGuidance(asset, relativePath);
+    }
+
+    const readme = await readRepoFile('docs/README.md');
+    assertIncludes(readme, 'optional Graphify context', 'docs/README.md');
+    assertIncludes(readme, 'Context Loading Policy', 'docs/README.md');
+  });
+
+  it('documents manual Graphify CLI usage without making it command-owned', async () => {
+    const usage = await readRepoFile('docs/usage.md');
+
+    for (const expected of [
+      'python -m pip install graphifyy',
+      'graphify .',
+      'do not prefix it as `/graphify .`',
+      'graphify-out/graph.html',
+      'graphify query',
+      'graphify path',
+      'graphify explain',
+      'AIFHub Extension does not require Graphify',
+      'does not add Graphify to extension dependencies'
+    ]) {
+      assertIncludes(usage, expected, 'docs/usage.md');
     }
   });
 

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -111,6 +111,21 @@ Graphify is an optional context/research provider. During repository inspection,
 - `.ai-factory/references/graphify/GRAPH_REPORT.md`
 - `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
 
+At the beginning of this optional Graphify check, test whether `uv` is available:
+
+```powershell
+uv --version
+```
+
+Read `utilities.graphify.enabled` from `.ai-factory/config.yaml` when available. If it is missing or `false`, include a non-blocking analysis hint that Graphify is recommended for large or unfamiliar repositories and show the manual setup commands:
+
+```powershell
+uv tool install graphifyy
+graphify install
+```
+
+If `uv` is unavailable, report that Graphify setup should start by installing `uv` and rerunning `uv --version`. Also mention that the user may generate reports manually with `graphify .` and set `utilities.graphify.enabled: true` only after the project chooses to use Graphify. If `utilities.graphify.enabled: true`, report Graphify as enabled and still treat missing reports as degraded context rather than failure.
+
 Missing Graphify or missing reports are degraded context, not bootstrap failure. Do not install `graphifyy`, run `graphify`, add Graphify dependencies or manifest entries, or start/register Graphify MCP automatically.
 
 Treat Graphify findings as supporting context only. `GRAPH_REPORT.md` can contain extracted, inferred, ambiguous, or confidence-labeled relationships; use those claims as hypotheses for direct repository inspection. Bootstrap decisions, config content, rules/base.md content, and artifact status must still be grounded in manifests, source files, project docs, existing AIFHub artifacts, or other direct repository evidence.
@@ -143,7 +158,19 @@ Resolve the bootstrap/config mode before creating directories:
 - If config.yaml exists, preserve existing values and add missing fields.
 - Preserve existing `language.ui`, `language.artifacts`, and `language.technical_terms` values. If `language.technical_terms` is missing, default it to `keep`; accepted values are `keep | translate | mixed`.
 - If localization answers were collected while config was missing, write those pending config values into the selected legacy `ai-factory` or `openspec-native` config shape.
-- Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `rules`, `workflow`.
+- Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `utilities`, `rules`, `workflow`.
+- Ensure the shared optional utility config is present in both legacy `ai-factory` and `openspec-native` modes, preserving existing user values:
+
+```yaml
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
+```
+
 - In legacy `ai-factory` mode:
   - Ensure this selected-protocol profile is present:
 
@@ -303,6 +330,7 @@ openspec init --tools none
 - Report the resolved bootstrap mode.
 - Report the bootstrap mode selection source: existing config, explicit user request, first-bootstrap answer, or autonomous default.
 - Report whether config values were created or preserved.
+- Report the Graphify utility setting and `uv` availability. If `utilities.graphify.enabled` is missing or `false`, include the optional recommendation `Graphify is recommended for large or unfamiliar repositories; check uv with: uv --version; install manually with: uv tool install graphifyy; activate manually with: graphify install`.
 - If autonomous/subagent mode defaulted to legacy `ai-factory` because the artifact protocol question could not be asked, report OpenSpec-native mode selection as an open question/blocker.
 - Report the active path set.
 - In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.
@@ -335,6 +363,14 @@ workflow:
 rules:
   base: .ai-factory/rules/base.md
   # area rules added by planning when needed
+
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
 
 agent_profile: default
 ```

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -102,6 +102,23 @@ Do not rewrite or delete those folders automatically in this skill.
 - Prefer direct evidence from manifests, source layout, config files, and project docs.
 - Note the tech stack for rules/base.md generation.
 
+### Step 2.1: Optional Graphify Context
+
+Graphify is an optional context/research provider. During repository inspection, this skill may read existing Graphify outputs as supporting context:
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
+- `.ai-factory/references/graphify/GRAPH_REPORT.md`
+- `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
+
+Missing Graphify or missing reports are degraded context, not bootstrap failure. Do not install `graphifyy`, run `graphify`, add Graphify dependencies or manifest entries, or start/register Graphify MCP automatically.
+
+Treat Graphify findings as supporting context only. `GRAPH_REPORT.md` can contain extracted, inferred, ambiguous, or confidence-labeled relationships; use those claims as hypotheses for direct repository inspection. Bootstrap decisions, config content, rules/base.md content, and artifact status must still be grounded in manifests, source files, project docs, existing AIFHub artifacts, or other direct repository evidence.
+
+Do not copy Graphify output during bootstrap unless the user explicitly asks to preserve reviewed output. If preserving reviewed Graphify context, use `.ai-factory/references/graphify/` for project-wide references or `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime context. Never store Graphify generated files under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+
+Before reading or preserving Graphify output, treat privacy as explicit caveat: do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+
 ### Step 2.5: Resolve Bootstrap Mode
 
 Resolve the bootstrap/config mode before creating directories:

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -49,6 +49,20 @@ paths:
   rules: .ai-factory/rules
 
 # ============================================================================
+# OPTIONAL UTILITIES
+# ============================================================================
+# Optional, user-owned tools that can provide extra context.
+utilities:
+  graphify:
+    # Recommended for large or unfamiliar repositories.
+    # AIFHub never installs or runs Graphify automatically.
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
+
+# ============================================================================
 # WORKFLOW SETTINGS
 # ============================================================================
 workflow:

--- a/skills/aif-mode/references/MODES.md
+++ b/skills/aif-mode/references/MODES.md
@@ -39,6 +39,14 @@ paths:
   state: .ai-factory/state
   qa: .ai-factory/qa
   generated_rules: .ai-factory/rules/generated
+
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
 ```
 
 Canonical requirements and change intent live under `openspec/`. Runtime state, QA evidence, migration reports, and generated rules live under `.ai-factory/`.
@@ -68,6 +76,14 @@ paths:
   plans: .ai-factory/plans
   specs: .ai-factory/specs
   rules: .ai-factory/rules
+
+utilities:
+  graphify:
+    enabled: false
+    uv_check: uv --version
+    install: uv tool install graphifyy
+    activate: graphify install
+    report_command: graphify .
 ```
 
 Legacy mode uses the companion plan model:


### PR DESCRIPTION
## Summary
- Add an optional Graphify recommendation to `/aif-analyze`, including `uv` availability checks and manual setup guidance.
- Add shared `utilities.graphify` config fields so projects can record whether Graphify is enabled without making it an AIFHub dependency.
- Update mode-sync defaults, docs, and prompt-asset contracts to keep Graphify optional, manual, and evidence-only.

## Testing
- Added and updated unit tests for `aif-analyze` bootstrap contracts, mode sync config rendering, and prompt asset guidance.
- Ran the full validation suite and repository test suite locally; both passed.