### PR TITLE
docs: add optional Context7 provider guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,8 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 |---|---|
 | [Documentation Index](docs/README.md) | Reading order and docs map |
 | [Usage](docs/usage.md) | Full command flow, read/write boundaries, examples, and troubleshooting |
-| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
+| [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
+| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, optional provider context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
 | [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |

--- a/agent-files/claude/aifhub-review-sidecar.md
+++ b/agent-files/claude/aifhub-review-sidecar.md
@@ -27,6 +27,14 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Treat extracted, inferred, ambiguous, or confidence-labeled Graphify relationships as hypotheses; findings must be grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
 - Do not treat Graphify output as canonical evidence, generated rules input, QA evidence, or roadmap completion proof.
 - Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+- May read existing reviewed Context7 notes under `.ai-factory/references/context7/` and `.ai-factory/state/<change-id>/context7/` as optional supporting documentation context for version-sensitive API review.
+- Missing Context7, missing Node.js runtime support, missing provider access, or missing notes are degraded context, not a review failure.
+- Manual Context7 examples such as `npx ctx7 library <name> <query>`, `npx ctx7 docs <libraryId> <query>`, `ctx7 library <name> <query>`, and `ctx7 docs <libraryId> <query>` are user-owned and outside sidecar command ownership.
+- If the user already configured Context7 MCP, available tools may include `resolve-library-id` plus a docs retrieval tool named `get-library-docs` or `query-docs`; use them only as optional read-only documentation context.
+- Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies, add Context7 MCP templates to `extension.json`, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or start/register Context7 MCP automatically.
+- Treat Context7 output as supporting context only; findings must be source-grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, package files in the repository, or other direct repository evidence.
+- Do not store raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
 - Do not edit files.
 - Return findings first, including active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, and QA evidence path.
 

--- a/agent-files/codex/aifhub-review-sidecar.toml
+++ b/agent-files/codex/aifhub-review-sidecar.toml
@@ -23,6 +23,14 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Treat extracted, inferred, ambiguous, or confidence-labeled Graphify relationships as hypotheses; findings must be grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
 - Do not treat Graphify output as canonical evidence, generated rules input, QA evidence, or roadmap completion proof.
 - Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in .ai-factory/, openspec/, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+- May read existing reviewed Context7 notes under .ai-factory/references/context7/ and .ai-factory/state/<change-id>/context7/ as optional supporting documentation context for version-sensitive API review.
+- Missing Context7, missing Node.js runtime support, missing provider access, or missing notes are degraded context, not a review failure.
+- Manual Context7 examples such as npx ctx7 library <name> <query>, npx ctx7 docs <libraryId> <query>, ctx7 library <name> <query>, and ctx7 docs <libraryId> <query> are user-owned and outside sidecar command ownership.
+- If the user already configured Context7 MCP, available tools may include resolve-library-id plus a docs retrieval tool named get-library-docs or query-docs; use them only as optional read-only documentation context.
+- Do not install ctx7 or @upstash/context7-mcp, run ctx7, run ctx7 setup, add Context7 dependencies, add Context7 MCP templates to extension.json, mutate .mcp.json, .cursor/mcp.json, .opencode.json, agent rules, or agent skills, or start/register Context7 MCP automatically.
+- Treat Context7 output as supporting context only; findings must be source-grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, package files in the repository, or other direct repository evidence.
+- Do not store raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration under openspec/changes/<change-id>/, openspec/specs/, .ai-factory/rules/generated/, or .ai-factory/qa/<change-id>/.
+- Do not persist CONTEXT7_API_KEY, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in .ai-factory/, openspec/, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
 - Do not edit files.
 - Return findings first, including active OpenSpec change, canonical artifacts inspected, generated rules state, runtime state path, and QA evidence path.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,14 +16,15 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 
 1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
 2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
-3. [Context Loading Policy](context-loading-policy.md) for consumer context, optional Graphify context guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
-4. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags, and degraded mode.
-5. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
-6. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
-7. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
-8. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
-9. [Handoff Validation Profile](handoff-validation-profile.md) for the read-only orchestration summary contract.
-10. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+3. [Context Providers](context-providers.md) for optional Graphify context and Context7 documentation provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries.
+4. [Context Loading Policy](context-loading-policy.md) for consumer context, optional Graphify context guidance, optional Context7 documentation context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
+5. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags, and degraded mode.
+6. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
+7. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
+8. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
+9. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
+10. [Handoff Validation Profile](handoff-validation-profile.md) for the read-only orchestration summary contract.
+11. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
 
 The remaining runtime-specific guides are supporting references:
 
@@ -38,8 +39,9 @@ The remaining runtime-specific guides are supporting references:
 
 | Guide | Purpose |
 |---|---|
-| [Usage](usage.md) | Full OpenSpec-native command flow, optional Graphify context, gates, finalization tail, commit, and examples |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
+| [Usage](usage.md) | Full OpenSpec-native command flow, optional Graphify context, optional Context7 guidance, gates, finalization tail, commit, and examples |
+| [Context Providers](context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety, and user-owned setup boundaries |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify context, optional Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, validation policy flags, sync points, rules gate, version support, and degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator for canonical artifacts, runtime evidence, QA, and generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness, and integration points |
@@ -61,6 +63,7 @@ This docs set covers:
 - artifact mode switching and sync through `/aif-mode`
 - command reads, writes, and forbidden writes
 - optional Graphify context provider guidance
+- optional Context7 documentation provider guidance
 - optional rules, review, and security gates
 - verification, fix, done, post-archive sync, commit, and evolve handoff
 - OpenSpec requirement coverage evidence and policy
@@ -87,6 +90,7 @@ npm test
 
 - [Project README](../README.md)
 - [Usage](usage.md)
+- [Context Providers](context-providers.md)
 - [Context Loading Policy](context-loading-policy.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
 - [OpenSpec Artifact Validation](openspec-validation.md)

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -1,4 +1,4 @@
-[Previous Page](usage.md) | [Back to Documentation](README.md) | [Next Page](openspec-compatibility.md)
+[Previous Page](context-providers.md) | [Back to Documentation](README.md) | [Next Page](openspec-compatibility.md)
 
 # Context Loading Policy
 
@@ -75,6 +75,14 @@ Generated rules and generated trace metadata are derived guidance only. If gener
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
 
+## Optional Context Providers
+
+Optional providers are read-only supporting context. They are not command prerequisites, dependency requirements, generated rules input, QA evidence, verification gates, done gates, or canonical OpenSpec sources.
+
+Provider output can be copied into `.ai-factory/` only after user review and only as concise notes or reviewed summaries. Raw provider output, MCP transcripts, setup output, generated provider configuration, and unreviewed sensitive output must stay out of canonical OpenSpec, generated rules, runtime QA, and validation artifacts.
+
+See [Context Providers](context-providers.md) for the central provider guide.
+
 ## Optional Graphify Context
 
 Graphify is an optional context/research provider. AIFHub commands may use existing Graphify output as supporting context, but they must not make Graphify a required extension dependency, install `graphifyy`, run `graphify`, add Graphify manifest dependencies, start or register Graphify MCP automatically, or turn Graphify availability into a verification gate.
@@ -107,6 +115,30 @@ Forbidden storage for Graphify generated files such as `GRAPH_REPORT.md`, `graph
 - `.ai-factory/qa/<change-id>/`
 
 Before copying Graphify output into `.ai-factory/`, review it for sensitive information. AIFHub guidance must not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+
+## Optional Context7 Documentation Context
+
+Context7 is an optional documentation provider for current library/API docs. AIFHub commands and sidecars may use existing user-provided or reviewed Context7 notes as supporting context, but they must not make Context7 a required extension dependency, install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 manifest dependencies, add Context7 MCP templates to `extension.json`, start or register Context7 MCP automatically, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or turn Context7 availability into a verification gate.
+
+Manual CLI examples such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>` are outside AIFHub command ownership. If a user-installed `ctx7` CLI is already available, the equivalent `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>` commands are also user-owned. If Context7 is unavailable, unauthenticated, rate-limited, missing provider access, or blocked by local Node.js runtime constraints, commands continue normally and report Context7 context as unavailable or degraded rather than failing.
+
+If the user has already configured Context7 MCP, agents may use it as optional read-only documentation context. The common flow is `resolve-library-id` followed by a docs retrieval tool. The retrieval tool name may be `get-library-docs` or `query-docs` depending on the Context7 client/server version.
+
+Context7 output remains supporting evidence only. Library IDs such as `/org/project`, `/org/project/version`, `/org/project@version`, `/packages/<name>`, and `/websites/<name>` are provider output, not stable AIFHub schema. Final requirements, plans, review findings, completion status, roadmap status, generated rules, and QA verdicts must be source-grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules trace metadata, or other direct repository evidence.
+
+Allowed durable storage for reviewed Context7 notes:
+
+- `.ai-factory/references/context7/` for project-wide documentation notes.
+- `.ai-factory/state/<change-id>/context7/` for change-scoped runtime notes.
+
+Forbidden storage for raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration:
+
+- `openspec/changes/<change-id>/`
+- `openspec/specs/`
+- `.ai-factory/rules/generated/`
+- `.ai-factory/qa/<change-id>/`
+
+Before copying Context7 notes into `.ai-factory/`, review them for sensitive information. AIFHub guidance must not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
 
 ## Bug Fix Context
 

--- a/docs/context-providers.md
+++ b/docs/context-providers.md
@@ -1,0 +1,105 @@
+[Previous Page](usage.md) | [Back to Documentation](README.md) | [Next Page](context-loading-policy.md)
+
+# Context Providers
+
+AIFHub may use optional provider output as supporting context when a user has already produced or reviewed it. Providers help agents inspect a project or external documentation, but they do not become AIFHub dependencies, gates, canonical evidence, generated rules input, or runtime requirements.
+
+Provider availability is always degraded behavior: missing tools, missing reports, missing MCP servers, missing API credentials, or unsupported local runtimes must not fail `/aif-explore`, `/aif-plan`, `/aif-review`, `/aif-implement`, `/aif-verify`, `/aif-done`, or any other AIFHub command by themselves.
+
+## Provider Roles
+
+Graphify is the optional repository architecture and relation-discovery provider. It can help identify dependencies, ownership paths, and impact areas before direct repository inspection.
+
+Context7 is the optional documentation provider for current library/API docs. It can help reduce uncertainty around version-sensitive API behavior, framework migration details, and third-party usage patterns.
+
+Both providers are supporting only. Final plans, review findings, generated rules, verification status, done status, and roadmap completion must remain source-grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules trace metadata, or other direct repository evidence.
+
+## AIFHub Boundaries
+
+AIFHub Extension must not:
+
+- install provider CLIs or packages, including `ctx7` or `@upstash/context7-mcp`;
+- run provider setup commands;
+- start or register provider MCP servers automatically;
+- add provider package dependencies or manifest dependencies;
+- add Context7 MCP templates to `extension.json`;
+- mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, agent skills, or runtime MCP settings for a provider;
+- turn provider availability into validation, verification, review, rules, security, done, or commit gates.
+
+Future runtime features such as a `context_provider_suggestion` metadata field may recommend manual provider usage, but they must not change the user-owned setup boundary.
+
+## Context7
+
+Use Context7 only when current library/API documentation can materially reduce uncertainty. Common cases include framework version changes, package migration notes, deprecations, generated client APIs, or a review finding that depends on a third-party contract.
+
+Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies, add Context7 MCP templates to `extension.json`, or start/register Context7 MCP automatically from AIFHub commands or sidecars.
+
+Manual CLI usage is user-owned. Users may run Context7 with `npx`:
+
+```bash
+npx ctx7 library <name> <query>
+npx ctx7 docs <libraryId> <query>
+```
+
+If the user already installed the CLI, the equivalent commands may be:
+
+```bash
+ctx7 library <name> <query>
+ctx7 docs <libraryId> <query>
+```
+
+The Context7 CLI requires a suitable local Node.js runtime. If `npx ctx7` or `ctx7` is unavailable, too old, unauthenticated, or rate-limited, AIFHub guidance should continue with degraded documentation context.
+
+Context7 library IDs can vary by source and version. Common examples include:
+
+- `/org/project`
+- `/org/project/version`
+- `/org/project@version`
+- `/packages/<name>`
+- `/websites/<name>`
+
+Treat exact IDs as provider output, not stable AIFHub schema.
+
+Context7 MCP setup is also user-owned. If a user has already configured a Context7 MCP server, agents may use available MCP tools as optional read-only documentation context. The usual lookup flow is `resolve-library-id` followed by a docs retrieval tool. The docs retrieval tool name may be `get-library-docs` or `query-docs` depending on the Context7 client/server version, so prompt guidance must tolerate both names.
+
+Do not run `ctx7 setup`. That command may write files such as `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills. AIFHub guidance may mention this as user-owned setup, but AIFHub commands and sidecars must not execute it or mutate those files.
+
+Allowed durable storage for reviewed Context7 notes:
+
+- `.ai-factory/references/context7/` for project-wide documentation notes.
+- `.ai-factory/state/<change-id>/context7/` for change-scoped documentation notes.
+
+A reviewed Context7 note should be concise and include the library name, resolved library ID when known, package version or docs version when known, query, retrieval date, source URL if available, and the short conclusion relevant to the AIFHub task.
+
+Forbidden storage for raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration:
+
+- `openspec/changes/<change-id>/`
+- `openspec/specs/`
+- `.ai-factory/rules/generated/`
+- `.ai-factory/qa/<change-id>/`
+
+Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
+
+## Graphify
+
+Graphify remains the optional repository research provider. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
+
+Manual Graphify usage, outside AIFHub command ownership:
+
+```powershell
+uv --version
+uv tool install graphifyy
+graphify install
+graphify .
+```
+
+Use `graphify .` in PowerShell; do not prefix it as `/graphify .`.
+
+Allowed durable storage for reviewed Graphify context:
+
+- `.ai-factory/references/graphify/` for project-wide reference copies.
+- `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime copies.
+
+Do not store raw Graphify generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html` under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+
+See [Usage](usage.md) and [Context Loading Policy](context-loading-policy.md) for command-specific Graphify guidance.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-[Back to Documentation](README.md) | [Back to README](../README.md) | [Next Page](context-loading-policy.md)
+[Back to Documentation](README.md) | [Back to README](../README.md) | [Next Page](context-providers.md)
 
 # Usage
 
@@ -49,7 +49,13 @@ The `aifhub-extension` package repository stays artifact-light: root `openspec/`
 
 AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
 
-## Optional Graphify Context
+## Optional Context Providers
+
+Context providers are manual, user-owned research aids. AIFHub may read reviewed provider notes as optional supporting context, but provider availability is degraded behavior and never a validation, verification, review, rules, security, done, or commit gate.
+
+See [Context Providers](context-providers.md) for the central policy.
+
+### Graphify
 
 Graphify can be used as a manual, user-owned repository research aid before or during AIFHub work. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
 
@@ -96,6 +102,45 @@ Do not store Graphify generated files under `openspec/changes/<change-id>/`, `op
 Treat Graphify findings as supporting evidence only. Reports can include extracted, inferred, ambiguous, or confidence-labeled relationships, so final plans, review findings, verification status, generated rules, and roadmap completion still need direct repository evidence from canonical OpenSpec artifacts, source files, tests, runtime state, or QA evidence.
 
 Before copying a report into `.ai-factory/`, review it for sensitive information. Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in AIFHub artifacts.
+
+### Context7
+
+Context7 can be used as a manual, user-owned documentation research aid for current library/API docs. AIFHub Extension does not require Context7, does not install `ctx7` or `@upstash/context7-mcp`, does not run `ctx7`, does not run `ctx7 setup`, does not add Context7 to extension dependencies, does not add Context7 MCP templates to `extension.json`, and does not start or register Context7 MCP automatically.
+
+Use Context7 when version-sensitive API documentation can materially reduce uncertainty during `/aif-explore`, `/aif-plan full`, or `/aif-review`. Examples include framework migrations, deprecations, third-party client behavior, package-specific configuration, or review findings that depend on current upstream docs.
+
+Manual CLI usage, outside AIFHub command ownership:
+
+```bash
+npx ctx7 library <name> <query>
+npx ctx7 docs <libraryId> <query>
+```
+
+If the user already installed Context7, equivalent local commands may be:
+
+```bash
+ctx7 library <name> <query>
+ctx7 docs <libraryId> <query>
+```
+
+Context7 CLI usage requires a suitable local Node.js runtime. If `npx ctx7` or a user-installed `ctx7` is unavailable, too old, unauthenticated, rate-limited, or missing provider access, continue with degraded documentation context and use repository evidence plus local package docs instead.
+
+Context7 library IDs are provider output and may include forms such as `/org/project`, `/org/project/version`, `/org/project@version`, `/packages/<name>`, or `/websites/<name>`. Treat exact IDs as unstable external references rather than AIFHub schema.
+
+If the user has already configured Context7 MCP, agents may use it as optional read-only documentation context. The usual MCP flow is `resolve-library-id` followed by a docs retrieval tool; depending on client/server version, that docs retrieval tool may be named `get-library-docs` or `query-docs`.
+
+Do not run `ctx7 setup` from AIFHub commands or sidecars. It can mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills. AIFHub guidance may mention it only as user-owned setup.
+
+To keep reviewed Context7 notes for later context loading, write concise summaries only to:
+
+- `.ai-factory/references/context7/` for project-wide documentation context.
+- `.ai-factory/state/<change-id>/context7/` for change-scoped runtime context.
+
+Do not store raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+
+Treat Context7 output as supporting evidence only. Plans, review findings, verification status, generated rules, and completion decisions must remain source-grounded in direct repository evidence from canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules, or package files in the repository.
+
+Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in AIFHub artifacts.
 
 ## Bug Fix Workflows
 
@@ -444,12 +489,15 @@ Reads:
 
 - changed files
 - OpenSpec context and generated rules when available
+- optional reviewed Context7 notes under `.ai-factory/references/context7/` or `.ai-factory/state/<change-id>/context7/` for version-sensitive API review
 
 Writes:
 
 - none
 
 `/aif-review` is an optional read-only code review gate. It returns a final `aif-gate-result` with `gate: "review"`, is useful before `/aif-verify` or for high-risk changes, and does not write OpenSpec, runtime, or QA artifacts.
+
+Review findings may use Context7 as supporting documentation context only. Findings still need changed-file evidence, canonical OpenSpec context, generated rules, runtime state, QA evidence, or other direct repository evidence; missing Context7 is degraded context, not a review failure.
 
 ### `/aif-security-checklist`
 

--- a/extension.json
+++ b/extension.json
@@ -156,6 +156,11 @@
       "file": "./injections/core/aif-explore-plan-folder.md"
     },
     {
+      "target": "aif-review",
+      "position": "prepend",
+      "file": "./injections/core/aif-review-context-providers.md"
+    },
+    {
       "target": "aif-roadmap",
       "position": "prepend",
       "file": "./injections/core/aif-roadmap-maturity-audit.md"

--- a/injections/core/aif-explore-plan-folder.md
+++ b/injections/core/aif-explore-plan-folder.md
@@ -32,6 +32,7 @@ Allowed read context:
 - `openspec/changes/<change-id>/**`
 - `.ai-factory/state/<change-id>/`
 - optional reviewed Graphify outputs such as `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `.ai-factory/references/graphify/GRAPH_REPORT.md`, and `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
+- optional reviewed Context7 notes under `.ai-factory/references/context7/` and `.ai-factory/state/<change-id>/context7/`
 
 Optional Graphify context:
 
@@ -43,6 +44,18 @@ Optional Graphify context:
 - Project-wide reviewed Graphify copies belong under `.ai-factory/references/graphify/`; change-scoped reviewed copies belong under `.ai-factory/state/<change-id>/graphify/`.
 - Do not store Graphify generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html` under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
 - Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+
+Optional Context7 context:
+
+- Context7 is optional supporting documentation context for current library/API docs.
+- `/aif-explore` may recommend that the user run Context7 manually outside AIFHub command ownership with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
+- Missing Context7, missing Node.js runtime support, missing provider access, or missing reviewed notes is degraded context, not an exploration failure.
+- If the user already configured Context7 MCP, available tools may include `resolve-library-id` plus a docs retrieval tool named `get-library-docs` or `query-docs`; use them only as optional read-only documentation context.
+- Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies or manifest entries, add Context7 MCP templates to `extension.json`, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or start/register Context7 MCP automatically.
+- Treat Context7 output as supporting context only; research conclusions must remain source-grounded in source files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
+- Reviewed project-wide Context7 notes belong under `.ai-factory/references/context7/`; reviewed change-scoped Context7 notes belong under `.ai-factory/state/<change-id>/context7/`.
+- Do not store raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
 
 Canonical OpenSpec change files under an active change are only:
 

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -44,6 +44,20 @@ Graphify is optional supporting context for integration discovery before creatin
 - Do not import raw Graphify output or generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html` into `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
 - Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
 
+#### Optional Context7 documentation context
+
+Context7 is optional supporting documentation context for current library/API docs before creating or refining a canonical OpenSpec change.
+
+- `/aif-plan full` may recommend that the user run Context7 manually outside AIFHub command ownership with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
+- `/aif-plan full` may read reviewed Context7 notes under `.ai-factory/references/context7/` and `.ai-factory/state/<change-id>/context7/`.
+- Missing Context7, missing Node.js runtime support, missing provider access, or missing reviewed notes is degraded context, not planning failure.
+- If the user already configured Context7 MCP, available tools may include `resolve-library-id` plus a docs retrieval tool named `get-library-docs` or `query-docs`; use them only as optional read-only documentation context.
+- Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies or manifest entries, add Context7 MCP templates to `extension.json`, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or start/register Context7 MCP automatically.
+- Treat Context7 output as supporting context only; final `proposal.md`, `design.md`, `tasks.md`, and delta specs must remain source-grounded in direct repository evidence and canonical OpenSpec/source context.
+- Reviewed project-wide Context7 notes belong under `.ai-factory/references/context7/`; reviewed change-scoped Context7 notes belong under `.ai-factory/state/<change-id>/context7/`.
+- Do not import raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration into `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
+
 #### Change ID policy
 
 - Derive a safe `<change-id>` slug from the request for new plans.

--- a/injections/core/aif-review-context-providers.md
+++ b/injections/core/aif-review-context-providers.md
@@ -1,0 +1,64 @@
+## AIFHub Review Context Provider Override
+
+Apply this block before the upstream `aif-review` body. When any rule below conflicts with the base skill text, this block wins.
+
+Follow `skills/shared/LANGUAGE-POLICY.md` before producing user-facing responses or generated artifacts.
+
+### Goal
+
+Keep `/aif-review` read-only while allowing optional, user-owned provider context for version-sensitive library/API review.
+
+### Mode Detection
+
+Before resolving review scope, read `.ai-factory/config.yaml` when it exists.
+
+- If the config contains `aifhub.artifactProtocol: openspec`, use **OpenSpec-native mode**.
+- Otherwise, use **Legacy AI Factory-only mode**.
+- If the config is missing, continue with Legacy AI Factory-only mode and state that no OpenSpec-native protocol was detected.
+
+### OpenSpec-native mode
+
+When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-review` is an optional read-only gate for one active OpenSpec change.
+
+Read context may include:
+
+- changed files;
+- canonical OpenSpec artifacts under `openspec/specs/**` and `openspec/changes/<change-id>/`;
+- generated rules under `.ai-factory/rules/generated/` when present;
+- runtime state under `.ai-factory/state/<change-id>/` when relevant;
+- QA evidence under `.ai-factory/qa/<change-id>/` when relevant;
+- reviewed Context7 notes under `.ai-factory/references/context7/` and `.ai-factory/state/<change-id>/context7/`;
+- reviewed Graphify outputs under `.ai-factory/references/graphify/` and `.ai-factory/state/<change-id>/graphify/` when dependency or impact review benefits from them.
+
+Context7 guidance:
+
+- Context7 is optional supporting documentation context for current library/API docs.
+- `/aif-review` may recommend that the user run Context7 manually outside AIFHub command ownership with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
+- Missing Context7, missing Node.js runtime support, missing provider access, or missing reviewed notes is degraded context, not a review failure.
+- If the user already configured Context7 MCP, available tools may include `resolve-library-id` plus a docs retrieval tool named `get-library-docs` or `query-docs`; use them only as optional read-only documentation context.
+- Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies or manifest entries, add Context7 MCP templates to `extension.json`, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or start/register Context7 MCP automatically.
+- Treat Context7 output as supporting context only. Findings must be source-grounded in changed files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, package files in the repository, or other direct repository evidence.
+- Do not store raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
+
+Write boundaries:
+
+- Do not edit files.
+- Do not write OpenSpec artifacts, runtime state, QA evidence, generated rules, provider notes, MCP config, provider config, or provider setup files.
+- Return the review result in the response only unless the user explicitly pipes or saves it with another command.
+
+### Legacy AI Factory-only mode
+
+When OpenSpec-native mode is not enabled, preserve upstream review behavior and keep the command read-only.
+
+- Review only the changed scope and legacy plan context that already exists.
+- Context7 remains optional supporting documentation context; missing Context7 is degraded context, not a review failure.
+- The same user-owned Context7 boundaries apply: no install, no `ctx7`, no `ctx7 setup`, no MCP mutation, no automatic MCP registration, no provider templates, and no file edits.
+- Findings must still be grounded in changed files, existing project artifacts, tests, or other direct repository evidence.
+
+### Output
+
+- Start with findings ordered by severity.
+- Include provider context in evidence only when it materially influenced a finding.
+- If Context7 or Graphify was unavailable or not used, mention it only when relevant to residual risk.
+- End with the upstream `aif-gate-result` contract for `/aif-review`.

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -87,6 +87,20 @@ const GRAPHIFY_CONTEXT_PROMPT_ASSETS = [
   'agent-files/claude/aifhub-review-sidecar.md'
 ];
 
+const CONTEXT7_CONTEXT_DOC_ASSETS = [
+  'docs/context-providers.md',
+  'docs/context-loading-policy.md',
+  'docs/usage.md'
+];
+
+const CONTEXT7_CONTEXT_PROMPT_ASSETS = [
+  'injections/core/aif-explore-plan-folder.md',
+  'injections/core/aif-plan-plan-folder.md',
+  'injections/core/aif-review-context-providers.md',
+  'agent-files/codex/aifhub-review-sidecar.toml',
+  'agent-files/claude/aifhub-review-sidecar.md'
+];
+
 const ROADMAP_REFERENCE_ASSETS = [
   'injections/references/aif-roadmap/roadmap-template.md',
   'injections/references/aif-roadmap/slice-checklist.md'
@@ -282,6 +296,43 @@ function assertGraphifyOptionalContextGuidance(source, label) {
   assert.match(source, /Graphify MCP automatically/i, `${label} should forbid automatic Graphify MCP registration`);
 }
 
+function assertContext7OptionalDocumentationGuidance(source, label) {
+  for (const expected of [
+    'Context7',
+    'npx ctx7',
+    'ctx7 library <name> <query>',
+    'ctx7 docs <libraryId> <query>',
+    'resolve-library-id',
+    'get-library-docs',
+    'query-docs',
+    '.ai-factory/references/context7/',
+    '.ai-factory/state/<change-id>/context7/',
+    'openspec/changes/<change-id>/',
+    'openspec/specs/',
+    '.ai-factory/rules/generated/',
+    '.ai-factory/qa/<change-id>/',
+    'supporting',
+    'degraded',
+    'direct repository evidence',
+    'source-grounded',
+    'CONTEXT7_API_KEY',
+    'API keys',
+    'tokens',
+    'raw authorization headers',
+    'private provider diagnostics',
+    'private backend diagnostics',
+    '.mcp.json',
+    '.cursor/mcp.json',
+    '.opencode.json'
+  ]) {
+    assertIncludes(source, expected, label);
+  }
+
+  assert.match(source, /do(?:es)? not .*install `?ctx7`?|must not .*install `?ctx7`?/i, `${label} should forbid automatic Context7 CLI install`);
+  assert.match(source, /do(?:es)? not .*run `?ctx7 setup`?|must not .*run `?ctx7 setup`?/i, `${label} should forbid automatic Context7 setup`);
+  assert.match(source, /Context7 MCP automatically|automatic(?:ally)? .*Context7 MCP/i, `${label} should forbid automatic Context7 MCP registration`);
+}
+
 describe('OpenSpec-native prompt asset contract', () => {
   it('discovers active prompt assets from extension.json only', async () => {
     const assets = await activePromptAssets();
@@ -295,6 +346,7 @@ describe('OpenSpec-native prompt asset contract', () => {
       COMMIT_PROMPT_ASSET,
       ...ROADMAP_REFERENCE_ASSETS,
       'injections/core/aif-implement-plan-folder.md',
+      'injections/core/aif-review-context-providers.md',
       'agent-files/codex/aifhub-verifier.toml',
       'agent-files/claude/aifhub-verifier.md'
     ]) {
@@ -496,6 +548,26 @@ describe('OpenSpec-native prompt asset contract', () => {
     ]) {
       assertIncludes(usage, expected, 'docs/usage.md');
     }
+  });
+
+  it('documents Context7 as optional documentation context, not an AIFHub dependency', async () => {
+    for (const relativePath of [...CONTEXT7_CONTEXT_DOC_ASSETS, ...CONTEXT7_CONTEXT_PROMPT_ASSETS]) {
+      const asset = await readRepoFile(relativePath);
+      assertContext7OptionalDocumentationGuidance(asset, relativePath);
+    }
+
+    const manifest = await loadManifest();
+    const reviewInjection = manifest.injections.find((entry) => entry.target === 'aif-review');
+    assert.ok(reviewInjection, 'extension.json should include an aif-review injection');
+    assert.equal(reviewInjection.position, 'prepend');
+    assert.equal(normalizeManifestPath(reviewInjection.file), 'injections/core/aif-review-context-providers.md');
+
+    const readme = await readRepoFile('docs/README.md');
+    assertIncludes(readme, 'Context Providers', 'docs/README.md');
+    assertIncludes(readme, 'optional Context7 documentation provider guidance', 'docs/README.md');
+
+    const rootReadme = await readRepoFile('README.md');
+    assertIncludes(rootReadme, 'docs/context-providers.md', 'README.md');
   });
 
   it('requires verifier prompts to use fail-fast OpenSpec verification context', async () => {


### PR DESCRIPTION
## Summary

- Add `docs/context-providers.md` with optional Context7 and Graphify provider boundaries.
- Document manual Context7 CLI/MCP usage, degraded behavior, credential safety, and reviewed-note storage paths.
- Add `/aif-review` Context7 provider injection and update explore/plan/review sidecar guidance.
- Add prompt/docs contract coverage for Context7 optional behavior and no automatic install/setup/MCP registration.

## Validation

- `openspec validate add-optional-context7-docs-provider-guidance --type change --strict --no-color`
- `npm run validate`
- `npm test`
- `git diff --check`

Closes #84