### PR TITLE
Recommend optional memory tools from local metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Documentation Index](docs/README.md) | Reading order and docs map |
 | [Usage](docs/usage.md) | Full command flow, read/write boundaries, examples, and troubleshooting |
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
+| [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, optional provider context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
 | [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |

--- a/commands/aifhub-memory-tools.mjs
+++ b/commands/aifhub-memory-tools.mjs
@@ -1,0 +1,16 @@
+// aifhub-memory-tools.mjs - installed-project wrapper for optional memory/context tool recommendations
+import { normalizeWrapperArgs, runInstalledScript } from './run-installed-script.mjs';
+
+const DESCRIPTION = 'Run AIFHub optional memory and context tool recommendation diagnostics.';
+
+export function register(program) {
+  program
+    .command('aifhub-memory-tools')
+    .description(DESCRIPTION)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument('[args...]')
+    .action(async (args, command) => {
+      await runInstalledScript('../scripts/memory-tool-recommender.mjs', normalizeWrapperArgs(args, command), import.meta.url);
+    });
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,14 +17,15 @@ OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-
 1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
 2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
 3. [Context Providers](context-providers.md) for optional Graphify context and Context7 documentation provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries.
-4. [Context Loading Policy](context-loading-policy.md) for consumer context, optional Graphify context guidance, optional Context7 documentation context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
-5. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags, and degraded mode.
-6. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
-7. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
-8. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
-9. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
-10. [Handoff Validation Profile](handoff-validation-profile.md) for the read-only orchestration summary contract.
-11. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+4. [Memory Tool Recommendations](memory-tool-recommendations.md) for local metadata-driven optional tool recommendations and installed wrapper commands.
+5. [Context Loading Policy](context-loading-policy.md) for consumer context, optional Graphify context guidance, optional Context7 documentation context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
+6. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags, and degraded mode.
+7. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
+8. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
+9. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
+10. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
+11. [Handoff Validation Profile](handoff-validation-profile.md) for the read-only orchestration summary contract.
+12. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
 
 The remaining runtime-specific guides are supporting references:
 
@@ -42,6 +43,7 @@ The remaining runtime-specific guides are supporting references:
 |---|---|
 | [Usage](usage.md) | Full OpenSpec-native command flow, optional Graphify context, optional Context7 guidance, gates, finalization tail, commit, and examples |
 | [Context Providers](context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety, and user-owned setup boundaries |
+| [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify context, optional Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, validation policy flags, sync points, rules gate, version support, and degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator for canonical artifacts, runtime evidence, QA, and generated rules |
@@ -94,6 +96,7 @@ npm test
 - [Project README](../README.md)
 - [Usage](usage.md)
 - [Context Providers](context-providers.md)
+- [Memory Tool Recommendations](memory-tool-recommendations.md)
 - [Context Loading Policy](context-loading-policy.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
 - [OpenSpec Artifact Validation](openspec-validation.md)

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -1,4 +1,4 @@
-[Previous Page](context-providers.md) | [Back to Documentation](README.md) | [Next Page](openspec-compatibility.md)
+[Previous Page](memory-tool-recommendations.md) | [Back to Documentation](README.md) | [Next Page](openspec-compatibility.md)
 
 # Context Loading Policy
 
@@ -81,13 +81,13 @@ Optional providers are read-only supporting context. They are not command prereq
 
 Provider output can be copied into `.ai-factory/` only after user review and only as concise notes or reviewed summaries. Raw provider output, MCP transcripts, setup output, generated provider configuration, and unreviewed sensitive output must stay out of canonical OpenSpec, generated rules, runtime QA, and validation artifacts.
 
-See [Context Providers](context-providers.md) for the central provider guide.
+See [Context Providers](context-providers.md) for the central provider guide and [Memory Tool Recommendations](memory-tool-recommendations.md) for local metadata-driven recommendation diagnostics.
 
 ## Optional Graphify Context
 
 Graphify is an optional context/research provider. AIFHub commands may use existing Graphify output as supporting context, but they must not make Graphify a required extension dependency, install `graphifyy`, run `graphify`, add Graphify manifest dependencies, start or register Graphify MCP automatically, or turn Graphify availability into a verification gate.
 
-Project preference is recorded in `.ai-factory/config.yaml` as `utilities.graphify.enabled`. At the beginning of the optional Graphify check, `/aif-analyze` should test `uv` availability with `uv --version`. If Graphify is missing, or if `utilities.graphify.enabled` is missing or `false`, `/aif-analyze` should report Graphify as optional and recommended for large or unfamiliar repositories, including the manual setup commands `uv tool install graphifyy` and `graphify install`. This recommendation is advisory only and must not trigger installation, execution, dependency changes, or MCP registration.
+Project preference is recorded in `.ai-factory/config.yaml` as `utilities.graphify.enabled` only for backward compatibility. New `/aif-analyze` recommendations should come from local installed recommendation metadata through `ai-factory aifhub-memory-tools recommend --from-project --json`. If Graphify is recommended, the recommendation is advisory only and must not trigger installation, execution, dependency changes, indexing, or MCP registration.
 
 Allowed Graphify inputs are existing local or copied outputs:
 
@@ -274,6 +274,7 @@ If `.ai-factory/config.yaml` is missing or incomplete:
 ## See Also
 
 - [Usage](usage.md)
+- [Memory Tool Recommendations](memory-tool-recommendations.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)

--- a/docs/context-providers.md
+++ b/docs/context-providers.md
@@ -1,4 +1,4 @@
-[Previous Page](usage.md) | [Back to Documentation](README.md) | [Next Page](context-loading-policy.md)
+[Previous Page](usage.md) | [Back to Documentation](README.md) | [Next Page](memory-tool-recommendations.md)
 
 # Context Providers
 
@@ -27,6 +27,16 @@ AIFHub Extension must not:
 - turn provider availability into validation, verification, review, rules, security, done, or commit gates.
 
 Future runtime features such as a `context_provider_suggestion` metadata field may recommend manual provider usage, but they must not change the user-owned setup boundary.
+
+For installed-project diagnostics and metadata-driven recommendations, use:
+
+```bash
+ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools status --json
+ai-factory aifhub-memory-tools metadata --json
+```
+
+The recommender reads only local installed metadata and must not fetch GitHub or the internet.
 
 ## Context7
 

--- a/docs/memory-tool-recommendations.md
+++ b/docs/memory-tool-recommendations.md
@@ -1,0 +1,87 @@
+[Previous Page](context-providers.md) | [Back to Documentation](README.md) | [Next Page](context-loading-policy.md)
+
+# Memory Tool Recommendations
+
+AIFHub uses local recommendation metadata to suggest optional memory and context tools during analysis. The metadata lives in the installed extension, not on GitHub:
+
+```text
+.ai-factory/extensions/aifhub-extension/docs/memory-tools-research/recommendation-metadata.yaml
+```
+
+When developing this extension itself, the source-tree copy under `docs/memory-tools-research/recommendation-metadata.yaml` may be used.
+
+## Commands
+
+Installed projects should use the wrapper command:
+
+```bash
+ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools recommend --shape large_framework_app --task architecture_or_impact_discovery --json
+ai-factory aifhub-memory-tools status --json
+ai-factory aifhub-memory-tools metadata --json
+```
+
+The wrapper resolves scripts from the installed extension and keeps the user project as the working directory.
+
+## Rules
+
+The recommender is advisory only:
+
+- `rg` remains the baseline for exact file and symbol lookup.
+- Tools are explicit opt-in only.
+- Missing tools are degraded context, not command failure.
+- Provider output is supporting context only, never canonical OpenSpec evidence.
+- AIFHub must not auto-install tools, run setup, index source, sync memory, register MCP servers, install hooks, start daemons, or write provider output.
+
+## Tool Decisions
+
+Allowed recommendations:
+
+- `rg`: baseline search.
+- Graphify: optional repo graph for large framework, legacy, and multirepo impact discovery after baseline `rg`.
+- `codex-agent-mem`: optional read-only continuity memory with an explicit SQLite DB path.
+- `context-mode`: manual temporary index for explicit generated output or large command output.
+- Context7: optional docs provider for version-sensitive library/API questions.
+- `agent-memory`: manual notes only when the user explicitly asks for durable notes.
+
+Not recommended by default:
+
+- `codex-mem`: default scope may ingest broad Codex history.
+- `eagle-mem`: scoped read and purge behavior is not proven.
+
+## Safe Status Probes
+
+`ai-factory aifhub-memory-tools status --json` may run only local, non-mutating probes:
+
+- `rg --version`
+- `uv --version`
+- `graphify --version` or `graphify --help`
+- `codex-agent-mem-policy --help` or `codex-agent-mem-smoke --help`
+- `context-mode doctor`
+- `ctx7 --version` or `npx --no-install ctx7 --help` only when `--check-docs-provider` is passed
+
+These probes must not install packages, create indexes, run setup, register MCP servers, write hooks, or start background processes.
+
+## Analyze Output
+
+`/aif-analyze` should summarize recommendations like this:
+
+```text
+Optional local tools:
+
+Baseline:
+- rg: use for exact file/symbol lookup.
+
+Recommended:
+- Graphify: useful for broad architecture/impact discovery in this large framework project.
+  Status: installed/not installed/unknown
+  Read scope: explicit project path
+  Purge: delete graphify-out/
+  Note: supporting context only, not OpenSpec evidence.
+
+Not recommended:
+- codex-mem: broad Codex history scope can cross project boundaries.
+- eagle-mem: scoped read and purge not proven.
+```
+
+If metadata is unavailable, `/aif-analyze` should report a degraded note and continue with `rg` as the baseline.

--- a/docs/memory-tools-research/recommendation-metadata.yaml
+++ b/docs/memory-tools-research/recommendation-metadata.yaml
@@ -72,6 +72,9 @@ task_signals:
   large_command_output_compression:
     recommend:
       - context-mode
+  version_sensitive_library_docs:
+    recommend:
+      - context7
   manual_durable_notes:
     conditional:
       - agent-memory
@@ -166,6 +169,29 @@ tools:
       project_shapes:
         - small_microservice
     suggestion_text: "Если анализ генерирует очень большой output, можно предложить context-mode как manual temporary index с обязательным purge."
+  context7:
+    display_name: Context7
+    doc: ../context-providers.md
+    repository: "https://github.com/upstash/context7"
+    tested_version: "docs-provider guidance only"
+    decision: optional
+    recommendation_action: suggest_for_version_sensitive_docs
+    integration_role: optional_docs_provider
+    install_policy: explicit_user_opt_in_only
+    stable_cli: partial
+    mcp_status: user_configured_optional
+    read_scope: explicit_library_or_docs_query
+    purge_path: "delete reviewed notes under .ai-factory/references/context7/ or .ai-factory/state/<change-id>/context7/"
+    recommended_for:
+      tasks:
+        - version_sensitive_library_docs
+        - framework_migration_or_deprecation_check
+    do_not_recommend_for:
+      tasks:
+        - canonical_openspec_evidence
+        - validation_gate
+        - automatic_mcp_registration
+    suggestion_text: "Если вопрос зависит от актуальных library/API docs, можно предложить Context7 как optional docs provider; setup и MCP registration остаются user-owned."
   codex-mem:
     display_name: codex-mem
     doc: codex-mem.md

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,13 +53,21 @@ AIFHub commands request OpenSpec validation, status, instructions, and archive t
 
 Context providers are manual, user-owned research aids. AIFHub may read reviewed provider notes as optional supporting context, but provider availability is degraded behavior and never a validation, verification, review, rules, security, done, or commit gate.
 
-See [Context Providers](context-providers.md) for the central policy.
+See [Context Providers](context-providers.md) for the central policy and [Memory Tool Recommendations](memory-tool-recommendations.md) for local metadata-driven recommendation diagnostics.
+
+Installed projects can inspect optional recommendations with:
+
+```bash
+ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools status --json
+ai-factory aifhub-memory-tools metadata --json
+```
 
 ### Graphify
 
 Graphify can be used as a manual, user-owned repository research aid before or during AIFHub work. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
 
-`/aif-analyze` records the project preference under shared utility config. At the start of the optional Graphify check it should verify whether `uv` is available with `uv --version`. When Graphify is not enabled, analysis should show a non-blocking recommendation with the manual setup commands:
+`/aif-analyze` keeps the Graphify shared utility config only as a backward-compatible preference. New optional tool recommendations come from local `recommendation-metadata.yaml` through the installed wrapper command, not from a provider config abstraction. The compatibility config shape remains:
 
 ```yaml
 utilities:
@@ -71,7 +79,7 @@ utilities:
     report_command: graphify .
 ```
 
-Set `utilities.graphify.enabled: true` only after the project chooses to use manually generated Graphify reports.
+Set `utilities.graphify.enabled: true` only after the project chooses to use manually generated Graphify reports. The setting does not install Graphify and does not replace metadata-driven recommendations.
 
 Manual usage, outside AIFHub command ownership:
 
@@ -290,7 +298,7 @@ If localization questions run first, `/aif-analyze` carries those answers forwar
 
 The selected artifact protocol owns its config profile. Legacy `artifactProtocol: ai-factory` configs do not include `aifhub.openspec` settings or OpenSpec runtime path defaults; OpenSpec-native `artifactProtocol: openspec` configs include those settings and paths explicitly.
 
-Shared protocol-neutral settings such as `utilities.graphify.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency.
+Shared protocol-neutral settings such as `utilities.graphify.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency. Optional memory/context tool recommendations are resolved from local installed metadata with `ai-factory aifhub-memory-tools recommend --from-project --json`; missing metadata is degraded context and leaves `rg` as the baseline.
 
 ### `/aif-plan full`
 
@@ -860,6 +868,7 @@ npm test
 ## See Also
 
 - [Documentation Index](README.md)
+- [Memory Tool Recommendations](memory-tool-recommendations.md)
 - [Context Loading Policy](context-loading-policy.md)
 - [OpenSpec Compatibility](openspec-compatibility.md)
 - [OpenSpec Coverage Matrix](spec-coverage.md)

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json",
   "name": "aifhub-extension",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Upstream-first extension for AI Factory 2.11+: bootstrap remains extension-owned; `aif-plan`, `aif-implement`, `aif-verify`, and `aif-fix` connect through injections; upstream `aif-rules-check` is augmented by the AIFHub OpenSpec generated-rules injection; `aif-done` and `aif-mode` remain extension-owned finalizers/orchestrators; Codex and Claude runtime files publish through top-level `agentFiles`.",
   "commands": [
     {
@@ -43,6 +43,11 @@
       "name": "aifhub-handoff-gate-summary",
       "description": "Run AIFHub Handoff gate summary diagnostics.",
       "module": "./commands/aifhub-handoff-gate-summary.mjs"
+    },
+    {
+      "name": "aifhub-memory-tools",
+      "description": "Run AIFHub optional memory and context tool recommendation diagnostics.",
+      "module": "./commands/aifhub-memory-tools.mjs"
     }
   ],
   "skills": [

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -137,14 +137,27 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
     }
   });
 
-  it('documents optional Graphify utility config and analyze recommendation', async () => {
+  it('documents metadata-driven optional tool recommendations and Graphify compatibility config', async () => {
     const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
     const template = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
     const combined = [skill, template].join('\n');
 
     for (const expected of [
+      '### Step 2.1: Optional Context/Memory Tool Recommendations',
+      'recommendation-metadata.yaml',
+      'ai-factory aifhub-memory-tools recommend --from-project --json',
+      'ai-factory aifhub-memory-tools status --json',
+      'ai-factory aifhub-memory-tools metadata --json',
+      'exact_file_or_symbol_lookup',
+      'architecture_or_impact_discovery',
+      'resume_previous_work',
+      'large_command_output_compression',
+      'version_sensitive_library_docs',
+      'codex-mem',
+      'eagle-mem',
+      'Provider output is supporting context only, never canonical OpenSpec evidence.',
       'utilities.graphify.enabled',
-      'Graphify is recommended for large or unfamiliar repositories',
+      'backward-compatible preference',
       'uv --version',
       'uv tool install graphifyy',
       'graphify install',

--- a/scripts/aifhub-command-wrappers-contract.test.mjs
+++ b/scripts/aifhub-command-wrappers-contract.test.mjs
@@ -59,6 +59,13 @@ const WRAPPER_COMMANDS = [
     module: './commands/aifhub-handoff-gate-summary.mjs',
     script: 'handoff-gate-summary.mjs',
     args: ['--change', 'add-oauth', '--stage', 'review', '--json']
+  },
+  {
+    name: 'aifhub-memory-tools',
+    description: 'Run AIFHub optional memory and context tool recommendation diagnostics.',
+    module: './commands/aifhub-memory-tools.mjs',
+    script: 'memory-tool-recommender.mjs',
+    args: ['recommend', '--shape', 'large_framework_app', '--task', 'architecture_or_impact_discovery', '--json']
   }
 ];
 
@@ -290,6 +297,11 @@ describe('AIFHub wrapper guidance contract', () => {
       ]],
       ['docs/handoff-validation-profile.md', [
         'ai-factory aifhub-handoff-gate-summary --change <change-id> --stage review --json'
+      ]],
+      ['docs/memory-tool-recommendations.md', [
+        'ai-factory aifhub-memory-tools recommend --from-project --json',
+        'ai-factory aifhub-memory-tools status --json',
+        'ai-factory aifhub-memory-tools metadata --json'
       ]],
       ['docs/legacy-plan-migration.md', [
         'ai-factory aifhub-migrate-legacy-plans --list',

--- a/scripts/memory-tool-recommender.mjs
+++ b/scripts/memory-tool-recommender.mjs
@@ -1,0 +1,874 @@
+#!/usr/bin/env node
+// memory-tool-recommender.mjs - local metadata-driven optional tool recommendations
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+
+export const RECOMMENDATION_RESULT_SCHEMA = 'aifhub.memory_tools.recommendation_result.v1';
+export const METADATA_RESULT_SCHEMA = 'aifhub.memory_tools.metadata_result.v1';
+export const STATUS_RESULT_SCHEMA = 'aifhub.memory_tools.status_result.v1';
+export const ERROR_SCHEMA = 'aifhub.memory_tools.error.v1';
+
+const METADATA_RELATIVE_PATH = path.join('docs', 'memory-tools-research', 'recommendation-metadata.yaml');
+const INSTALLED_EXTENSION_PARTS = ['.ai-factory', 'extensions', 'aifhub-extension'];
+const VALID_PROJECT_SHAPES = new Set([
+  'large_legacy',
+  'multirepo',
+  'large_framework_app',
+  'go_service',
+  'small_microservice'
+]);
+const DEFAULT_TASK_SIGNAL = 'architecture_or_impact_discovery';
+const ALWAYS_REJECTED_TOOLS = new Set(['codex-mem', 'eagle-mem']);
+const MANUAL_ONLY_TASKS = new Map([
+  ['agent-memory', new Set(['manual_durable_notes'])]
+]);
+const IGNORE_DIRS = new Set([
+  '.git',
+  '.hg',
+  '.svn',
+  '.ai-factory/extensions',
+  'node_modules',
+  'vendor',
+  'dist',
+  'build',
+  'coverage',
+  '.cache',
+  '.next',
+  '.turbo',
+  'target',
+  'tmp',
+  'temp',
+  'graphify-out'
+]);
+
+export async function runMemoryToolRecommender(args = [], options = {}) {
+  const parsed = parseArgs(args);
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const json = parsed.flags.json !== false;
+
+  try {
+    if (parsed.command === 'metadata') {
+      const loaded = await tryLoadMetadata(parsed, cwd, options);
+      if (!loaded.ok) {
+        return emitResult(metadataErrorBody(loaded), 1, { ...options, json });
+      }
+      return emitResult(metadataSummary(loaded.metadata), 0, { ...options, json });
+    }
+
+    if (parsed.command === 'status') {
+      const loaded = await tryLoadMetadata(parsed, cwd, options);
+      const body = await buildStatusResult({
+        metadata: loaded.ok ? loaded.metadata : null,
+        metadataError: loaded.ok ? null : loaded,
+        checkDocsProvider: Boolean(parsed.flags.checkDocsProvider),
+        probeRunner: options.probeRunner
+      });
+      return emitResult(body, 0, { ...options, json });
+    }
+
+    if (parsed.command === 'recommend') {
+      const loaded = await tryLoadMetadata(parsed, cwd, options);
+      const taskSignals = parsed.flags.task.length > 0 ? parsed.flags.task : [DEFAULT_TASK_SIGNAL];
+      const projectShape = parsed.flags.fromProject
+        ? await classifyProjectShape(cwd)
+        : normalizeProjectShape(parsed.flags.shape);
+
+      if (!loaded.ok) {
+        const body = degradedRecommendationResult({
+          metadataError: loaded,
+          projectShape,
+          taskSignals
+        });
+        return emitResult(body, 0, { ...options, json });
+      }
+
+      const body = await buildRecommendationResult({
+        metadata: loaded.metadata,
+        projectShape,
+        taskSignals,
+        checkDocsProvider: Boolean(parsed.flags.checkDocsProvider),
+        probeRunner: options.probeRunner
+      });
+      return emitResult(body, 0, { ...options, json });
+    }
+
+    return emitResult({
+      schema: ERROR_SCHEMA,
+      ok: false,
+      error: {
+        code: 'unknown-command',
+        message: `Unknown command: ${parsed.command}`
+      }
+    }, 2, { ...options, json });
+  } catch (err) {
+    return emitResult({
+      schema: ERROR_SCHEMA,
+      ok: false,
+      error: {
+        code: 'unexpected-error',
+        message: err?.message ?? String(err)
+      }
+    }, 1, { ...options, json });
+  }
+}
+
+export async function loadRecommendationMetadata(options = {}) {
+  const resolved = options.metadataPath
+    ? await resolveMetadataPath({ metadataPath: options.metadataPath, cwd: options.cwd })
+    : await resolveMetadataPath(options);
+
+  if (!resolved.ok) {
+    throw new Error(resolved.error?.message ?? 'Recommendation metadata unavailable.');
+  }
+
+  const raw = await readFile(resolved.path, 'utf8');
+  return parseRecommendationMetadata(raw, {
+    sourcePath: resolved.path,
+    sourceKind: resolved.kind
+  });
+}
+
+export function parseRecommendationMetadata(raw, options = {}) {
+  const parsed = parseSimpleYaml(raw);
+  parsed.source_path = options.sourcePath ? toPosix(path.normalize(options.sourcePath)) : null;
+  parsed.source_kind = options.sourceKind ?? null;
+
+  const required = [
+    ['schema', parsed.schema],
+    ['default_policy.baseline_tool', parsed.default_policy?.baseline_tool],
+    ['tools', parsed.tools]
+  ];
+
+  for (const [label, value] of required) {
+    if (value === undefined || value === null || value === '') {
+      throw new Error(`Invalid recommendation metadata: missing ${label}`);
+    }
+  }
+
+  return parsed;
+}
+
+export async function resolveMetadataPath(options = {}) {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+
+  if (options.metadataPath) {
+    const explicitPath = path.resolve(cwd, options.metadataPath);
+    return (await pathExists(explicitPath))
+      ? { ok: true, path: explicitPath, kind: 'explicit' }
+      : metadataMissing([explicitPath], 'Explicit metadata path does not exist.');
+  }
+
+  const scriptDir = path.resolve(
+    options.scriptDir
+      ?? path.dirname(fileURLToPath(import.meta.url))
+  );
+  const candidates = [];
+
+  const scriptRelativeRoot = path.resolve(scriptDir, '..');
+  const scriptRelativeMetadata = path.join(scriptRelativeRoot, METADATA_RELATIVE_PATH);
+  candidates.push(scriptRelativeMetadata);
+  if (isInstalledExtensionPath(scriptRelativeRoot) && await pathExists(scriptRelativeMetadata)) {
+    return { ok: true, path: scriptRelativeMetadata, kind: 'installed-script-relative' };
+  }
+
+  const installedProjectMetadata = path.join(cwd, ...INSTALLED_EXTENSION_PARTS, METADATA_RELATIVE_PATH);
+  candidates.push(installedProjectMetadata);
+  if (await pathExists(installedProjectMetadata)) {
+    return { ok: true, path: installedProjectMetadata, kind: 'installed-project' };
+  }
+
+  const sourceTreeMetadata = path.join(cwd, METADATA_RELATIVE_PATH);
+  candidates.push(sourceTreeMetadata);
+  if (await isAifhubExtensionSource(cwd) && await pathExists(sourceTreeMetadata)) {
+    return { ok: true, path: sourceTreeMetadata, kind: 'source-tree' };
+  }
+
+  return metadataMissing(candidates, 'Local recommendation metadata was not found.');
+}
+
+export async function buildRecommendationResult(options = {}) {
+  const metadata = options.metadata;
+  const projectShape = normalizeProjectShape(options.projectShape);
+  const taskSignals = normalizeTaskSignals(options.taskSignals);
+  const baseline = [metadata?.default_policy?.baseline_tool ?? 'rg'];
+  const warnings = [];
+  const candidates = collectCandidateTools(metadata, projectShape, taskSignals);
+  const recommendations = [];
+
+  for (const toolId of candidates) {
+    const tool = metadata.tools?.[toolId];
+    if (!tool || isRejectedTool(toolId, tool)) continue;
+    if (!isAllowedForRequest(toolId, tool, projectShape, taskSignals, metadata)) continue;
+
+    const probe = await runProbeForTool(toolId, {
+      checkDocsProvider: Boolean(options.checkDocsProvider),
+      probeRunner: options.probeRunner
+    });
+    recommendations.push(buildRecommendation(toolId, tool, {
+      projectShape,
+      taskSignals,
+      availability: probe.availability,
+      command: probe.command
+    }));
+  }
+
+  return {
+    schema: RECOMMENDATION_RESULT_SCHEMA,
+    metadata_available: true,
+    metadata_source: metadata.source_path ?? null,
+    project_shape: projectShape,
+    task_signals: taskSignals,
+    baseline,
+    recommendations: dedupeRecommendations(recommendations),
+    do_not_recommend: buildDoNotRecommend(metadata, projectShape, taskSignals),
+    warnings
+  };
+}
+
+async function buildStatusResult(options = {}) {
+  const metadata = options.metadata;
+  const tools = metadata?.tools ? Object.keys(metadata.tools) : [];
+  const probes = {};
+
+  for (const toolId of ['rg', 'uv', ...tools]) {
+    probes[toolId] = await runProbeForTool(toolId, {
+      checkDocsProvider: Boolean(options.checkDocsProvider),
+      probeRunner: options.probeRunner
+    });
+  }
+
+  return {
+    schema: STATUS_RESULT_SCHEMA,
+    metadata_available: Boolean(metadata),
+    metadata_source: metadata?.source_path ?? null,
+    probes,
+    warnings: options.metadataError
+      ? [metadataWarning(options.metadataError)]
+      : []
+  };
+}
+
+function metadataSummary(metadata) {
+  const tools = {};
+  for (const [toolId, tool] of Object.entries(metadata.tools ?? {})) {
+    tools[toolId] = {
+      display_name: tool.display_name ?? toolId,
+      decision: tool.decision ?? null,
+      recommendation_action: tool.recommendation_action ?? null,
+      install_policy: tool.install_policy ?? metadata.default_policy?.install_policy ?? null,
+      read_scope: tool.read_scope ?? null,
+      purge_path: tool.purge_path ?? null
+    };
+  }
+
+  return {
+    schema: METADATA_RESULT_SCHEMA,
+    metadata_schema: metadata.schema,
+    metadata_available: true,
+    metadata_source: metadata.source_path ?? null,
+    default_policy: metadata.default_policy ?? {},
+    project_shape_signals: Object.keys(metadata.project_shape_signals ?? {}),
+    task_signals: Object.keys(metadata.task_signals ?? {}),
+    tools
+  };
+}
+
+function degradedRecommendationResult(options = {}) {
+  return {
+    schema: RECOMMENDATION_RESULT_SCHEMA,
+    metadata_available: false,
+    metadata_source: options.metadataError?.path ?? null,
+    project_shape: normalizeProjectShape(options.projectShape),
+    task_signals: normalizeTaskSignals(options.taskSignals),
+    baseline: ['rg'],
+    recommendations: [],
+    do_not_recommend: [],
+    warnings: [metadataWarning(options.metadataError)]
+  };
+}
+
+function metadataErrorBody(error) {
+  return {
+    schema: ERROR_SCHEMA,
+    ok: false,
+    metadata_available: false,
+    metadata_source: error?.path ?? null,
+    error: {
+      code: error?.code ?? 'metadata-unavailable',
+      message: error?.error?.message ?? error?.message ?? 'Recommendation metadata unavailable.'
+    }
+  };
+}
+
+function metadataWarning(error) {
+  return {
+    code: error?.code ?? 'metadata-unavailable',
+    message: `Recommendation metadata unavailable: ${error?.error?.message ?? error?.message ?? 'local metadata not found'}`
+  };
+}
+
+function collectCandidateTools(metadata, projectShape, taskSignals) {
+  const candidates = new Set();
+  const shape = metadata.project_shape_signals?.[projectShape] ?? {};
+
+  for (const toolId of asArray(shape.suggest_tools)) candidates.add(toolId);
+  for (const toolId of asArray(shape.conditional_tools)) {
+    if (toolMatchesTask(metadata.tools?.[toolId], taskSignals)) {
+      candidates.add(toolId);
+    }
+  }
+
+  for (const signal of taskSignals) {
+    const task = metadata.task_signals?.[signal] ?? {};
+    for (const toolId of asArray(task.recommend)) candidates.add(toolId);
+    for (const toolId of asArray(task.conditional)) candidates.add(toolId);
+  }
+
+  candidates.delete(metadata.default_policy?.baseline_tool ?? 'rg');
+  return [...candidates];
+}
+
+function toolMatchesTask(tool, taskSignals) {
+  if (!tool) return false;
+  const recommendedTasks = [
+    ...asArray(tool.recommended_for?.tasks),
+    ...asArray(tool.conditional_for?.tasks)
+  ];
+  return taskSignals.some((signal) => recommendedTasks.includes(signal));
+}
+
+function isAllowedForRequest(toolId, tool, projectShape, taskSignals, metadata) {
+  if (ALWAYS_REJECTED_TOOLS.has(toolId)) return false;
+
+  const manualTaskSet = MANUAL_ONLY_TASKS.get(toolId);
+  if (manualTaskSet && !taskSignals.some((signal) => manualTaskSet.has(signal))) {
+    return false;
+  }
+
+  const shape = metadata.project_shape_signals?.[projectShape] ?? {};
+  if (asArray(shape.avoid_tools).includes(toolId)) return false;
+
+  for (const signal of taskSignals) {
+    const task = metadata.task_signals?.[signal] ?? {};
+    if (asArray(task.avoid).includes(toolId)) return false;
+    if (asArray(task.avoid_by_default).includes(toolId)) return false;
+  }
+
+  if (asArray(tool.do_not_recommend_for?.project_shapes).includes(projectShape)) return false;
+  if (taskSignals.some((signal) => asArray(tool.do_not_recommend_for?.tasks).includes(signal))) return false;
+
+  return !isRejectedTool(toolId, tool);
+}
+
+function isRejectedTool(toolId, tool) {
+  return ALWAYS_REJECTED_TOOLS.has(toolId)
+    || tool.decision === 'reject_default'
+    || tool.decision === 'reject_defer'
+    || /^do_not_/.test(String(tool.recommendation_action ?? ''));
+}
+
+function buildRecommendation(toolId, tool, context) {
+  const installPolicy = tool.install_policy ?? 'explicit_user_opt_in_only';
+  return {
+    tool_id: toolId,
+    display_name: tool.display_name ?? toolId,
+    status: tool.decision ?? 'optional',
+    availability: context.availability ?? 'unknown',
+    reason: `${context.projectShape} + ${context.taskSignals.join(', ')}`,
+    install_policy: installPolicy,
+    read_scope: tool.read_scope ?? 'unknown',
+    purge_path: tool.purge_path ?? 'unknown',
+    next_step: nextStepForTool(toolId, tool)
+  };
+}
+
+function nextStepForTool(toolId, tool) {
+  if (toolId === 'graphify') {
+    return 'Use rg first; optionally run graphify manually if broad search is noisy.';
+  }
+  if (toolId === 'codex-agent-mem') {
+    return 'Use only for continuity with read-only/minimal mode and an explicit DB path.';
+  }
+  if (toolId === 'context-mode') {
+    return 'Use only as a manual temporary index for explicit generated output, then purge it.';
+  }
+  if (toolId === 'context7') {
+    return 'Use only as optional user-owned docs lookup for version-sensitive library/API questions.';
+  }
+  if (toolId === 'agent-memory') {
+    return 'Use only as a manual markdown notebook when the user explicitly asks for durable notes.';
+  }
+  return tool.suggestion_text ?? 'Use only as explicit opt-in supporting context.';
+}
+
+function buildDoNotRecommend(metadata, projectShape, taskSignals) {
+  const entries = new Map();
+
+  for (const [toolId, tool] of Object.entries(metadata.tools ?? {})) {
+    if (isRejectedTool(toolId, tool)) {
+      entries.set(toolId, {
+        tool_id: toolId,
+        reason: tool.avoid_reason ?? `${tool.display_name ?? toolId} is not recommended by local metadata.`
+      });
+    }
+  }
+
+  const shape = metadata.project_shape_signals?.[projectShape] ?? {};
+  for (const toolId of asArray(shape.avoid_tools)) {
+    const tool = metadata.tools?.[toolId] ?? {};
+    entries.set(toolId, {
+      tool_id: toolId,
+      reason: tool.avoid_reason ?? `${tool.display_name ?? toolId} is avoided for ${projectShape}.`
+    });
+  }
+
+  for (const signal of taskSignals) {
+    const task = metadata.task_signals?.[signal] ?? {};
+    for (const toolId of [...asArray(task.avoid), ...asArray(task.avoid_by_default)]) {
+      const tool = metadata.tools?.[toolId] ?? {};
+      entries.set(toolId, {
+        tool_id: toolId,
+        reason: tool.avoid_reason ?? `${tool.display_name ?? toolId} is avoided for ${signal}.`
+      });
+    }
+  }
+
+  return [...entries.values()];
+}
+
+async function runProbeForTool(toolId, options = {}) {
+  if (options.probeRunner) {
+    const probe = await options.probeRunner(toolId, options);
+    return normalizeProbeResult(probe);
+  }
+
+  if (toolId === 'rg') return probeAny([['rg', ['--version']]]);
+  if (toolId === 'uv') return probeAny([['uv', ['--version']]]);
+  if (toolId === 'graphify') return probeAny([['graphify', ['--version']], ['graphify', ['--help']]]);
+  if (toolId === 'codex-agent-mem') {
+    return probeAny([
+      ['codex-agent-mem-policy', ['--help']],
+      ['codex-agent-mem-smoke', ['--help']]
+    ]);
+  }
+  if (toolId === 'context-mode') return probeAny([['context-mode', ['doctor']]]);
+  if (toolId === 'context7') {
+    if (!options.checkDocsProvider) {
+      return {
+        availability: 'unknown',
+        command: null,
+        note: 'Context7 probe skipped; pass --check-docs-provider to check local docs provider availability.'
+      };
+    }
+    return probeAny([['ctx7', ['--version']], ['npx', ['--no-install', 'ctx7', '--help']]]);
+  }
+
+  return {
+    availability: 'unknown',
+    command: null
+  };
+}
+
+async function probeAny(commands) {
+  let last = null;
+
+  for (const [command, args] of commands) {
+    const probe = await probeCommand(command, args);
+    if (probe.availability === 'installed') return probe;
+    last = probe;
+  }
+
+  return last ?? { availability: 'unknown', command: null };
+}
+
+async function probeCommand(command, args) {
+  const commandLabel = [command, ...args].join(' ');
+  try {
+    await execFileAsync(command, args, {
+      windowsHide: true,
+      timeout: 5000,
+      maxBuffer: 64 * 1024
+    });
+    return {
+      availability: 'installed',
+      command: commandLabel
+    };
+  } catch (err) {
+    return {
+      availability: err?.code === 'ENOENT' ? 'not_installed' : 'unknown',
+      command: commandLabel,
+      reason: err?.code === 'ENOENT' ? 'command-not-found' : 'probe-failed'
+    };
+  }
+}
+
+function normalizeProbeResult(probe) {
+  if (!probe || typeof probe !== 'object') {
+    return { availability: 'unknown', command: null };
+  }
+  const availability = ['installed', 'not_installed', 'unknown'].includes(probe.availability)
+    ? probe.availability
+    : 'unknown';
+  return {
+    ...probe,
+    availability,
+    command: probe.command ?? null
+  };
+}
+
+async function classifyProjectShape(cwd) {
+  const stats = await scanProject(cwd);
+  if (stats.manifestCount >= 3 || stats.workspaceMarkers > 0) return 'multirepo';
+  if (stats.hasGoMod) return stats.fileCount <= 100 ? 'small_microservice' : 'go_service';
+  if (stats.fileCount <= 100) return 'small_microservice';
+  if (stats.fileCount >= 1500) return 'large_legacy';
+  if (stats.hasFrameworkMarker || stats.fileCount >= 250) return 'large_framework_app';
+  return 'large_framework_app';
+}
+
+async function scanProject(rootDir) {
+  const result = {
+    fileCount: 0,
+    manifestCount: 0,
+    workspaceMarkers: 0,
+    hasGoMod: false,
+    hasFrameworkMarker: false
+  };
+
+  async function walk(currentDir, relativeDir = '') {
+    let entries;
+    try {
+      entries = await readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const rel = relativeDir ? path.join(relativeDir, entry.name) : entry.name;
+      const normalized = toPosix(rel);
+      if (entry.isDirectory()) {
+        if (shouldIgnoreDir(normalized)) continue;
+        await walk(path.join(currentDir, entry.name), rel);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      result.fileCount += 1;
+      if (isManifestName(entry.name)) result.manifestCount += 1;
+      if (entry.name === 'go.mod') result.hasGoMod = true;
+      if (isWorkspaceMarker(entry.name)) result.workspaceMarkers += 1;
+      if (isFrameworkMarker(normalized)) result.hasFrameworkMarker = true;
+    }
+  }
+
+  await walk(rootDir);
+  return result;
+}
+
+function shouldIgnoreDir(relativeDir) {
+  if (IGNORE_DIRS.has(relativeDir)) return true;
+  const parts = relativeDir.split('/');
+  return parts.some((part) => IGNORE_DIRS.has(part));
+}
+
+function isManifestName(name) {
+  return [
+    'package.json',
+    'go.mod',
+    'pyproject.toml',
+    'requirements.txt',
+    'Cargo.toml',
+    'pom.xml',
+    'build.gradle',
+    'composer.json'
+  ].includes(name);
+}
+
+function isWorkspaceMarker(name) {
+  return [
+    'pnpm-workspace.yaml',
+    'lerna.json',
+    'rush.json',
+    'nx.json',
+    'turbo.json'
+  ].includes(name);
+}
+
+function isFrameworkMarker(relativePath) {
+  return /(^|\/)(src|app|pages|routes|controllers|components)\//.test(relativePath)
+    || /(^|\/)(next|vite|nuxt|angular|svelte|astro)\.config\./.test(relativePath);
+}
+
+async function tryLoadMetadata(parsed, cwd, options = {}) {
+  try {
+    const resolved = await resolveMetadataPath({
+      metadataPath: parsed.flags.metadata,
+      scriptDir: options.scriptDir,
+      cwd
+    });
+    if (!resolved.ok) return resolved;
+
+    const raw = await readFile(resolved.path, 'utf8');
+    return {
+      ok: true,
+      metadata: parseRecommendationMetadata(raw, {
+        sourcePath: resolved.path,
+        sourceKind: resolved.kind
+      })
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'metadata-unavailable',
+      error: {
+        message: err?.message ?? String(err)
+      }
+    };
+  }
+}
+
+function parseArgs(args) {
+  const command = args[0] && !args[0].startsWith('-') ? args[0] : 'recommend';
+  const rest = command === args[0] ? args.slice(1) : args;
+  const flags = {
+    json: false,
+    fromProject: false,
+    checkDocsProvider: false,
+    shape: null,
+    task: [],
+    metadata: null
+  };
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (token === '--json') {
+      flags.json = true;
+    } else if (token === '--from-project') {
+      flags.fromProject = true;
+    } else if (token === '--check-docs-provider') {
+      flags.checkDocsProvider = true;
+    } else if (token === '--shape') {
+      flags.shape = rest[++index];
+    } else if (token === '--task') {
+      flags.task.push(rest[++index]);
+    } else if (token === '--metadata') {
+      flags.metadata = rest[++index];
+    }
+  }
+
+  return {
+    command,
+    flags
+  };
+}
+
+function normalizeProjectShape(shape) {
+  const normalized = String(shape ?? 'large_framework_app').trim();
+  return VALID_PROJECT_SHAPES.has(normalized) ? normalized : 'large_framework_app';
+}
+
+function normalizeTaskSignals(signals) {
+  const normalized = asArray(signals).map((signal) => String(signal).trim()).filter(Boolean);
+  return normalized.length > 0 ? [...new Set(normalized)] : [DEFAULT_TASK_SIGNAL];
+}
+
+function dedupeRecommendations(recommendations) {
+  const seen = new Set();
+  return recommendations.filter((item) => {
+    if (seen.has(item.tool_id)) return false;
+    seen.add(item.tool_id);
+    return true;
+  });
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null || value === '') return [];
+  return [value];
+}
+
+async function isAifhubExtensionSource(rootDir) {
+  try {
+    const raw = await readFile(path.join(rootDir, 'extension.json'), 'utf8');
+    return JSON.parse(raw).name === 'aifhub-extension';
+  } catch {
+    return false;
+  }
+}
+
+function isInstalledExtensionPath(rootDir) {
+  const normalized = toPosix(path.normalize(rootDir));
+  return normalized.endsWith(INSTALLED_EXTENSION_PARTS.join('/'));
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function metadataMissing(candidates, message) {
+  return {
+    ok: false,
+    code: 'metadata-unavailable',
+    path: null,
+    searched: candidates.map((candidate) => toPosix(path.normalize(candidate))),
+    error: {
+      message
+    }
+  };
+}
+
+function parseSimpleYaml(raw) {
+  const root = {};
+  const stack = [{ indent: -1, value: root, parent: null, key: null }];
+
+  for (const rawLine of String(raw ?? '').split(/\r?\n/)) {
+    const uncommented = stripInlineComment(rawLine);
+    if (!uncommented.trim()) continue;
+
+    const indent = uncommented.match(/^\s*/)[0].length;
+    const content = uncommented.trim();
+
+    while (stack.length > 1 && indent <= stack.at(-1).indent) {
+      stack.pop();
+    }
+
+    let frame = stack.at(-1);
+
+    if (content.startsWith('- ')) {
+      frame = ensureArrayFrame(frame, stack);
+      const itemRaw = content.slice(2).trim();
+      const keyValue = itemRaw.match(/^([A-Za-z0-9_-]+):(?:\s*(.*?))?\s*$/);
+
+      if (keyValue) {
+        const item = {};
+        frame.value.push(item);
+        const key = keyValue[1];
+        const rawValue = keyValue[2] ?? '';
+        if (rawValue.length > 0) {
+          item[key] = parseScalar(rawValue);
+          stack.push({ indent, value: item, parent: frame.value, key: frame.value.length - 1 });
+        } else {
+          item[key] = {};
+          stack.push({ indent, value: item, parent: frame.value, key: frame.value.length - 1 });
+          stack.push({ indent: indent + 1, value: item[key], parent: item, key });
+        }
+      } else {
+        frame.value.push(parseScalar(itemRaw));
+      }
+      continue;
+    }
+
+    const match = content.match(/^([A-Za-z0-9_-]+):(?:\s*(.*?))?\s*$/);
+    if (!match) continue;
+
+    const key = match[1];
+    const rawValue = match[2] ?? '';
+    const parent = frame.value;
+
+    if (rawValue.length === 0) {
+      parent[key] = {};
+      stack.push({ indent, value: parent[key], parent, key });
+    } else {
+      parent[key] = parseScalar(rawValue);
+    }
+  }
+
+  return root;
+}
+
+function ensureArrayFrame(frame, stack) {
+  if (Array.isArray(frame.value)) return frame;
+  if (frame.parent && frame.key !== null) {
+    const array = [];
+    frame.parent[frame.key] = array;
+    frame.value = array;
+    stack[stack.length - 1] = frame;
+    return frame;
+  }
+  throw new Error('Invalid YAML list placement.');
+}
+
+function parseScalar(value) {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) return '';
+
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (lower === 'true') return true;
+  if (lower === 'false') return false;
+  if (lower === 'null') return null;
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+
+  return trimmed;
+}
+
+function stripInlineComment(value) {
+  let quote = null;
+  const raw = String(value ?? '');
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if ((char === '"' || char === "'") && (index === 0 || raw[index - 1] !== '\\')) {
+      quote = quote === char ? null : quote ?? char;
+      continue;
+    }
+    if (char === '#' && quote === null && (index === 0 || /\s/.test(raw[index - 1]))) {
+      return raw.slice(0, index);
+    }
+  }
+
+  return raw;
+}
+
+function emitResult(body, exitCode, options = {}) {
+  const output = options.json === false
+    ? String(body?.error?.message ?? body?.schema ?? '')
+    : `${JSON.stringify(body, null, 2)}\n`;
+
+  if (Array.isArray(options.stdout)) {
+    options.stdout.push(output);
+  } else if (options.stdout && typeof options.stdout.write === 'function') {
+    options.stdout.write(output);
+  } else {
+    process.stdout.write(output);
+  }
+
+  if (options.exit !== false) {
+    process.exitCode = exitCode;
+  }
+
+  return {
+    exitCode,
+    body
+  };
+}
+
+function toPosix(value) {
+  return String(value).replaceAll(path.sep, '/');
+}
+
+function isDirectRun() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectRun()) {
+  const result = await runMemoryToolRecommender(process.argv.slice(2));
+  process.exit(result.exitCode);
+}

--- a/scripts/memory-tool-recommender.test.mjs
+++ b/scripts/memory-tool-recommender.test.mjs
@@ -1,0 +1,265 @@
+// memory-tool-recommender.test.mjs - metadata-driven optional memory/context tool recommendations
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildRecommendationResult,
+  loadRecommendationMetadata,
+  parseRecommendationMetadata,
+  resolveMetadataPath,
+  runMemoryToolRecommender
+} from './memory-tool-recommender.mjs';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const REAL_METADATA = path.join(REPO_ROOT, 'docs', 'memory-tools-research', 'recommendation-metadata.yaml');
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'memory-tool-recommender-'));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function runCli(args, options = {}) {
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    [path.join(REPO_ROOT, 'scripts', 'memory-tool-recommender.mjs'), ...args],
+    {
+      cwd: options.cwd ?? REPO_ROOT,
+      env: {
+        ...process.env,
+        ...(options.env ?? {})
+      },
+      timeout: 10000
+    }
+  );
+
+  assert.equal(stderr, '');
+  return JSON.parse(stdout);
+}
+
+describe('recommendation metadata parsing', () => {
+  it('parses required policy fields and tool decisions', async () => {
+    const raw = await readFile(REAL_METADATA, 'utf8');
+    const metadata = parseRecommendationMetadata(raw, { sourcePath: REAL_METADATA });
+
+    assert.equal(metadata.schema, 'aifhub.memory_tools.recommendation.v1');
+    assert.equal(metadata.default_policy.baseline_tool, 'rg');
+    assert.equal(metadata.default_policy.never_auto_install, true);
+    assert.equal(metadata.default_policy.install_policy, 'explicit_user_opt_in_only');
+    assert.equal(metadata.default_policy.require_explicit_paths, true);
+    assert.equal(metadata.default_policy.require_purge_path, true);
+    assert.equal(metadata.tools.graphify.decision, 'optional');
+    assert.equal(metadata.tools['codex-agent-mem'].read_scope, 'explicit_sqlite_db_path');
+    assert.equal(metadata.tools['context-mode'].decision, 'manual_helper_only');
+    assert.equal(metadata.tools['codex-mem'].decision, 'reject_default');
+    assert.equal(metadata.tools['eagle-mem'].decision, 'reject_defer');
+    assert.equal(metadata.tools.context7.decision, 'optional');
+  });
+});
+
+describe('metadata source resolution', () => {
+  it('prefers installed script-relative metadata', async () => {
+    const installedRoot = path.join(tmpDir, '.ai-factory', 'extensions', 'aifhub-extension');
+    await mkdir(path.join(installedRoot, 'scripts'), { recursive: true });
+    await mkdir(path.join(installedRoot, 'docs', 'memory-tools-research'), { recursive: true });
+    await copyFile(
+      REAL_METADATA,
+      path.join(installedRoot, 'docs', 'memory-tools-research', 'recommendation-metadata.yaml')
+    );
+
+    const resolved = await resolveMetadataPath({
+      scriptDir: path.join(installedRoot, 'scripts'),
+      cwd: tmpDir
+    });
+
+    assert.equal(
+      resolved.path,
+      path.join(installedRoot, 'docs', 'memory-tools-research', 'recommendation-metadata.yaml')
+    );
+    assert.equal(resolved.kind, 'installed-script-relative');
+  });
+
+  it('uses source-tree metadata only inside the aifhub extension repository', async () => {
+    const sourceRoot = path.join(tmpDir, 'source');
+    await mkdir(path.join(sourceRoot, 'docs', 'memory-tools-research'), { recursive: true });
+    await writeFile(
+      path.join(sourceRoot, 'extension.json'),
+      JSON.stringify({ name: 'aifhub-extension' }),
+      'utf8'
+    );
+    await copyFile(
+      REAL_METADATA,
+      path.join(sourceRoot, 'docs', 'memory-tools-research', 'recommendation-metadata.yaml')
+    );
+
+    const resolved = await resolveMetadataPath({
+      scriptDir: path.join(sourceRoot, 'scripts'),
+      cwd: sourceRoot
+    });
+
+    assert.equal(
+      resolved.path,
+      path.join(sourceRoot, 'docs', 'memory-tools-research', 'recommendation-metadata.yaml')
+    );
+    assert.equal(resolved.kind, 'source-tree');
+  });
+});
+
+describe('recommendation results', () => {
+  it('recommends Graphify for large framework architecture discovery', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const result = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['architecture_or_impact_discovery'],
+      probeRunner: async () => ({ availability: 'unknown' })
+    });
+
+    const graphify = result.recommendations.find((item) => item.tool_id === 'graphify');
+    assert.equal(result.schema, 'aifhub.memory_tools.recommendation_result.v1');
+    assert.deepEqual(result.baseline, ['rg']);
+    assert.ok(graphify);
+    assert.equal(result.recommendations.some((item) => item.tool_id === 'context-mode'), false);
+    assert.equal(graphify.display_name, 'Graphify');
+    assert.equal(graphify.status, 'optional');
+    assert.equal(graphify.install_policy, 'explicit_user_opt_in_only');
+    assert.equal(graphify.read_scope, 'explicit_project_path');
+    assert.match(graphify.next_step, /Use rg first/i);
+  });
+
+  it('recommends codex-agent-mem only for continuity tasks', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const result = await buildRecommendationResult({
+      metadata,
+      projectShape: 'go_service',
+      taskSignals: ['resume_previous_work'],
+      probeRunner: async () => ({ availability: 'not_installed' })
+    });
+
+    const continuity = result.recommendations.find((item) => item.tool_id === 'codex-agent-mem');
+    assert.ok(continuity);
+    assert.equal(continuity.status, 'optional');
+    assert.equal(continuity.availability, 'not_installed');
+    assert.equal(continuity.read_scope, 'explicit_sqlite_db_path');
+    assert.match(continuity.next_step, /explicit DB path/i);
+  });
+
+  it('recommends context-mode only for large temporary output compression', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const result = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['large_command_output_compression'],
+      probeRunner: async () => ({ availability: 'unknown' })
+    });
+
+    const contextMode = result.recommendations.find((item) => item.tool_id === 'context-mode');
+    assert.ok(contextMode);
+    assert.equal(contextMode.status, 'manual_helper_only');
+    assert.equal(contextMode.read_scope, 'explicit_indexed_content');
+    assert.match(contextMode.next_step, /manual temporary/i);
+  });
+
+  it('keeps small microservices on rg baseline and avoids repo graph helpers', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const result = await buildRecommendationResult({
+      metadata,
+      projectShape: 'small_microservice',
+      taskSignals: ['exact_file_or_symbol_lookup'],
+      probeRunner: async () => ({ availability: 'installed' })
+    });
+
+    assert.deepEqual(result.baseline, ['rg']);
+    assert.equal(result.recommendations.some((item) => item.tool_id === 'graphify'), false);
+    assert.equal(result.recommendations.some((item) => item.tool_id === 'context-mode'), false);
+    assert.ok(result.do_not_recommend.some((item) => item.tool_id === 'codex-mem'));
+    assert.ok(result.do_not_recommend.some((item) => item.tool_id === 'eagle-mem'));
+  });
+
+  it('only recommends agent-memory for explicit manual durable notes tasks', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const withoutManualNotes = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['architecture_or_impact_discovery'],
+      probeRunner: async () => ({ availability: 'unknown' })
+    });
+    const withManualNotes = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['manual_durable_notes'],
+      probeRunner: async () => ({ availability: 'unknown' })
+    });
+
+    assert.equal(withoutManualNotes.recommendations.some((item) => item.tool_id === 'agent-memory'), false);
+    assert.equal(withManualNotes.recommendations.some((item) => item.tool_id === 'agent-memory'), true);
+  });
+});
+
+describe('CLI behavior', () => {
+  it('prints recommendation JSON for explicit shape and task signals', async () => {
+    const result = await runCli([
+      'recommend',
+      '--shape',
+      'large_framework_app',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ]);
+
+    assert.equal(result.schema, 'aifhub.memory_tools.recommendation_result.v1');
+    assert.equal(result.project_shape, 'large_framework_app');
+    assert.deepEqual(result.task_signals, ['architecture_or_impact_discovery']);
+    assert.ok(result.recommendations.some((item) => item.tool_id === 'graphify'));
+  });
+
+  it('degrades recommend output when metadata is unavailable', async () => {
+    const result = await runMemoryToolRecommender([
+      'recommend',
+      '--shape',
+      'large_framework_app',
+      '--metadata',
+      path.join(tmpDir, 'missing.yaml'),
+      '--json'
+    ], {
+      cwd: tmpDir,
+      stdout: [],
+      stderr: [],
+      exit: false
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.body.schema, 'aifhub.memory_tools.recommendation_result.v1');
+    assert.equal(result.body.metadata_available, false);
+    assert.deepEqual(result.body.baseline, ['rg']);
+    assert.deepEqual(result.body.recommendations, []);
+    assert.ok(result.body.warnings.some((warning) => /metadata unavailable/i.test(warning.message)));
+  });
+
+  it('reports safe probe failures as unknown or not_installed without failing recommendations', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const result = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['architecture_or_impact_discovery'],
+      probeRunner: async () => ({ availability: 'not_installed', command: 'graphify --version' })
+    });
+
+    const graphify = result.recommendations.find((item) => item.tool_id === 'graphify');
+    assert.equal(graphify.availability, 'not_installed');
+  });
+});

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -102,29 +102,83 @@ Do not rewrite or delete those folders automatically in this skill.
 - Prefer direct evidence from manifests, source layout, config files, and project docs.
 - Note the tech stack for rules/base.md generation.
 
-### Step 2.1: Optional Graphify Context
+### Step 2.1: Optional Context/Memory Tool Recommendations
 
-Graphify is an optional context/research provider. During repository inspection, this skill may read existing Graphify outputs as supporting context:
+Use local recommendation metadata to suggest optional context and memory tools during repository inspection.
+
+Read metadata from the installed extension path when available:
+
+```text
+.ai-factory/extensions/aifhub-extension/docs/memory-tools-research/recommendation-metadata.yaml
+```
+
+When this skill is running inside the AIFHub extension source repository, the source-tree metadata path may be used:
+
+```text
+docs/memory-tools-research/recommendation-metadata.yaml
+```
+
+Installed-project diagnostics should use the wrapper command:
+
+```bash
+ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools status --json
+ai-factory aifhub-memory-tools metadata --json
+```
+
+If metadata is unavailable, skip recommendations with a degraded note and keep `rg` as the baseline tool.
+
+Classify project shape from repository evidence:
+
+- `multirepo`
+- `large_framework_app`
+- `large_legacy`
+- `go_service`
+- `small_microservice`
+
+Detect task signals from the user request and analysis context:
+
+- `exact_file_or_symbol_lookup`
+- `architecture_or_impact_discovery`
+- `multirepo_surface_mapping`
+- `resume_previous_work`
+- `open_work_or_completion_check`
+- `large_command_output_compression`
+- `version_sensitive_library_docs`
+- `manual_durable_notes`
+
+Recommendation rules:
+
+- `rg` remains the baseline for exact file/symbol lookup, small projects, and first-pass literal search.
+- Recommend only tools allowed by local metadata.
+- Prefer installed/local tools in recommendations; non-installed tools may be described as optional manual install only when metadata allows.
+- Never auto-install, run setup, start MCP, register MCP, index source, sync memory, install hooks, start background daemons, or persist provider output.
+- Provider output is supporting context only, never canonical OpenSpec evidence.
+- `codex-mem` and `eagle-mem` are not recommended by default.
+- `agent-memory` is recommended only when the user explicitly asks for manual durable notes.
+
+Safe local availability probes are limited to:
+
+```bash
+rg --version
+uv --version
+graphify --version
+graphify --help
+codex-agent-mem-policy --help
+codex-agent-mem-smoke --help
+context-mode doctor
+ctx7 --version
+npx --no-install ctx7 --help
+```
+
+Run the Context7 probes only when a docs-provider check is explicitly requested. Do not run `ctx7 setup`.
+
+Optional Graphify context remains allowed only as supporting context. During repository inspection, this skill may read existing reviewed Graphify outputs:
 
 - `graphify-out/GRAPH_REPORT.md`
 - `graphify-out/graph.json`
 - `.ai-factory/references/graphify/GRAPH_REPORT.md`
 - `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
-
-At the beginning of this optional Graphify check, test whether `uv` is available:
-
-```powershell
-uv --version
-```
-
-Read `utilities.graphify.enabled` from `.ai-factory/config.yaml` when available. If it is missing or `false`, include a non-blocking analysis hint that Graphify is recommended for large or unfamiliar repositories and show the manual setup commands:
-
-```powershell
-uv tool install graphifyy
-graphify install
-```
-
-If `uv` is unavailable, report that Graphify setup should start by installing `uv` and rerunning `uv --version`. Also mention that the user may generate reports manually with `graphify .` and set `utilities.graphify.enabled: true` only after the project chooses to use Graphify. If `utilities.graphify.enabled: true`, report Graphify as enabled and still treat missing reports as degraded context rather than failure.
 
 Missing Graphify or missing reports are degraded context, not bootstrap failure. Do not install `graphifyy`, run `graphify`, add Graphify dependencies or manifest entries, or start/register Graphify MCP automatically.
 
@@ -132,7 +186,7 @@ Treat Graphify findings as supporting context only. `GRAPH_REPORT.md` can contai
 
 Do not copy Graphify output during bootstrap unless the user explicitly asks to preserve reviewed output. If preserving reviewed Graphify context, use `.ai-factory/references/graphify/` for project-wide references or `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime context. Never store Graphify generated files under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
 
-Before reading or preserving Graphify output, treat privacy as explicit caveat: do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
+Before reading or preserving provider output, treat privacy as an explicit caveat: do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, private provider diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or provider reference copies.
 
 ### Step 2.5: Resolve Bootstrap Mode
 
@@ -159,7 +213,7 @@ Resolve the bootstrap/config mode before creating directories:
 - Preserve existing `language.ui`, `language.artifacts`, and `language.technical_terms` values. If `language.technical_terms` is missing, default it to `keep`; accepted values are `keep | translate | mixed`.
 - If localization answers were collected while config was missing, write those pending config values into the selected legacy `ai-factory` or `openspec-native` config shape.
 - Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `utilities`, `rules`, `workflow`.
-- Ensure the shared optional utility config is present in both legacy `ai-factory` and `openspec-native` modes, preserving existing user values:
+- Ensure the shared optional utility config is present in both legacy `ai-factory` and `openspec-native` modes, preserving existing user values. `utilities.graphify` is a backward-compatible preference shim only; new optional memory/context recommendations come from local `recommendation-metadata.yaml`, not from a generic provider config abstraction:
 
 ```yaml
 utilities:
@@ -330,7 +384,8 @@ openspec init --tools none
 - Report the resolved bootstrap mode.
 - Report the bootstrap mode selection source: existing config, explicit user request, first-bootstrap answer, or autonomous default.
 - Report whether config values were created or preserved.
-- Report the Graphify utility setting and `uv` availability. If `utilities.graphify.enabled` is missing or `false`, include the optional recommendation `Graphify is recommended for large or unfamiliar repositories; check uv with: uv --version; install manually with: uv tool install graphifyy; activate manually with: graphify install`.
+- Report optional local tool recommendations from `ai-factory aifhub-memory-tools recommend --from-project --json` when the installed wrapper is available, or from source-tree metadata only when running inside the AIFHub extension repository. Include baseline `rg`, recommended tools with availability/read scope/purge path, and not-recommended tools such as `codex-mem` and `eagle-mem`. If metadata is unavailable, report a degraded note and continue.
+- Report the backward-compatible Graphify utility setting and `uv` availability only as compatibility context. If `utilities.graphify.enabled` is missing or `false`, Graphify may still be recommended only through local metadata; show manual setup commands only as explicit opt-in guidance: `uv --version`, `uv tool install graphifyy`, `graphify install`, and `graphify .`.
 - If autonomous/subagent mode defaulted to legacy `ai-factory` because the artifact protocol question could not be asked, report OpenSpec-native mode selection as an open question/blocker.
 - Report the active path set.
 - In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.

--- a/skills/aif-analyze/references/project-scan-checklist.md
+++ b/skills/aif-analyze/references/project-scan-checklist.md
@@ -24,6 +24,29 @@ Look for the main working areas:
 - `docs/`, `config/`
 - `migrations/`, `prisma/`, `db/`
 
+## Optional Tool Recommendation Signals
+
+Classify project shape from evidence, not from repository name:
+
+- `small_microservice`: small file count, one service manifest, narrow source tree, exact `rg` lookup is likely enough.
+- `go_service`: `go.mod` plus service-style packages or integrations; use baseline `rg` first.
+- `large_framework_app`: framework markers such as `app/`, `src/`, routes/controllers/components, build config, and enough files that broad impact search may be noisy.
+- `multirepo`: multiple manifests, workspace markers, or coordinated component directories.
+- `large_legacy`: very large file count, mixed older layouts, dense integrations, and noisy literal search.
+
+Detect task signals from the user's request and analysis context:
+
+- `exact_file_or_symbol_lookup`: user asks for a known file, symbol, config key, or literal string.
+- `architecture_or_impact_discovery`: user asks for architecture, dependencies, impact, ownership, or broad codebase understanding.
+- `multirepo_surface_mapping`: user asks how multiple packages/repos/components connect.
+- `resume_previous_work`: user asks to resume, continue, or recover previous session context.
+- `open_work_or_completion_check`: user asks what remains open or whether work is complete.
+- `large_command_output_compression`: analysis output is too large and needs temporary retrieval/compression.
+- `version_sensitive_library_docs`: answer depends on current library/API docs, migrations, or deprecations.
+- `manual_durable_notes`: user explicitly asks for durable manual notes.
+
+Always keep `rg` as the baseline. Optional memory/context tools may only be recommended through local metadata and explicit opt-in.
+
 ## Source Control
 
 Use git only to confirm repository state and remotes:


### PR DESCRIPTION
## Summary

- Adds a metadata-driven optional memory/context tool recommender that reads local `recommendation-metadata.yaml` and keeps `rg` as the baseline.
- Registers the installed-project `ai-factory aifhub-memory-tools ...` wrapper command surface.
- Updates `/aif-analyze`, project scan guidance, docs, and local metadata, including Context7 visibility as an optional docs provider.

## Safety

- No auto-install, setup, indexing, sync, MCP registration, hooks, background services, or provider-output writes.
- Recommendations stay explicit opt-in and include availability, read scope, purge path, and install policy.
- `codex-mem` and `eagle-mem` remain default-unsafe do-not-recommend entries.

## Validation

- `node --test scripts/memory-tool-recommender.test.mjs`
- `npm test`
- `npm run validate`
- OpenSpec validation for `recommend-optional-memory-tools-from-local-metadata`