### PR TITLE
Close context and memory tools backlog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.*/
 /.*
+!/.gitattributes
 !/.github/
 /.github/*
 !/.github/workflows/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,33 +1,33 @@
-[Back to README](../README.md) | [Next Page](usage.md)
+[К README](../README.md) | [Следующая страница](usage.md)
 
-# Documentation
+# Документация
 
-This documentation explains the AIFHub Extension v1 workflow:
+Эта документация описывает workflow AIFHub Extension v1:
 
 ```text
 AI Factory UX + OpenSpec artifact protocol
 ```
 
-OpenSpec-native artifacts under `openspec/` are canonical. AI Factory artifacts under `.ai-factory/` hold runtime state, QA evidence, generated rules, and legacy migration input.
+OpenSpec-native artifacts в `openspec/` являются canonical. AI Factory artifacts в `.ai-factory/` хранят runtime state, QA evidence, generated rules и legacy migration input.
 
-OpenSpec CLI features are reached through AIFHub wrappers and `scripts/openspec-runner.mjs`; OpenSpec skills or slash commands are not installed by the extension.
+OpenSpec CLI features вызываются через AIFHub wrappers и `scripts/openspec-runner.mjs`; OpenSpec skills или slash commands extension не устанавливает.
 
-## Reading Order
+## Порядок Чтения
 
-1. [Project README](../README.md) for the landing page, quick start, artifact layout, compatibility summary, migration summary, and troubleshooting summary.
-2. [Usage](usage.md) for the full command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting, and smoke checks.
-3. [Context Providers](context-providers.md) for optional Graphify context and Context7 documentation provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries.
-4. [Memory Tool Recommendations](memory-tool-recommendations.md) for local metadata-driven optional tool recommendations and installed wrapper commands.
-5. [Context Loading Policy](context-loading-policy.md) for consumer context, optional Graphify context guidance, optional Context7 documentation context, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff, and legacy path rules.
-6. [OpenSpec Compatibility](openspec-compatibility.md) for optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags, and degraded mode.
-7. [OpenSpec Artifact Validation](openspec-validation.md) for the AIFHub contract validator layered over OpenSpec CLI validation.
-8. [OpenSpec Coverage Matrix](spec-coverage.md) for requirement-to-task-to-code coverage evidence and verify/done policy.
-9. [Legacy Plan Migration](legacy-plan-migration.md) if existing `.ai-factory/plans` artifacts need to move into OpenSpec-native changes.
-10. [Active Change Resolver](active-change-resolver.md) for active change selection, runtime paths, current pointer behavior, and ambiguity diagnostics.
-11. [Handoff Validation Profile](handoff-validation-profile.md) for the read-only orchestration summary contract.
-12. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) for the v1 artifact ownership decision.
+1. [Project README](../README.md) - landing page, quick start, artifact layout, compatibility summary, migration summary и troubleshooting summary.
+2. [Usage](usage.md) - полный command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, commit/evolve handoff, OAuth example, troubleshooting и smoke checks.
+3. [Context Providers](context-providers.md) - optional Graphify context, CodeGraph manual CLI context, Context7 documentation provider guidance, reviewed-note paths, degraded behavior и user-owned setup boundaries.
+4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
+5. [Context Loading Policy](context-loading-policy.md) - consumer context, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, commit handoff и legacy path rules.
+6. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
+8. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
+9. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
+10. [Active Change Resolver](active-change-resolver.md) - active change selection, runtime paths, current pointer behavior и ambiguity diagnostics.
+11. [Handoff Validation Profile](handoff-validation-profile.md) - read-only orchestration summary contract.
+12. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) - v1 artifact ownership decision.
 
-The remaining runtime-specific guides are supporting references:
+Остальные runtime-specific guides являются supporting references:
 
 - [AIFHub MCP](aifhub-mcp.md)
 - [Codex Agents](codex-agents.md)
@@ -39,59 +39,60 @@ The remaining runtime-specific guides are supporting references:
 
 ## Guides
 
-| Guide | Purpose |
+| Guide | Назначение |
 |---|---|
-| [Usage](usage.md) | Full OpenSpec-native command flow, optional Graphify context, optional Context7 guidance, gates, finalization tail, commit, and examples |
-| [Context Providers](context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety, and user-owned setup boundaries |
-| [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify context, optional Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, and legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, validation policy flags, sync points, rules gate, version support, and degraded mode |
-| [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator for canonical artifacts, runtime evidence, QA, and generated rules |
-| [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness, and integration points |
-| [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands and artifact mapping |
-| [Active Change Resolver](active-change-resolver.md) | Active change selection and runtime paths |
-| [Handoff Validation Profile](handoff-validation-profile.md) | Read-only validation summary contract for Handoff orchestration |
-| [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec and AI Factory runtime state contract |
-| [AIFHub MCP](aifhub-mcp.md) | Optional MCP server tools and runtime-specific config shapes |
-| [Codex Agents](codex-agents.md) | Namespaced Codex subagents and invocation contract |
-| [Claude Agents](claude-agents.md) | Namespaced Claude subagents and install target |
+| [Usage](usage.md) | Полный OpenSpec-native command flow, optional Graphify/CodeGraph/Context7 guidance, gates, finalization tail, commit и examples |
+| [Context Providers](context-providers.md) | Optional Graphify context, CodeGraph manual CLI context и Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety и user-owned setup boundaries |
+| [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff и legacy boundaries |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
+| [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
+| [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
+| [Active Change Resolver](active-change-resolver.md) | Active change selection и runtime paths |
+| [Handoff Validation Profile](handoff-validation-profile.md) | Read-only validation summary contract для Handoff orchestration |
+| [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec и AI Factory runtime state contract |
+| [AIFHub MCP](aifhub-mcp.md) | Optional MCP server tools и runtime-specific config shapes |
+| [Codex Agents](codex-agents.md) | Namespaced Codex subagents и invocation contract |
+| [Claude Agents](claude-agents.md) | Namespaced Claude subagents и install target |
 | [Research по Memory Tools](memory-tools-research/README.md) | Результаты проверки local memory/retrieval кандидатов для optional context providers |
-| [Codex Plan Mode](codex-plan-mode.md) | Codex mode and question-format guidance |
+| [Codex Plan Mode](codex-plan-mode.md) | Codex mode и question-format guidance |
 | [Handoff Naming](handoff.md) | Stage vocabulary versus public CLI commands |
 
-## Scope
+## Границы
 
-This docs set covers:
+Этот набор docs покрывает:
 
 - OpenSpec-native v1 workflow
-- artifact mode switching and sync through `/aif-mode`
-- command reads, writes, and forbidden writes
+- artifact mode switching и sync через `/aif-mode`
+- command reads, writes и forbidden writes
 - optional Graphify context provider guidance
+- optional CodeGraph manual CLI context provider guidance
 - optional Context7 documentation provider guidance
 - optional local memory/retrieval candidate research
-- optional rules, review, and security gates
-- verification, fix, done, post-archive sync, commit, and evolve handoff
-- OpenSpec requirement coverage evidence and policy
+- optional rules, review и security gates
+- verification, fix, done, post-archive sync, commit и evolve handoff
+- OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
-- AI Factory runtime state, QA evidence, and generated rules
-- legacy AI Factory-only compatibility and migration
-- runtime-managed Codex and Claude agent files
-- optional AIFHub MCP server registration and runtime-specific settings shapes
+- AI Factory runtime state, QA evidence и generated rules
+- legacy AI Factory-only compatibility и migration
+- runtime-managed Codex и Claude agent files
+- optional AIFHub MCP server registration и runtime-specific settings shapes
 
-It does not document `.ai-factory/plans` as the normal v1 artifact model. Those paths are legacy compatibility and migration input only.
+Она не описывает `.ai-factory/plans` как normal v1 artifact model. Эти paths являются только legacy compatibility и migration input.
 
-## Local Checks
+## Локальные Проверки
 
-Run:
+Запуск:
 
 ```bash
 npm run validate
 npm test
 ```
 
-`npm run validate` checks markdown links under `docs/`, `injections/`, and `skills/`. Root `README.md` links need a manual check when edited.
+`npm run validate` проверяет markdown links в `docs/`, `injections/` и `skills/`. Links в root `README.md` требуют manual check при изменениях.
 
-## See Also
+## См. Также
 
 - [Project README](../README.md)
 - [Usage](usage.md)

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -1,4 +1,4 @@
-[Previous Page](memory-tool-recommendations.md) | [Back to Documentation](README.md) | [Next Page](openspec-compatibility.md)
+[Предыдущая страница](memory-tool-recommendations.md) | [К документации](README.md) | [Следующая страница](openspec-compatibility.md)
 
 # Context Loading Policy
 
@@ -75,21 +75,23 @@ Generated rules and generated trace metadata are derived guidance only. If gener
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
 
-## Optional Context Providers
+## Опциональные Context Providers
 
-Optional providers are read-only supporting context. They are not command prerequisites, dependency requirements, generated rules input, QA evidence, verification gates, done gates, or canonical OpenSpec sources.
+Optional providers - это read-only supporting context. Они не являются command prerequisites, dependency requirements, generated rules input, QA evidence, verification gates, done gates или canonical OpenSpec sources.
 
-Provider output can be copied into `.ai-factory/` only after user review and only as concise notes or reviewed summaries. Raw provider output, MCP transcripts, setup output, generated provider configuration, and unreviewed sensitive output must stay out of canonical OpenSpec, generated rules, runtime QA, and validation artifacts.
+Provider output можно копировать в `.ai-factory/` только после user review и только как concise notes или reviewed summaries. Raw provider output, MCP transcripts, setup output, generated provider configuration и unreviewed sensitive output должны оставаться вне canonical OpenSpec, generated rules, runtime QA и validation artifacts.
 
-See [Context Providers](context-providers.md) for the central provider guide and [Memory Tool Recommendations](memory-tool-recommendations.md) for local metadata-driven recommendation diagnostics.
+Central provider guide находится в [Context Providers](context-providers.md), local metadata-driven recommendation diagnostics - в [Memory Tool Recommendations](memory-tool-recommendations.md).
 
-## Optional Graphify Context
+Context/compression providers не должны rewrite validation artifacts и не должны compress protected artifacts in place. Protected validation artifacts включают `aif-gate-result`, `coverage.json`, `done-readiness.json`, `openspec/specs/**`, generated-rules traces и exact evidence snippets.
 
-Graphify is an optional context/research provider. AIFHub commands may use existing Graphify output as supporting context, but they must not make Graphify a required extension dependency, install `graphifyy`, run `graphify`, add Graphify manifest dependencies, start or register Graphify MCP automatically, or turn Graphify availability into a verification gate.
+## Опциональный Graphify Context
 
-Project preference is recorded in `.ai-factory/config.yaml` as `utilities.graphify.enabled` only for backward compatibility. New `/aif-analyze` recommendations should come from local installed recommendation metadata through `ai-factory aifhub-memory-tools recommend --from-project --json`. If Graphify is recommended, the recommendation is advisory only and must not trigger installation, execution, dependency changes, indexing, or MCP registration.
+Graphify - optional context/research provider. AIFHub commands могут использовать existing Graphify output как supporting context, но не должны делать Graphify required extension dependency, устанавливать `graphifyy`, запускать `graphify`, добавлять Graphify manifest dependencies, запускать или регистрировать Graphify MCP automatically, или превращать Graphify availability в verification gate.
 
-Allowed Graphify inputs are existing local or copied outputs:
+Project preference записывается в `.ai-factory/config.yaml` как `utilities.context_tools.enabled`; `utilities.graphify.enabled` остается backward-compatible. Новые `/aif-analyze` recommendations должны приходить из local installed recommendation metadata через `ai-factory aifhub-memory-tools recommend --from-project --json`. Follow-on skills должны использовать `ai-factory aifhub-memory-tools select --from-project --command <skill> --json` и только returned `selected_tools`. Если Graphify рекомендован, рекомендация остается advisory only и не должна запускать installation, execution, dependency changes, indexing или MCP registration.
+
+Allowed Graphify inputs - existing local или copied outputs:
 
 - `graphify-out/GRAPH_REPORT.md`
 - `graphify-out/graph.json`
@@ -98,47 +100,57 @@ Allowed Graphify inputs are existing local or copied outputs:
 - `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
 - `.ai-factory/state/<change-id>/graphify/graph.json`
 
-If Graphify is unavailable, or if no `graphify-out/GRAPH_REPORT.md` or copied report exists, commands continue normally and report Graphify context as unavailable or degraded rather than failing.
+Если Graphify недоступен или нет `graphify-out/GRAPH_REPORT.md`/copied report, команды продолжают нормально и сообщают Graphify context как unavailable/degraded, а не fail.
 
-Graphify output remains supporting evidence only. `GRAPH_REPORT.md` may include extracted, inferred, ambiguous, or confidence-labeled relationships; commands must treat those graph-derived claims as hypotheses for further inspection. Final requirements, plans, findings, completion status, roadmap status, generated rules, and QA verdicts must be grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, or other direct repository evidence.
+Graphify output остается только supporting evidence. `GRAPH_REPORT.md` может включать extracted, inferred, ambiguous или confidence-labeled relationships; команды должны treat graph-derived claims как hypotheses for further inspection. Final requirements, plans, findings, completion status, roadmap status, generated rules и QA verdicts должны быть grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence или другом direct repository evidence.
 
-Allowed durable storage for reviewed Graphify context:
+Allowed durable storage для reviewed Graphify context:
 
-- `.ai-factory/references/graphify/` for project-wide reference copies.
-- `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime copies.
+- `.ai-factory/references/graphify/` для project-wide reference copies.
+- `.ai-factory/state/<change-id>/graphify/` для change-scoped runtime copies.
 
-Forbidden storage for Graphify generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html`:
-
-- `openspec/changes/<change-id>/`
-- `openspec/specs/`
-- `.ai-factory/rules/generated/`
-- `.ai-factory/qa/<change-id>/`
-
-Before copying Graphify output into `.ai-factory/`, review it for sensitive information. AIFHub guidance must not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Graphify reference copies.
-
-## Optional Context7 Documentation Context
-
-Context7 is an optional documentation provider for current library/API docs. AIFHub commands and sidecars may use existing user-provided or reviewed Context7 notes as supporting context, but they must not make Context7 a required extension dependency, install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 manifest dependencies, add Context7 MCP templates to `extension.json`, start or register Context7 MCP automatically, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or turn Context7 availability into a verification gate.
-
-Manual CLI examples such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>` are outside AIFHub command ownership. If a user-installed `ctx7` CLI is already available, the equivalent `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>` commands are also user-owned. If Context7 is unavailable, unauthenticated, rate-limited, missing provider access, or blocked by local Node.js runtime constraints, commands continue normally and report Context7 context as unavailable or degraded rather than failing.
-
-If the user has already configured Context7 MCP, agents may use it as optional read-only documentation context. The common flow is `resolve-library-id` followed by a docs retrieval tool. The retrieval tool name may be `get-library-docs` or `query-docs` depending on the Context7 client/server version.
-
-Context7 output remains supporting evidence only. Library IDs such as `/org/project`, `/org/project/version`, `/org/project@version`, `/packages/<name>`, and `/websites/<name>` are provider output, not stable AIFHub schema. Final requirements, plans, review findings, completion status, roadmap status, generated rules, and QA verdicts must be source-grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules trace metadata, or other direct repository evidence.
-
-Allowed durable storage for reviewed Context7 notes:
-
-- `.ai-factory/references/context7/` for project-wide documentation notes.
-- `.ai-factory/state/<change-id>/context7/` for change-scoped runtime notes.
-
-Forbidden storage for raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration:
+Forbidden storage для Graphify generated files вроде `GRAPH_REPORT.md`, `graph.json` или `graph.html`:
 
 - `openspec/changes/<change-id>/`
 - `openspec/specs/`
 - `.ai-factory/rules/generated/`
 - `.ai-factory/qa/<change-id>/`
 
-Before copying Context7 notes into `.ai-factory/`, review them for sensitive information. AIFHub guidance must not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
+Перед копированием Graphify output в `.ai-factory/` проверьте его на sensitive information. AIFHub guidance не должен persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics или unreviewed sensitive output в `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules или Graphify reference copies.
+
+## Опциональный CodeGraph Context
+
+CodeGraph - manual CLI-only optional provider для broad repo graph questions. Metadata хранит его как `manual_cli_only` с `suggest_manual_cli_for_repo_graph_when_enabled_or_explicit`. Explicit CLI scoped read и purge verified, но `install`/MCP/agent configuration mutation behavior не принят для AIFHub automation.
+
+Safe probes ограничены `codegraph --version`, `codegraph --help` и `codegraph status`.
+
+`/aif-analyze` может рекомендовать CodeGraph только из local metadata. `/aif-explore` может run CodeGraph только когда `ai-factory aifhub-memory-tools select --from-project --command aif-explore --json` возвращает его в `selected_tools` с `manual_purged_cli_execution`. Command lifecycle приходит из field `execution` в этом CLI output. Если pre-existing `.codegraph/` уже есть, считайте его user-owned state и не delete/reinitialize silently.
+
+AIFHub commands не должны запускать CodeGraph installer, sync, MCP server, hooks или agent configuration mutation commands. CodeGraph output не должен заменять `rg`, canonical OpenSpec artifacts, generated rules, QA evidence или verification/done gates.
+
+## Опциональный Context7 Documentation Context
+
+Context7 - optional documentation provider для current library/API docs. AIFHub commands и sidecars могут использовать existing user-provided или reviewed Context7 notes как supporting context, но не должны делать Context7 required extension dependency, устанавливать `ctx7` или `@upstash/context7-mcp`, запускать `ctx7`, запускать `ctx7 setup`, добавлять Context7 manifest dependencies, добавлять Context7 MCP templates в `extension.json`, start/register Context7 MCP automatically, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules или agent skills, или превращать Context7 availability в verification gate.
+
+Manual CLI examples вроде `npx ctx7 library <name> <query>` и `npx ctx7 docs <libraryId> <query>` находятся вне AIFHub command ownership. Если user-installed `ctx7` CLI уже доступен, equivalent commands `ctx7 library <name> <query>` и `ctx7 docs <libraryId> <query>` тоже user-owned. Если Context7 unavailable, unauthenticated, rate-limited, missing provider access или blocked by local Node.js runtime constraints, команды продолжают нормально и report Context7 context как unavailable/degraded, а не fail.
+
+Если пользователь уже configured Context7 MCP, agents могут использовать его как optional read-only documentation context. Common flow: `resolve-library-id`, затем docs retrieval tool. Retrieval tool может называться `get-library-docs` или `query-docs` в зависимости от Context7 client/server version.
+
+Context7 output остается только supporting evidence. Library IDs вроде `/org/project`, `/org/project/version`, `/org/project@version`, `/packages/<name>` и `/websites/<name>` являются provider output, а не stable AIFHub schema. Final requirements, plans, review findings, completion status, roadmap status, generated rules и QA verdicts должны быть source-grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules trace metadata или другом direct repository evidence.
+
+Allowed durable storage для reviewed Context7 notes:
+
+- `.ai-factory/references/context7/` для project-wide documentation notes.
+- `.ai-factory/state/<change-id>/context7/` для change-scoped runtime notes.
+
+Forbidden storage для raw Context7 output, MCP transcripts, API responses, setup output или generated provider configuration:
+
+- `openspec/changes/<change-id>/`
+- `openspec/specs/`
+- `.ai-factory/rules/generated/`
+- `.ai-factory/qa/<change-id>/`
+
+Перед копированием Context7 notes в `.ai-factory/` проверьте их на sensitive information. AIFHub guidance не должен persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics или unreviewed sensitive output в `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules или Context7 reference copies.
 
 ## Bug Fix Context
 

--- a/docs/context-providers.md
+++ b/docs/context-providers.md
@@ -1,66 +1,71 @@
-[Previous Page](usage.md) | [Back to Documentation](README.md) | [Next Page](memory-tool-recommendations.md)
+[Предыдущая страница](usage.md) | [К документации](README.md) | [Следующая страница](memory-tool-recommendations.md)
 
-# Context Providers
+# Провайдеры Контекста
 
-AIFHub may use optional provider output as supporting context when a user has already produced or reviewed it. Providers help agents inspect a project or external documentation, but they do not become AIFHub dependencies, gates, canonical evidence, generated rules input, or runtime requirements.
+AIFHub может использовать optional provider output как supporting context, когда пользователь уже создал или проверил этот output. Providers помогают агентам исследовать проект или внешнюю документацию, но не становятся dependencies, gates, canonical evidence, generated rules input или runtime requirements для AIFHub.
 
-Provider availability is always degraded behavior: missing tools, missing reports, missing MCP servers, missing API credentials, or unsupported local runtimes must not fail `/aif-explore`, `/aif-plan`, `/aif-review`, `/aif-implement`, `/aif-verify`, `/aif-done`, or any other AIFHub command by themselves.
+Provider availability всегда является degraded behavior: отсутствующие tools, reports, MCP servers, API credentials или неподдерживаемые local runtimes сами по себе не должны ломать `/aif-explore`, `/aif-plan`, `/aif-review`, `/aif-implement`, `/aif-verify`, `/aif-done` или любую другую AIFHub command.
 
-## Provider Roles
+## Роли Providers
 
-Graphify is the optional repository architecture and relation-discovery provider. It can help identify dependencies, ownership paths, and impact areas before direct repository inspection.
+Graphify - optional provider для repository architecture и relation discovery. Он может помочь найти dependencies, ownership paths и impact areas перед прямой проверкой репозитория.
 
-Context7 is the optional documentation provider for current library/API docs. It can help reduce uncertainty around version-sensitive API behavior, framework migration details, and third-party usage patterns.
+Context7 - optional documentation provider для актуальных library/API docs. Он снижает неопределенность вокруг version-sensitive API behavior, framework migration details и third-party usage patterns.
 
-Both providers are supporting only. Final plans, review findings, generated rules, verification status, done status, and roadmap completion must remain source-grounded in canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules trace metadata, or other direct repository evidence.
+Оба provider являются только supporting context. Final plans, review findings, generated rules, verification status, done status и roadmap completion должны оставаться source-grounded в canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules trace metadata или другом direct repository evidence.
 
-## AIFHub Boundaries
+## Границы AIFHub
 
-AIFHub Extension must not:
+AIFHub Extension не должен:
 
-- install provider CLIs or packages, including `ctx7` or `@upstash/context7-mcp`;
-- run provider setup commands;
-- start or register provider MCP servers automatically;
-- add provider package dependencies or manifest dependencies;
-- add Context7 MCP templates to `extension.json`;
-- mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, agent skills, or runtime MCP settings for a provider;
-- turn provider availability into validation, verification, review, rules, security, done, or commit gates.
+- устанавливать provider CLIs или packages, включая `ctx7` или `@upstash/context7-mcp`;
+- запускать provider setup commands;
+- автоматически запускать или регистрировать provider MCP servers;
+- добавлять provider package dependencies или manifest dependencies;
+- добавлять Context7 MCP templates в `extension.json`;
+- менять `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, agent skills или runtime MCP settings для provider;
+- превращать provider availability в validation, verification, review, rules, security, done или commit gates.
 
-Future runtime features such as a `context_provider_suggestion` metadata field may recommend manual provider usage, but they must not change the user-owned setup boundary.
+Будущие runtime features вроде metadata field `context_provider_suggestion` могут рекомендовать manual provider usage, но не должны менять user-owned setup boundary.
 
-For installed-project diagnostics and metadata-driven recommendations, use:
+Для installed-project diagnostics и metadata-driven recommendations используйте:
 
 ```bash
 ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools select --from-project --command aif-explore --json
 ai-factory aifhub-memory-tools status --json
 ai-factory aifhub-memory-tools metadata --json
 ```
 
-The recommender reads only local installed metadata and must not fetch GitHub or the internet.
+Recommender читает только local installed metadata и не должен обращаться к GitHub или internet. Follow-on skills должны использовать `select`, а затем только returned `selected_tools`; project config хранит accepted provider ids в `utilities.context_tools.enabled`.
+
+## Защищенные Validation Artifacts
+
+Context и compression tools не должны rewrite validation artifacts и не должны compress protected artifacts in place. Protected validation artifacts: `aif-gate-result`, `coverage.json`, `done-readiness.json`, `openspec/specs/**`, generated-rules traces и exact evidence snippets.
 
 ## Context7
 
-Use Context7 only when current library/API documentation can materially reduce uncertainty. Common cases include framework version changes, package migration notes, deprecations, generated client APIs, or a review finding that depends on a third-party contract.
+Используйте Context7 только когда актуальная library/API documentation materially снижает неопределенность. Типовые случаи: framework version changes, package migration notes, deprecations, generated client APIs или review finding, который зависит от third-party contract.
 
-Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies, add Context7 MCP templates to `extension.json`, or start/register Context7 MCP automatically from AIFHub commands or sidecars.
+Не устанавливайте `ctx7` или `@upstash/context7-mcp`, не запускайте `ctx7`, не запускайте `ctx7 setup`, не добавляйте Context7 dependencies, не добавляйте Context7 MCP templates в `extension.json`, не запускайте и не регистрируйте Context7 MCP automatically из AIFHub commands или sidecars.
 
-Manual CLI usage is user-owned. Users may run Context7 with `npx`:
+Manual CLI usage принадлежит пользователю. Пользователь может запускать Context7 через `npx`:
 
 ```bash
 npx ctx7 library <name> <query>
 npx ctx7 docs <libraryId> <query>
 ```
 
-If the user already installed the CLI, the equivalent commands may be:
+Если CLI уже установлен пользователем, equivalent commands:
 
 ```bash
 ctx7 library <name> <query>
 ctx7 docs <libraryId> <query>
 ```
 
-The Context7 CLI requires a suitable local Node.js runtime. If `npx ctx7` or `ctx7` is unavailable, too old, unauthenticated, or rate-limited, AIFHub guidance should continue with degraded documentation context.
+Context7 CLI требует подходящий local Node.js runtime. Если `npx ctx7` или `ctx7` недоступен, слишком старый, unauthenticated или rate-limited, AIFHub guidance должен продолжить с degraded documentation context.
 
-Context7 library IDs can vary by source and version. Common examples include:
+Context7 library IDs могут зависеть от source и version. Примеры:
 
 - `/org/project`
 - `/org/project/version`
@@ -70,31 +75,31 @@ Context7 library IDs can vary by source and version. Common examples include:
 
 Treat exact IDs as provider output, not stable AIFHub schema.
 
-Context7 MCP setup is also user-owned. If a user has already configured a Context7 MCP server, agents may use available MCP tools as optional read-only documentation context. The usual lookup flow is `resolve-library-id` followed by a docs retrieval tool. The docs retrieval tool name may be `get-library-docs` or `query-docs` depending on the Context7 client/server version, so prompt guidance must tolerate both names.
+Context7 MCP setup тоже user-owned. Если пользователь уже настроил Context7 MCP server, agents могут использовать доступные MCP tools как optional read-only documentation context. Обычный lookup flow: `resolve-library-id`, затем docs retrieval tool. Docs retrieval tool может называться `get-library-docs` или `query-docs` в зависимости от версии Context7 client/server, поэтому prompt guidance должен поддерживать оба имени.
 
-Do not run `ctx7 setup`. That command may write files such as `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills. AIFHub guidance may mention this as user-owned setup, but AIFHub commands and sidecars must not execute it or mutate those files.
+Не запускайте `ctx7 setup`. Эта команда может писать `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules или agent skills. AIFHub guidance может упоминать это как user-owned setup, но AIFHub commands и sidecars не должны выполнять ее или менять эти files.
 
-Allowed durable storage for reviewed Context7 notes:
+Разрешенное durable storage для reviewed Context7 notes:
 
-- `.ai-factory/references/context7/` for project-wide documentation notes.
-- `.ai-factory/state/<change-id>/context7/` for change-scoped documentation notes.
+- `.ai-factory/references/context7/` для project-wide documentation notes.
+- `.ai-factory/state/<change-id>/context7/` для change-scoped documentation notes.
 
-A reviewed Context7 note should be concise and include the library name, resolved library ID when known, package version or docs version when known, query, retrieval date, source URL if available, and the short conclusion relevant to the AIFHub task.
+Reviewed Context7 note должен быть кратким и включать library name, resolved library ID если известен, package/docs version если известна, query, retrieval date, source URL если доступен, и короткий conclusion, relevant для AIFHub task.
 
-Forbidden storage for raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration:
+Forbidden storage для raw Context7 output, MCP transcripts, API responses, setup output или generated provider configuration:
 
 - `openspec/changes/<change-id>/`
 - `openspec/specs/`
 - `.ai-factory/rules/generated/`
 - `.ai-factory/qa/<change-id>/`
 
-Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules, or Context7 reference copies.
+Не persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics или unreviewed sensitive output в `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence, generated rules или Context7 reference copies.
 
 ## Graphify
 
-Graphify remains the optional repository research provider. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
+Graphify остается optional repository research provider. AIFHub Extension не требует Graphify, не устанавливает `graphifyy`, не запускает `graphify`, не добавляет Graphify в extension dependencies и не запускает или регистрирует Graphify MCP automatically.
 
-Manual Graphify usage, outside AIFHub command ownership:
+Manual Graphify usage вне AIFHub command ownership:
 
 ```powershell
 uv --version
@@ -103,13 +108,33 @@ graphify install
 graphify .
 ```
 
-Use `graphify .` in PowerShell; do not prefix it as `/graphify .`.
+В PowerShell используйте `graphify .`; не добавляйте prefix `/graphify .`.
 
-Allowed durable storage for reviewed Graphify context:
+Для private real roots предпочтительно запускать Graphify на sanitized temporary copy, если пользователь явно не принял local `graphify-out/` files в project root. Safety smoke от 2026-05-23 использовал `graphify update <temp-copy> --no-cluster` и не запускал semantic/LLM extraction.
 
-- `.ai-factory/references/graphify/` for project-wide reference copies.
-- `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime copies.
+Разрешенное durable storage для reviewed Graphify context:
 
-Do not store raw Graphify generated files such as `GRAPH_REPORT.md`, `graph.json`, or `graph.html` under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+- `.ai-factory/references/graphify/` для project-wide reference copies.
+- `.ai-factory/state/<change-id>/graphify/` для change-scoped runtime copies.
 
-See [Usage](usage.md) and [Context Loading Policy](context-loading-policy.md) for command-specific Graphify guidance.
+Не храните raw Graphify generated files вроде `GRAPH_REPORT.md`, `graph.json` или `graph.html` в `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/` или `.ai-factory/qa/<change-id>/`.
+
+См. [Usage](usage.md) и [Context Loading Policy](context-loading-policy.md) для command-specific Graphify guidance.
+
+## CodeGraph
+
+CodeGraph - manual CLI-only repo graph provider для broad analyze/explore questions. Local metadata фиксирует его как `manual_cli_only` с `suggest_manual_cli_for_repo_graph_when_enabled_or_explicit`.
+
+Allowed availability probes для AIFHub automation ограничены:
+
+```bash
+codegraph --version
+codegraph --help
+codegraph status
+```
+
+Manual safety testing 2026-05-23 проверил explicit-path CLI `init`, `index --quiet`, `status`, JSON `query` и `uninit --force` на 29 real local project roots без protected agent/config mutations и без leftover `.codegraph/` directories.
+
+`/aif-analyze` может рекомендовать CodeGraph, когда metadata показывает, что broad repo graph полезен. `/aif-explore` может использовать scoped CLI lifecycle только когда `select --command aif-explore --json` возвращает CodeGraph в `selected_tools` с `manual_purged_cli_execution`, и только с purge command из returned `execution` field перед завершением.
+
+AIFHub commands не должны auto-install CodeGraph, запускать `codegraph install`, запускать `codegraph sync`, запускать `codegraph serve --mcp`, mutate agent configuration, register MCP automatically или treat CodeGraph output as canonical OpenSpec evidence. Manual `init/index/query/uninit` разрешен только в `/aif-explore` с explicit path, command-specific permission и purge.

--- a/docs/memory-tool-recommendations.md
+++ b/docs/memory-tool-recommendations.md
@@ -1,70 +1,122 @@
-[Previous Page](context-providers.md) | [Back to Documentation](README.md) | [Next Page](context-loading-policy.md)
+[Предыдущая страница](context-providers.md) | [К документации](README.md) | [Следующая страница](context-loading-policy.md)
 
-# Memory Tool Recommendations
+# Рекомендации По Memory Tools
 
-AIFHub uses local recommendation metadata to suggest optional memory and context tools during analysis. The metadata lives in the installed extension, not on GitHub:
+AIFHub использует локальную metadata рекомендаций, чтобы во время анализа предлагать optional memory и context tools. Metadata живет в установленном extension, а не на GitHub:
 
 ```text
 .ai-factory/extensions/aifhub-extension/docs/memory-tools-research/recommendation-metadata.yaml
 ```
 
-When developing this extension itself, the source-tree copy under `docs/memory-tools-research/recommendation-metadata.yaml` may be used.
+При разработке самого extension можно использовать source-tree копию:
 
-## Commands
+```text
+docs/memory-tools-research/recommendation-metadata.yaml
+```
 
-Installed projects should use the wrapper command:
+## Команды
+
+Установленные проекты должны использовать wrapper command:
 
 ```bash
 ai-factory aifhub-memory-tools recommend --from-project --json
 ai-factory aifhub-memory-tools recommend --shape large_framework_app --task architecture_or_impact_discovery --json
+ai-factory aifhub-memory-tools select --from-project --command aif-explore --json
+ai-factory aifhub-memory-tools select --from-project --command aif-plan --json
 ai-factory aifhub-memory-tools status --json
 ai-factory aifhub-memory-tools metadata --json
 ```
 
-The wrapper resolves scripts from the installed extension and keeps the user project as the working directory.
+Wrapper находит scripts из установленного extension и оставляет рабочей директорией пользовательский проект.
 
-## Rules
+## Правила
 
-The recommender is advisory only:
+Recommender только советует:
 
-- `rg` remains the baseline for exact file and symbol lookup.
-- Tools are explicit opt-in only.
-- Missing tools are degraded context, not command failure.
-- Provider output is supporting context only, never canonical OpenSpec evidence.
-- AIFHub must not auto-install tools, run setup, index source, sync memory, register MCP servers, install hooks, start daemons, or write provider output.
+- `rg` остается baseline для точного поиска файлов и symbols.
+- Инструменты включаются только через explicit opt-in.
+- Отсутствующие tools означают degraded context, а не failure команды.
+- Provider output является только supporting context, никогда canonical OpenSpec evidence.
+- AIFHub не должен auto-install tools, запускать setup, индексировать source, sync memory, register MCP servers, install hooks, start daemons или записывать provider output.
+- Если metadata содержит поля, рекомендации включают allowed command scopes, forbidden command scopes, command-specific permission, privacy caveat, read scope, purge path, availability и explicit opt-in install policy.
+- Context/compression tools не должны rewrite validation artifacts и не должны compress protected artifacts in place.
+- `/aif-analyze` записывает только user-accepted tool ids в `utilities.context_tools.enabled`.
+- Follow-on skills вызывают `select` для своей команды и используют только `selected_tools`; изменение списка tools должно требовать metadata/config changes, а не prompt rewrites.
 
-## Tool Decisions
+Protected validation artifacts:
 
-Allowed recommendations:
+- `aif-gate-result`
+- `coverage.json`
+- `done-readiness.json`
+- `openspec/specs/**`
+- generated-rules traces
+- exact evidence snippets
+
+## Решения По Tools
+
+Разрешенные рекомендации:
 
 - `rg`: baseline search.
-- Graphify: optional repo graph for large framework, legacy, and multirepo impact discovery after baseline `rg`.
-- `codex-agent-mem`: optional read-only continuity memory with an explicit SQLite DB path.
-- `context-mode`: manual temporary index for explicit generated output or large command output.
-- Context7: optional docs provider for version-sensitive library/API questions.
-- `agent-memory`: manual notes only when the user explicitly asks for durable notes.
+- Graphify: optional repo graph для large framework, legacy и multirepo impact discovery после baseline `rg`.
+- `codex-agent-mem`: optional read-only continuity memory с explicit SQLite DB path.
+- `context-mode`: manual temporary index для explicit generated output или large command output.
+- Context7: optional docs provider для version-sensitive library/API questions.
+- `agent-memory`: manual notes только когда пользователь явно просит durable notes.
+- CodeGraph: `manual_cli_only` / `suggest_manual_cli_for_repo_graph_when_enabled_or_explicit`; CLI scoped read и purge прошли explicit real-root testing. `/aif-analyze` может рекомендовать его для broad repo graph questions, а `/aif-explore` может использовать его только когда command-specific `select` output возвращает его в `selected_tools`.
 
-Not recommended by default:
+Не рекомендовать по умолчанию:
 
-- `codex-mem`: default scope may ingest broad Codex history.
-- `eagle-mem`: scoped read and purge behavior is not proven.
+- `codex-mem`: default scope может ingest broad Codex history.
+- `eagle-mem`: scoped read и purge behavior не доказаны.
 
-## Safe Status Probes
+AIFHub по-прежнему не принимает CodeGraph `install`, MCP serving, hooks/background services или agent configuration mutation.
 
-`ai-factory aifhub-memory-tools status --json` may run only local, non-mutating probes:
+## Безопасные Status Probes
+
+`ai-factory aifhub-memory-tools status --json` может запускать только локальные non-mutating probes:
 
 - `rg --version`
 - `uv --version`
-- `graphify --version` or `graphify --help`
-- `codex-agent-mem-policy --help` or `codex-agent-mem-smoke --help`
+- `graphify --version` или `graphify --help`
+- `codex-agent-mem-policy --help` или `codex-agent-mem-smoke --help`
 - `context-mode doctor`
-- `ctx7 --version` or `npx --no-install ctx7 --help` only when `--check-docs-provider` is passed
+- `ctx7 --version` или `npx --no-install ctx7 --help` только когда передан `--check-docs-provider`
+- `codegraph --version`, `codegraph --help` или `codegraph status` только как availability probes
 
-These probes must not install packages, create indexes, run setup, register MCP servers, write hooks, or start background processes.
+Эти probes не должны install packages, run setup, register MCP servers, write hooks или start background processes. `codegraph init/index/query/uninit` разрешен только когда `select --command aif-explore --json` возвращает CodeGraph в `selected_tools` с `manual_purged_cli_execution`, explicit project path и purge через `codegraph uninit --force <project>`.
 
-## Analyze Output
+## Выбор Через Config
 
-`/aif-analyze` should summarize recommendations like this:
+`/aif-analyze` должен классифицировать текущий проект, запустить `recommend`, спросить пользователя, какие рекомендации включить, и сохранить accepted tool ids в config:
+
+```yaml
+utilities:
+  context_tools:
+    enabled:
+      - codegraph
+      - graphify
+```
+
+Compatibility flags вроде `utilities.graphify.enabled: true` и `utilities.codegraph.enabled: true` все еще читаются командой `select`, но стабильный provider list - это `utilities.context_tools.enabled`.
+
+Во время выполнения skill используйте command-specific selection:
+
+```bash
+ai-factory aifhub-memory-tools select --from-project --command aif-explore --json
+ai-factory aifhub-memory-tools select --from-project --command aif-plan --json
+```
+
+Selection output включает `selected_tools`, `not_selected_tools`, `permission`, `execution`, `forbidden_operations` и `protected_artifacts`. Metadata output включает такое же per-tool execution guidance, чтобы `/aif-analyze` мог показать доступные параметры без hard-code конкретного provider. Skill не должен использовать configured tools, которых нет в `selected_tools`.
+
+## Evidence На Реальных Проектах
+
+Follow-up smoke от 2026-05-23 использовал пять real local project roots, записанных только как anonymous profiles. `rg` был единственным default tool, который напрямую читал source. Graphify запускался AST-only на temporary copies; memory/context tools использовали isolated temp DB/data dirs и anonymous marker notes.
+
+Позже CodeGraph был установлен по явному запросу пользователя и проверен на 29 real local project roots через `init`, `index --quiet`, `status`, JSON `query` и `uninit --force`. Lifecycle прошел на всех 29 roots без protected agent/config mutations и без оставшихся `.codegraph/` directories. Принятая рекомендация - manual CLI-only; `install`/MCP/agent-config behavior все еще не принят для AIFHub automation.
+
+## Вывод Анализа
+
+`/aif-analyze` должен кратко суммировать рекомендации так:
 
 ```text
 Optional local tools:
@@ -76,7 +128,7 @@ Recommended:
 - Graphify: useful for broad architecture/impact discovery in this large framework project.
   Status: installed/not installed/unknown
   Read scope: explicit project path
-  Purge: delete graphify-out/
+  Очистка: delete graphify-out/
   Note: supporting context only, not OpenSpec evidence.
 
 Not recommended:
@@ -84,4 +136,4 @@ Not recommended:
 - eagle-mem: scoped read and purge not proven.
 ```
 
-If metadata is unavailable, `/aif-analyze` should report a degraded note and continue with `rg` as the baseline.
+Если metadata недоступна, `/aif-analyze` должен сообщить degraded note и продолжить с `rg` как baseline.

--- a/docs/memory-tools-research/README.md
+++ b/docs/memory-tools-research/README.md
@@ -1,4 +1,4 @@
-# Research по Memory Tools
+# Research По Memory Tools
 
 Этот каталог фиксирует выводы по инструментам локальной памяти и retrieval для issue #85. Документы описывают результаты установки и полевых проверок без названий приватных проектов.
 
@@ -6,11 +6,12 @@
 
 Файл [recommendation-metadata.yaml](recommendation-metadata.yaml) содержит machine-readable правила для analysis-этапа. Его можно читать при анализе проекта и превращать project signals в предложение пользователю:
 
-- если проект выглядит как `multirepo`, предложить `Graphify` как optional repo graph для surface mapping;
+- если проект выглядит как `multirepo` или large framework, предложить `Graphify` или `CodeGraph` как optional repo graph для broad architecture/impact mapping;
 - если задача про resume/open work между сессиями, предложить `codex-agent-mem` в read-only MCP mode с explicit DB path;
 - если задача про большой command output, предложить `context-mode` как temporary manual helper с обязательным purge;
 - если проект маленький или нужен точный file/symbol lookup, оставить baseline `rg`;
 - `codex-mem` и `eagle-mem` не предлагать по умолчанию из-за scope/privacy risks.
+- `CodeGraph` можно предлагать только как `manual_cli_only` для `/aif-analyze` и использовать в `/aif-explore` только когда `select --command aif-explore --json` возвращает его в `selected_tools` с purge-командой; `install`/MCP/agent-config surface не принят.
 
 Эта meta не разрешает auto-install. Любой инструмент из списка должен предлагаться пользователю только как explicit opt-in с объяснением read scope, purge path и privacy tradeoff.
 
@@ -41,7 +42,7 @@
    - Stable CLI: `--help`, `--version` или ближайшая безопасная команда.
    - MCP: `tools/list` и минимальные read-only calls, если MCP заявлен.
    - Read scope: только explicit temp path, explicit DB или explicit indexed content.
-   - Purge: удалить index/DB/sidecar files или вызвать documented purge command.
+   - Очистка: удалить index/DB/sidecar files или вызвать documented purge command.
    - Privacy: не читать global history, user home, hooks или real source root без явного opt-in.
 
 6. Проверить функциональные сценарии.
@@ -69,7 +70,9 @@
 
 ## Сводка
 
-| Tool | Repository | Tested Version | Где подходит | Решение |
+README содержит только общую сводку и итоговую рекомендацию. Датированные результаты тестирования, anonymous profile таблицы, safety evidence и выводы по конкретному инструменту находятся в файле этого инструмента.
+
+| Tool | Repository | Проверенная версия | Где подходит | Решение |
 |---|---|---:|---|---|
 | [Graphify](graphify.md) | [safishamsi/graphify](https://github.com/safishamsi/graphify) | `graphifyy 0.8.14` | Repo graph / architecture / impact discovery. Не memory. | Оставить как optional guidance для больших/legacy/multirepo проектов. |
 | [codex-agent-mem](codex-agent-mem.md) | [MarceloCaporale/codex-agent-mem](https://github.com/MarceloCaporale/codex-agent-mem) | `1.0.2` | Cross-session continuity, open work, closure checks, compact context packs. | Основной кандидат для optional read-only continuity memory. |
@@ -77,6 +80,7 @@
 | [codex-mem](codex-mem.md) | package не содержит repository metadata; ближайший проверенный публичный repo: [Just-Boring-Cat/codex-mem](https://github.com/Just-Boring-Cat/codex-mem) | `0.1.1` | Codex session/history memory. | Reject as default; privacy risk без строгой изоляции. |
 | [agent-memory](agent-memory.md) | [jayzeng/agentmemory](https://github.com/jayzeng/agentmemory) | `myagentmemory 0.4.12` | Manual markdown memory. | Docs-only/manual notes, без интеграции. |
 | [eagle-mem](eagle-mem.md) | [eagleisbatman/eagle-mem](https://github.com/eagleisbatman/eagle-mem) | `4.9.10` | Shared memory + hooks + guardrails + lanes. | Reject/defer; слишком широкий surface для issue #85. |
+| [CodeGraph](codegraph.md) | [colbymchenry/codegraph](https://github.com/colbymchenry/codegraph) | `@colbymchenry/codegraph 0.9.3` | Manual CLI-only repo graph для broad analyze/explore questions. | `manual_cli_only`; scoped CLI read/purge verified, но `install`/MCP/agent-config surface не принят. |
 
 ## Итоговая Рекомендация
 
@@ -89,5 +93,8 @@
 - `Graphify` можно документировать как optional repo-graph provider для исследования больших кодовых баз.
 - `context-mode` может остаться manual helper для temporary indexing больших command outputs.
 - `codex-mem`, `agent-memory` и `eagle-mem` не должны становиться default AIFHub integrations.
+- `CodeGraph` можно рекомендовать из `/aif-analyze` как manual CLI-only opt-in и использовать из `/aif-explore` только когда selection CLI возвращает его в `selected_tools`; `install`/MCP/agent-config surface не принят.
 
 Любая будущая реализация должна требовать explicit opt-in, explicit local paths, отсутствие global hooks по умолчанию, отсутствие canonical OpenSpec writes, отсутствие зависимости от install path и документированный purge/delete-index path.
+
+Compression/context helpers не должны rewrite validation artifacts. Protected validation artifacts включают `aif-gate-result`, `coverage.json`, `done-readiness.json`, OpenSpec specs under `openspec/specs/**`, generated-rules traces и exact evidence snippets. Optional tools не должны compress protected artifacts in place.

--- a/docs/memory-tools-research/agent-memory.md
+++ b/docs/memory-tools-research/agent-memory.md
@@ -1,10 +1,10 @@
 # agent-memory
 
-Package: `myagentmemory 0.4.12`
+Пакет: `myagentmemory 0.4.12`
 
-Repository: [jayzeng/agentmemory](https://github.com/jayzeng/agentmemory)
+Репозиторий: [jayzeng/agentmemory](https://github.com/jayzeng/agentmemory)
 
-Repository README говорит, что `agentmemory` - canonical GitHub repository для `agent-memory` CLI, published as `myagentmemory` on npm.
+README репозитория говорит, что `agentmemory` - canonical GitHub repository для `agent-memory` CLI, опубликованный как `myagentmemory` в npm.
 
 ## Мета Для Анализа
 
@@ -80,11 +80,11 @@ Usable MCP server не найден.
 
 Тесты использовали только explicit temp paths. Dependency install для cloned repo выполнялся через `bun install --ignore-scripts`, потому что package `postinstall` настраивает `git config core.hooksPath .githooks`, если запускается внутри git repository.
 
-### Upstream Tests
+### Upstream Тесты
 
-| Test Command | Result | Notes |
+| Test Command | Результат | Заметки |
 |---|---:|---|
-| `bun test test/unit.test.ts` | 139 passed / 0 failed | Core memory, scratchpad, qmd mocks, distil, parser utilities passed. |
+| `bun test test/unit.test.ts` | 139 passed / 0 failed | Core memory, scratchpad, qmd mocks, distil и parser utilities прошли. |
 | `bun test test/cli.test.ts` | 41 passed / 3 failed | Failures были Windows/environment-specific вокруг skill install detection и shell script execution. |
 | `bun run build` | PASS | TypeScript `--noEmit` check passed. |
 | `bun run build:cli` | PASS | Собран `dist\agent-memory.exe`; `version` и `--help` работали. |
@@ -100,7 +100,7 @@ Manual skill install/uninstall через CLI работал, когда при�
 
 Smoke test использовал explicit temp memory directory через `--dir`.
 
-| Operation | Time | Result |
+| Операция | Время | Результат |
 |---|---:|---|
 | `init --json` | 195.4 ms | Created memory dir; qmd disabled |
 | `write --target long_term` | 147.3 ms | Wrote `MEMORY.md` |
@@ -133,7 +133,7 @@ Shared controlled result: `init`, long-term write, topic write, scratchpad add �
 
 Проверка выполнялась как manual markdown memory. Для каждого профиля использовался отдельный temp `--dir`; source files не индексировались. `search` проверялся только для фиксации `qmd` limitation.
 
-| Profile | Shape | Init | Write | Context | Search | qmd | Memory Size | Purge | Decision |
+| Profile | Shape | Init | Write | Context | Search | qmd | Memory Size | Очистка | Решение |
 |---|---|---:|---:|---:|---:|---|---:|---|---|
 | R2026-05-22-P01 | `go_service` | 122 ms | 109 ms | 132 ms | 100 ms | missing | 323 B | PASS | Manual notes only. |
 | R2026-05-22-P02 | `large_framework_app` | 122 ms | 118 ms | 121 ms | 107 ms | missing | 332 B | PASS | Manual notes only. |
@@ -151,15 +151,29 @@ Shared controlled result: `init`, long-term write, topic write, scratchpad add �
 
 Вывод по этому прогону: project shape не влияет на ценность tool, потому что это manual note directory. Без `qmd` нет usable retrieval. Рекомендация остаётся docs-only/manual notes.
 
-## Scope И Privacy
+## Локальный Прогон На Real Project Roots (2026-05-23)
+
+Проверка выполнялась как manual markdown memory с отдельным temp `--dir` на каждый profile. Source files не индексировались. Команды запускались в форме `agent-memory <command> --dir <path> --json`; важный CLI caveat - если поставить `--dir` перед command, CLI печатает help и может завершиться без полезной операции, поэтому smoke должен проверять marker/file content, а не только exit code.
+
+| Profile | Shape | Init | Write | Read | Context | Status | Marker Found | Решение |
+|---|---|---:|---:|---:|---:|---:|---|---|
+| real-profile-01 | `large_legacy_web_app` | 123 ms | 124 ms | 128 ms | 306 ms | 113 ms | yes | Manual notes only. |
+| real-profile-02 | `go_service` | 94 ms | 99 ms | 116 ms | 94 ms | 98 ms | yes | Manual notes only. |
+| real-profile-03 | `large_framework_app` | 97 ms | 100 ms | 94 ms | 96 ms | 98 ms | yes | Manual notes only. |
+| real-profile-04 | `multi_app_workspace` | 97 ms | 99 ms | 147 ms | 99 ms | 131 ms | yes | Manual notes only. |
+| real-profile-05 | `small_microservice` | 100 ms | 119 ms | 106 ms | 96 ms | 110 ms | yes | Manual notes only. |
+
+Вывод не меняется: tool быстрый и пригоден как local markdown notebook, но это не project retrieval provider и он не оправдывает AIFHub integration.
+
+## Границы И Privacy
 
 Explicit `--dir` - хороший механизм. Он ограничивает storage выбранной memory directory и не требует project-source indexing.
 
-Risk comes from optional skills/global setup, `postinstall` hook behavior и semantic search dependencies. Эти варианты не приняты как default integration behavior.
+Риск связан с optional skills/global setup, `postinstall` hook behavior и semantic search dependencies. Эти варианты не приняты как default integration behavior.
 
-## Purge
+## Очистка
 
-Purge - удалить выбранную memory directory или файлы. Для controlled manual-memory case отдельная purge command не нужна.
+Очистка - удалить выбранную memory directory или файлы. Для controlled manual-memory case отдельная purge command не нужна.
 
 ## Вывод
 

--- a/docs/memory-tools-research/codegraph.md
+++ b/docs/memory-tools-research/codegraph.md
@@ -1,0 +1,153 @@
+# CodeGraph
+
+Репозиторий: [colbymchenry/codegraph](https://github.com/colbymchenry/codegraph)
+
+Проверенный package: `@colbymchenry/codegraph 0.9.3`; установлен global по явному запросу пользователя и протестирован 2026-05-23.
+
+## Мета Для Анализа
+
+```yaml
+tool_id: codegraph
+decision: manual_cli_only
+recommendation_action: suggest_manual_cli_for_repo_graph_when_enabled_or_explicit
+role: manual_cli_repo_graph_provider
+install_policy: explicit_user_opt_in_only
+read_scope: explicit_project_path_verified_for_cli_init_index_status_query
+purge_path: codegraph_uninit_force_verified
+recommend_when:
+  project_shapes:
+    - multirepo
+    - large_framework_app
+  tasks:
+    - architecture_or_impact_discovery
+    - multirepo_surface_mapping
+do_not_recommend_when:
+  tasks:
+    - implementation
+    - validation_gate
+    - exact_file_or_symbol_lookup
+analysis_hint: "Scoped CLI init/index/status/query/uninit worked on real local roots. /aif-analyze may recommend it as manual CLI-only; follow-on skills may use it only when the selection CLI returns it for that command and then purge it."
+```
+
+## Что Это
+
+CodeGraph - local code knowledge graph tool для AI agents. Public docs описывают repository indexing в local SQLite graph, symbol/call/impact queries, MCP tools и agent configuration support для Claude Code, Cursor, Codex CLI, OpenCode и Hermes Agent.
+
+## Решение AIFHub
+
+Использовать CodeGraph как `manual_cli_only`, а не как automatic provider.
+
+Scoped CLI safety criterion теперь выполнен для explicit, user-requested local runs:
+
+- `codegraph init <project>` и `codegraph index --quiet <project>` остались scoped to explicit project path;
+- `codegraph status <project>` и `codegraph query --path <project> --json` работали после indexing;
+- `codegraph uninit --force <project>` удалил `.codegraph/`;
+- protected agent/config files не изменились во время run.
+
+`/aif-analyze` может рекомендовать CodeGraph для broad repo graph questions и записывать accepted id в `utilities.context_tools.enabled` только после user approval. `/aif-explore` может запускать scoped CLI lifecycle только когда `ai-factory aifhub-memory-tools select --from-project --command aif-explore --json` возвращает CodeGraph в `selected_tools`, и только если команда может purge project-local `.codegraph/` перед завершением.
+
+AIFHub все еще не должен install или register CodeGraph автоматически, потому что более широкий lifecycle surface не принят: `codegraph install`, MCP serving, agent configuration mutation, hooks/background behavior и long-term provider-output storage остаются вне approved integration contract.
+
+## Границы
+
+Не делать:
+
+- auto-install CodeGraph;
+- run `codegraph install`, `codegraph sync`, `codegraph serve`, `codegraph serve --mcp`, agent configuration commands, hooks или background services;
+- run `codegraph init` или `codegraph index` из AIFHub commands, кроме `/aif-explore` с `manual_purged_cli_execution`, explicit project path и guaranteed purge;
+- mutate `.mcp.json`, `.codex/config.toml`, `.cursor/`, `.opencode.json`, `AGENTS.md`, `CLAUDE.md` или agent permission files;
+- use CodeGraph output as OpenSpec evidence, generated rules input, QA evidence, verify/done gate evidence или replacement for `rg`.
+
+## Локальные CLI Probes (2026-05-23)
+
+| Проверка | Результат | Решение |
+|---|---|---|
+| `codegraph --version` | `0.9.3` | CLI доступен. |
+| `codegraph --help` | PASS | Command surface проверен. |
+| `codegraph status <project>` до init | PASS; сообщает, что project не initialized | Safe non-mutating availability/status check. |
+| `codegraph init --index <temp-copy>` | PASS | Создает только project-local `.codegraph/`. |
+| `codegraph query --path <temp-copy> --limit 5 --json "message"` | PASS | Возвращает JSON results после indexing. |
+| `codegraph files --path <temp-copy> --json` | PASS | Возвращает indexed file list после indexing. |
+| `codegraph uninit --force <temp-copy>` | PASS | Удаляет `.codegraph/`. |
+
+Temp-copy smoke использовал sanitized copy одного local service root. Generated `.codegraph/` directory был удален через `uninit`; temp path, project name, snippets и query output не сохраняются в docs.
+
+## Прогон На Real Project Roots (2026-05-23)
+
+Follow-up run покрыл 29 real local project roots, выбранных как git roots или top-level marker roots внутри project folders, которые запросил пользователь. Nested vendor/template/cache/config directories исключались как non-project roots. Документация хранит только aggregate counts и anonymous local ids; реальные project names, local paths, snippets, query output и temp paths исключены.
+
+Command sequence для каждого root:
+
+```bash
+codegraph init <project>
+codegraph index --quiet <project>
+codegraph status <project>
+codegraph query --path <project> --limit 3 --json main
+codegraph uninit --force <project>
+```
+
+Сводка:
+
+| Проверка | Результат |
+|---|---:|
+| Проверено project roots | 29 |
+| Полный command lifecycle прошел | 29 |
+| Command failures | 0 |
+| Query failures | 0 |
+| Protected agent/config mutations | 0 |
+| Оставшиеся `.codegraph/` directories после `uninit` | 0 |
+| Диапазон index latency | 583-25,077 ms |
+| Средняя index latency | 6,261 ms |
+| Диапазон transient index DB size | 0.13-32.65 MB |
+| Общий transient index DB size до purge | 177.11 MB |
+| Roots без recognized source nodes | 3 |
+
+Protected file snapshot включал root-level `.mcp.json`, `.codex/config.toml`, `.codex/hooks.json`, `.cursor/mcp.json`, `.cursor/settings.json`, `.opencode.json`, `opencode.json`, `AGENTS.md` и `CLAUDE.md`.
+
+Anonymous per-root results:
+
+| Profile | Lifecycle | Index Time | Transient DB | Очистка | Notes |
+|---|---|---:|---:|---|---|
+| cg-root-01 | PASS | 679 ms | 0.13 MB | PASS | Нет recognized source nodes. |
+| cg-root-02 | PASS | 1,776 ms | 4.41 MB | PASS | JSON query вернул results. |
+| cg-root-03 | PASS | 1,683 ms | 2.17 MB | PASS | JSON query вернул results. |
+| cg-root-04 | PASS | 25,077 ms | 11.36 MB | PASS | Самый медленный root. |
+| cg-root-05 | PASS | 1,868 ms | 3.97 MB | PASS | JSON query вернул results. |
+| cg-root-06 | PASS | 6,833 ms | 9.76 MB | PASS | JSON query вернул results. |
+| cg-root-07 | PASS | 805 ms | 0.72 MB | PASS | JSON query вернул results. |
+| cg-root-08 | PASS | 10,723 ms | 12.57 MB | PASS | JSON query вернул results. |
+| cg-root-09 | PASS | 22,314 ms | 32.65 MB | PASS | Самая большая transient DB. |
+| cg-root-10 | PASS | 6,991 ms | 3.82 MB | PASS | JSON query вернул results. |
+| cg-root-11 | PASS | 1,474 ms | 2.02 MB | PASS | JSON query вернул results. |
+| cg-root-12 | PASS | 583 ms | 0.13 MB | PASS | Нет recognized source nodes. |
+| cg-root-13 | PASS | 783 ms | 0.13 MB | PASS | Нет recognized source nodes. |
+| cg-root-14 | PASS | 2,313 ms | 1.85 MB | PASS | JSON query вернул results. |
+| cg-root-15 | PASS | 11,648 ms | 15.32 MB | PASS | JSON query вернул results. |
+| cg-root-16 | PASS | 22,664 ms | 14.18 MB | PASS | Второй самый медленный root. |
+| cg-root-17 | PASS | 10,923 ms | 9.35 MB | PASS | JSON query вернул results. |
+| cg-root-18 | PASS | 1,355 ms | 1.48 MB | PASS | JSON query вернул results. |
+| cg-root-19 | PASS | 20,753 ms | 11.95 MB | PASS | JSON query вернул results. |
+| cg-root-20 | PASS | 13,201 ms | 14.31 MB | PASS | JSON query вернул results. |
+| cg-root-21 | PASS | 2,663 ms | 4.33 MB | PASS | JSON query вернул results. |
+| cg-root-22 | PASS | 1,864 ms | 2.89 MB | PASS | JSON query вернул results. |
+| cg-root-23 | PASS | 665 ms | 0.20 MB | PASS | JSON query вернул results. |
+| cg-root-24 | PASS | 1,186 ms | 1.81 MB | PASS | JSON query вернул results. |
+| cg-root-25 | PASS | 4,114 ms | 6.41 MB | PASS | JSON query вернул results. |
+| cg-root-26 | PASS | 2,676 ms | 7.08 MB | PASS | JSON query вернул results. |
+| cg-root-27 | PASS | 982 ms | 1.30 MB | PASS | JSON query вернул results. |
+| cg-root-28 | PASS | 790 ms | 0.43 MB | PASS | JSON query вернул results. |
+| cg-root-29 | PASS | 2,191 ms | 0.36 MB | PASS | JSON query вернул results. |
+
+## Очистка
+
+Accepted purge для explicit user-owned CLI experiments:
+
+```bash
+codegraph uninit --force <project>
+```
+
+Real-root run подтвердил, что команда удаляет `.codegraph/` для roots, где не было pre-existing CodeGraph index. Если root уже содержит user-owned `.codegraph/`, не delete и не reinitialize его silently.
+
+## Вывод
+
+CodeGraph CLI scoped read и purge verified для explicit local experiments. Принятая AIFHub integration - manual CLI-only: `/aif-analyze` может рекомендовать его для broad graph questions, а `/aif-explore` может использовать его только когда selection CLI возвращает его в `selected_tools`, с `codegraph uninit --force <project>` before completion. `codegraph install`, MCP и agent-config mutation остаются rejected.

--- a/docs/memory-tools-research/codex-agent-mem.md
+++ b/docs/memory-tools-research/codex-agent-mem.md
@@ -1,8 +1,8 @@
 # codex-agent-mem
 
-Repository: [MarceloCaporale/codex-agent-mem](https://github.com/MarceloCaporale/codex-agent-mem)
+Репозиторий: [MarceloCaporale/codex-agent-mem](https://github.com/MarceloCaporale/codex-agent-mem)
 
-Tested package: `codex-agent-mem 1.0.2`.
+Проверенный package: `codex-agent-mem 1.0.2`.
 
 ## Мета Для Анализа
 
@@ -79,13 +79,13 @@ Live MCP calls заняли 411 ms total для session list, bootstrap context,
 
 ## Результаты Тестов
 
-| Check | Result |
+| Проверка | Результат |
 |---|---|
 | Stable CLI | PASS |
 | MCP `tools/list` | PASS |
 | Read-only mode | PASS |
 | Explicit DB path | PASS |
-| Purge/delete index | PASS через удаление SQLite DB |
+| Очистка/delete index | PASS через удаление SQLite DB |
 | Private code indexing risk | Low в read-only continuity mode |
 | Token output | Compact context pack reported `pack_tokens=130` |
 
@@ -109,7 +109,7 @@ Shared controlled result: smoke DB работал за 794.4 ms, live read-only 
 
 Проверка выполнялась как continuity smoke, а не source indexing. Для каждого профиля создавалась отдельная temp SQLite DB; MCP запускался в `--read-only --profile minimal` mode. Source files не индексировались.
 
-| Profile | Shape | Smoke | MCP Calls | Tools | DB Size | Pack Tokens | Privacy/Purge | Decision |
+| Profile | Shape | Smoke | MCP Calls | Tools | DB Size | Pack Tokens | Privacy/Очистка | Решение |
 |---|---|---:|---:|---:|---:|---:|---|---|
 | R2026-05-22-P01 | `go_service` | 1.7 s | 839 ms | 7 | 208.0 KB | n/a | explicit DB; purge PASS | Optional только для continuity. |
 | R2026-05-22-P02 | `large_framework_app` | 1.3 s | 1.0 s | 7 | 208.0 KB | n/a | explicit DB; purge PASS | Optional только для continuity. |
@@ -127,7 +127,21 @@ Shared controlled result: smoke DB работал за 794.4 ms, live read-only 
 
 Вывод по этому прогону: project shape почти не влияет, потому что tool не читает source. Рекомендация остаётся прежней: предлагать только если нужна continuity между сессиями и есть explicit DB path.
 
-## Scope И Privacy
+## Локальный Прогон На Real Project Roots (2026-05-23)
+
+Проверка выполнялась как continuity smoke с отдельной temp SQLite DB на каждый anonymous profile. Real source files не индексировались; `project_key` был anonymous id.
+
+| Profile | Shape | Smoke | DB Created | Source Indexed | Результат | Решение |
+|---|---|---:|---|---|---|---|
+| real-profile-01 | `large_legacy_web_app` | 684 ms | yes | no | PASS | Optional only for continuity/open work. |
+| real-profile-02 | `go_service` | 510 ms | yes | no | PASS | Optional only for continuity/open work. |
+| real-profile-03 | `large_framework_app` | 493 ms | yes | no | PASS | Optional only for continuity/open work. |
+| real-profile-04 | `multi_app_workspace` | 484 ms | yes | no | PASS | Optional only for continuity/open work. |
+| real-profile-05 | `small_microservice` | 951 ms | yes | no | PASS | Usually unnecessary unless session continuity matters. |
+
+Вывод не изменился: tool безопасно работает с explicit DB path, но он не помогает initial code discovery. Для поиска по коду baseline остаётся `rg`, для broad repo graph - optional Graphify.
+
+## Границы И Privacy
 
 Safe configuration использует:
 
@@ -140,7 +154,7 @@ Safe configuration использует:
 
 Избегать default/global setup, пока пользователь явно не opt-in. Bootstrap был safe в trial, потому что он печатал config snippet и не мутировал Codex config automatically.
 
-## Purge
+## Очистка
 
 Практический purge path - удалить configured SQLite DB и sidecar files, если они есть:
 

--- a/docs/memory-tools-research/codex-mem.md
+++ b/docs/memory-tools-research/codex-mem.md
@@ -1,6 +1,6 @@
 # codex-mem
 
-Package: `codex-mem 0.1.1`
+Пакет: `codex-mem 0.1.1`
 
 Package metadata не содержит repository URL. Ближайший публичный repository, проверенный во время research: [Just-Boring-Cat/codex-mem](https://github.com/Just-Boring-Cat/codex-mem), но installed npm package сам не доказывает связь с этим repository.
 
@@ -47,7 +47,7 @@ MCP exposed 8 tools:
 - `recent_sessions`
 - `build_context`
 
-## Isolated Test Results
+## Результаты Изолированных Тестов
 
 С правильной explicit isolation:
 
@@ -55,9 +55,9 @@ MCP exposed 8 tools:
 - `CODEX_MEM_DATA_DIR` указывал на temp data dir.
 - `CODEX_MEM_DB_PATH` указывал на temp SQLite DB.
 
-Results:
+Результаты:
 
-| Operation | Time |
+| Операция | Время |
 |---|---:|
 | `save` manual note | 413.4 ms |
 | `search` manual note | 392.1 ms |
@@ -85,7 +85,7 @@ Shared controlled result: explicit isolated manual note save/search/stats сра
 
 Проверка выполнялась только в full isolation: отдельные `CODEX_HOME`, `CODEX_MEM_DATA_DIR` и `CODEX_MEM_DB_PATH` на профиль. `sync` не запускался, глобальная Codex history не читалась.
 
-| Profile | Shape | Save | Search | Stats | DB Size | Found | Purge | Decision |
+| Profile | Shape | Save | Search | Stats | DB Size | Found | Очистка | Решение |
 |---|---|---:|---:|---:|---:|---|---|---|
 | R2026-05-22-P01 | `go_service` | 421 ms | 394 ms | 384 ms | 56.0 KB | yes | PASS | Safe only with full isolation; reject default. |
 | R2026-05-22-P02 | `large_framework_app` | 531 ms | 395 ms | 406 ms | 56.0 KB | yes | PASS | Safe only with full isolation; reject default. |
@@ -103,7 +103,21 @@ Shared controlled result: explicit isolated manual note save/search/stats сра
 
 Вывод по этому прогону: isolated manual-note mode работает стабильно, но это не снимает blocker по default broad Codex history scope. Рекомендация остаётся `reject_default`.
 
-## Privacy Failure
+## Локальный Прогон На Real Project Roots (2026-05-23)
+
+Проверка выполнялась только в full isolation: отдельные temp `CODEX_HOME`, `CODEX_MEM_DATA_DIR` и `CODEX_MEM_DB_PATH`. `sync`, `worker`, `init-mcp` и global Codex history не запускались. Каждая команда сохраняла только anonymous marker note с real project `--cwd` scope и проверяла scoped search.
+
+| Profile | Shape | Save | Search | Stats | Scoped Search | Source Indexed | Решение |
+|---|---|---:|---:|---:|---|---|---|
+| real-profile-01 | `large_legacy_web_app` | 597 ms | 428 ms | 445 ms | 1 result | no | Safe only with full isolation; reject default. |
+| real-profile-02 | `go_service` | 377 ms | 378 ms | 369 ms | 1 result | no | Safe only with full isolation; reject default. |
+| real-profile-03 | `large_framework_app` | 403 ms | 427 ms | 415 ms | 1 result | no | Safe only with full isolation; reject default. |
+| real-profile-04 | `multi_app_workspace` | 380 ms | 470 ms | 948 ms | 1 result | no | Safe only with full isolation; reject default. |
+| real-profile-05 | `small_microservice` | 704 ms | 563 ms | 372 ms | 1 result | no | Safe only with full isolation; reject default. |
+
+Вывод не меняется: isolated scoped notes работают, но опасным остается default/global Codex history scope. AIFHub не должен рекомендовать это как default provider.
+
+## Сбой Privacy
 
 Default behavior unsafe для AIFHub integration.
 
@@ -111,7 +125,7 @@ Default behavior unsafe для AIFHub integration.
 
 Оба generated indexes были quarantined, а global default store был removed из active home directory. Важный вывод не в operator mistake, а в том, что default source у tool - broad Codex session/history data.
 
-## Scope И Privacy
+## Границы И Privacy
 
 Default read scope включает Codex session/history logs под user's Codex home. Там могут быть private prompts, tool outputs, paths, snippets и cross-project context.
 
@@ -123,9 +137,9 @@ Safe use требует explicit настройки всех переменны�
 
 Это слишком fragile для default AIFHub integration.
 
-## Purge
+## Очистка
 
-Purge возможен удалением configured SQLite DB и sidecar files:
+Очистка возможна удалением configured SQLite DB и sidecar files:
 
 - `codex-mem.db`
 - `codex-mem.db-wal`

--- a/docs/memory-tools-research/context-mode.md
+++ b/docs/memory-tools-research/context-mode.md
@@ -1,8 +1,8 @@
 # context-mode
 
-Repository: [mksglu/context-mode](https://github.com/mksglu/context-mode)
+Репозиторий: [mksglu/context-mode](https://github.com/mksglu/context-mode)
 
-Tested package: `context-mode 1.0.146`.
+Проверенный package: `context-mode 1.0.146`.
 
 ## Мета Для Анализа
 
@@ -86,7 +86,7 @@ Shared controlled result: explicit indexed canary был retrievable before purg
 
 Проверка выполнялась только на explicit generated text: anonymous profile summary + canary. Source files не индексировались. Для каждого профиля использовался отдельный `CONTEXT_MODE_DATA_DIR`, затем выполнялся `ctx_purge({ confirm: true, scope: "project" })`.
 
-| Profile | Shape | Indexed Tokens | Index | Search | Found | Purge | Decision |
+| Profile | Shape | Indexed Tokens | Index | Search | Found | Очистка | Решение |
 |---|---|---:|---:|---:|---|---|---|
 | R2026-05-22-P01 | `go_service` | ~43 | 59 ms | 8 ms | yes | PASS | Manual helper для explicit generated output. |
 | R2026-05-22-P02 | `large_framework_app` | ~46 | 49 ms | 8 ms | yes | PASS | Manual helper для explicit generated output. |
@@ -104,7 +104,21 @@ Shared controlled result: explicit indexed canary был retrievable before purg
 
 Вывод по этому прогону: `context-mode` быстро работает как temporary index для явного generated output, но это не доказательство пользы как source-code retrieval tool. Рекомендация остаётся manual/helper-only.
 
-## Scope И Privacy
+## Локальный Прогон На Real Project Roots (2026-05-23)
+
+Проверка выполнялась через MCP SDK на пяти real project roots, но индексировались только generated profile summaries из `rg` baseline. Source snippets, paths, secrets и validation artifacts не передавались в `ctx_index`. Для каждого профиля использовался отдельный `CONTEXT_MODE_DATA_DIR`, затем выполнялся `ctx_purge({ confirm: true, scope: "project" })`.
+
+| Profile | Shape | MCP Connect | `ctx_index` | `ctx_search` | `ctx_purge` | Результат | Решение |
+|---|---|---:|---:|---:|---:|---|---|
+| real-profile-01 | `large_legacy_web_app` | 3.36 s | 83 ms | 8 ms | 121 ms | PASS | Manual helper только для generated output. |
+| real-profile-02 | `go_service` | 1.55 s | 36 ms | 7 ms | 9 ms | PASS | Manual helper только для generated output. |
+| real-profile-03 | `large_framework_app` | 1.69 s | 39 ms | 7 ms | 8 ms | PASS | Manual helper только для generated output. |
+| real-profile-04 | `multi_app_workspace` | 2.29 s | 40 ms | 7 ms | 8 ms | PASS | Manual helper только для generated output. |
+| real-profile-05 | `small_microservice` | 1.73 s | 46 ms | 8 ms | 10 ms | PASS | Обычно не нужен для малых проектов. |
+
+`context-mode doctor` также прошел runtime/server/FTS5 checks, а Codex hook registration failed/warned, потому что hooks намеренно не устанавливались. Для AIFHub docs это ожидаемо: не устанавливать hooks и не register MCP automatically.
+
+## Границы И Privacy
 
 Privacy content-driven:
 
@@ -114,7 +128,11 @@ Privacy content-driven:
 
 Для AIFHub это значит, что `context-mode` не должен регистрироваться как default provider. Если используется, то только как manual, per-session helper для большого command output и docs, а не persistent project memory.
 
-## Purge
+## Защищенные Validation Artifacts
+
+`context-mode` не должен rewrite validation artifacts и не должен compress protected artifacts in place. Protected validation artifacts включают `aif-gate-result`, `coverage.json`, `done-readiness.json`, OpenSpec specs, generated-rules traces и exact evidence snippets.
+
+## Очистка
 
 `ctx_purge` поддерживает explicit scopes:
 

--- a/docs/memory-tools-research/eagle-mem.md
+++ b/docs/memory-tools-research/eagle-mem.md
@@ -1,8 +1,8 @@
 # eagle-mem
 
-Repository: [eagleisbatman/eagle-mem](https://github.com/eagleisbatman/eagle-mem)
+Репозиторий: [eagleisbatman/eagle-mem](https://github.com/eagleisbatman/eagle-mem)
 
-Tested package: `eagle-mem 4.9.10`.
+Проверенный package: `eagle-mem 4.9.10`.
 
 ## Мета Для Анализа
 
@@ -46,7 +46,7 @@ Usable MCP provider не проверен.
 
 Trial намеренно не выполнял full install, потому что installation touch hooks и global/user agent configuration.
 
-| Check | Result |
+| Проверка | Результат |
 |---|---|
 | npm install | PASS |
 | Windows wrapper | FAIL/PARTIAL |
@@ -54,7 +54,7 @@ Trial намеренно не выполнял full install, потому что
 | doctor | Reports not installed |
 | MCP | Not proven |
 | Scoped read root | Not proven |
-| Purge/delete index | Not proven |
+| Очистка/delete index | Not proven |
 
 ## Результаты По Project Profiles (2026-05-22)
 
@@ -72,7 +72,7 @@ Trial намеренно не выполнял full install, потому что
 
 Проверка выполнялась только как `help` + `doctor` под isolated `HOME`/`USERPROFILE` через Git Bash. Full install, hooks, background lanes, source scan и DB setup намеренно не запускались.
 
-| Profile | Shape | Help | Doctor | Install State | Runtime Bytes | Purge | Decision |
+| Profile | Shape | Help | Doctor | Install State | Runtime Bytes | Очистка | Решение |
 |---|---|---:|---:|---|---:|---|---|
 | R2026-05-22-P01 | `go_service` | 282 ms | 3.1 s | not installed | 0 B | PASS | Reject/defer; install/hooks not tested. |
 | R2026-05-22-P02 | `large_framework_app` | 439 ms | 2.8 s | not installed | 0 B | PASS | Reject/defer; install/hooks not tested. |
@@ -90,13 +90,25 @@ Trial намеренно не выполнял full install, потому что
 
 Вывод по этому прогону: isolated `doctor` подтверждает, что без install tool не имеет scoped retrieval evidence. Windows `.cmd` wrapper через default WSL bash падал; явный Git Bash работал. Рекомендация остаётся reject/defer.
 
-## Scope И Privacy
+## Локальный Прогон На Real Project Roots (2026-05-23)
+
+Для real project roots выполнялись только safe probes, потому что full install включает hooks, runtime setup, DB migrations, background automation и possible agent lifecycle ownership. Source scan/index не запускался.
+
+| Probe | Isolation | Результат | Заметки |
+|---|---|---|---|
+| Windows `.cmd --help` | default shell bridge | FAIL | Wrapper вызвал WSL bash с Windows path, который WSL не смог resolved. |
+| Direct WSL `help` | isolated `HOME`, isolated `EAGLE_MEM_DIR`, hooks/auto-update disabled | PASS | Command list был readable; install не выполнялся. |
+| Direct WSL `doctor` | isolated `HOME`, isolated `EAGLE_MEM_DIR`, hooks/auto-update disabled | PARTIAL/PASS exit | Reported `Overall: Not installed`, SQLite missing, hooks not found, manifest missing. |
+
+Этот run намеренно не создавал source indexes или project memories. Результат усиливает предыдущее решение: scoped read root, purge path и clean disablement не доказаны для optional-provider model AIFHub.
+
+## Границы И Privacy
 
 Дизайн tool включает automatic hooks, project scanning, source indexing, session summaries, guardrails и shared agent memory. Этот surface слишком широкий для optional provider model в AIFHub.
 
 Для AIFHub основной риск не в конкретной leak, наблюдавшейся в trial. Риск в lifecycle ownership: global hooks и background automation усложняют гарантии bounded read scope и clean disablement.
 
-## Purge
+## Очистка
 
 Not proven. Так как full install был intentionally skipped, purge behavior не validated.
 

--- a/docs/memory-tools-research/graphify.md
+++ b/docs/memory-tools-research/graphify.md
@@ -1,8 +1,8 @@
 # Graphify
 
-Repository: [safishamsi/graphify](https://github.com/safishamsi/graphify)
+Репозиторий: [safishamsi/graphify](https://github.com/safishamsi/graphify)
 
-Tested package: `graphifyy 0.8.14` с дополнительным `mcp 1.27.1` для поддержки MCP server.
+Проверенный package: `graphifyy 0.8.14` с дополнительным `mcp 1.27.1` для поддержки MCP server.
 
 ## Мета Для Анализа
 
@@ -88,7 +88,7 @@ MCP не был готов сразу после установки `graphifyy`:
 
 Все профили были скопированы в sanitized temp fixtures. Graphify запускался только на temp path; `graphify-out/` оставался внутри temp fixture и удаляется как derived index.
 
-| Profile | Shape | Files | Cold Index | Query | Graph | Benchmark Query Tokens | Reduction | Quality | Decision |
+| Profile | Shape | Files | Cold Index | Query | Graph | Benchmark Query Tokens | Reduction | Quality | Решение |
 |---|---|---:|---:|---:|---|---:|---:|---|---|
 | R2026-05-22-P01 | `go_service` | 534 | 15.9 s | 5.4 s | 3328 nodes / 8785 edges | ~44226 | 5.1x | partial | Только после `rg` и ручной validation. |
 | R2026-05-22-P02 | `large_framework_app` | 681 | 31.2 s | 3.2 s | 16056 nodes / 25592 edges | ~8193 | 120.9x | good | Optional для broad analysis. |
@@ -106,7 +106,27 @@ MCP не был готов сразу после установки `graphifyy`:
 
 Вывод по этому прогону: Graphify стоит предлагать для `large_framework_app` и `multirepo`, где broad `rg` output дорогой или шумный. Для `large_legacy` и `go_service` польза есть, но результат требует ручной проверки. Для `small_microservice` overhead не оправдан даже при красивом token reduction.
 
-## Scope И Privacy
+## Локальный Прогон На Real Project Roots (2026-05-23)
+
+Проверка выполнялась на временных копиях пяти real project roots. Оригинальные roots не изменялись. Команда была только AST-only:
+
+```text
+graphify update <temp-copy> --no-cluster
+```
+
+`graphify extract` и semantic/LLM backend не запускались. `graphify-out/` создавался только внутри temp copy.
+
+| Profile | Shape | Files In Baseline | Copy | AST Update | Reported Graph | Результат | Решение |
+|---|---|---:|---:|---:|---|---|---|
+| real-profile-01 | `large_legacy_web_app` | 874 | 6.8 s | 78.8 s | 4,188 nodes / 7,641 edges | PASS | Optional только после `rg`; broad graph может быть дорогим. |
+| real-profile-02 | `go_service` | 583 | 3.0 s | 18.2 s | 3,863 nodes / 9,451 edges | PASS | Optional только для broad impact discovery. |
+| real-profile-03 | `large_framework_app` | 558 | 3.2 s | 51.2 s | 16,071 nodes / 19,382 edges | PASS | Optional для broad architecture/impact mapping. |
+| real-profile-04 | `multi_app_workspace` | 330 | 2.6 s | 8.6 s | 981 nodes / 1,656 edges | PASS | Optional для surface mapping. |
+| real-profile-05 | `small_microservice` | 59 | 0.4 s | 2.1 s | 549 nodes / 1,247 edges | PASS | Не рекомендовать по умолчанию; `rg` достаточно. |
+
+Operational finding: у `graphify update` нет `--out` flag, и он пишет `graphify-out/` рядом с target path. Для real private projects guidance AIFHub должен либо использовать sanitized/temp copy, либо требовать explicit user acceptance перед записью derived graph data в project root.
+
+## Границы И Privacy
 
 Read scope явный: project path, переданный Graphify. Output хранится в `graphify-out/`.
 
@@ -117,9 +137,9 @@ Safety constraints:
 - Не запускать `graphify install` по умолчанию; он может добавлять agent/hook integrations.
 - Предпочитать CLI/MCP usage с explicit `graph.json` path.
 
-## Purge
+## Очистка
 
-Purge простой:
+Очистка простая:
 
 - Удалить `graphify-out/`.
 - Или использовать `graphify uninstall --purge`, если Graphify был installed в проект.

--- a/docs/memory-tools-research/recommendation-metadata.yaml
+++ b/docs/memory-tools-research/recommendation-metadata.yaml
@@ -8,11 +8,250 @@ default_policy:
   require_purge_path: true
   baseline_tool: rg
   privacy_rule: "Не предлагать инструмент, если read scope не ограничен или purge path не проверен."
+skill_usage_matrix:
+  aif-analyze:
+    allowed:
+      - rg
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codegraph
+    forbidden:
+      - codex-mem
+      - eagle-mem
+    notes: "Recommend only; do not install, setup, index, register MCP, mutate provider config, or treat provider output as evidence."
+  aif-explore:
+    allowed:
+      - rg
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codegraph
+    forbidden:
+      - codex-mem
+      - eagle-mem
+    notes: "Read existing reviewed provider output, or use explicitly enabled tools only when metadata grants command-specific permission and purge is defined."
+  aif-plan:
+    allowed:
+      - rg
+      - graphify
+      - context7
+    forbidden:
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Optional supporting context before writing canonical OpenSpec artifacts; final plan must use direct repository evidence."
+  aif-review:
+    allowed:
+      - rg
+      - graphify
+      - context7
+      - codex-agent-mem
+    forbidden:
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Optional supporting context for impact/docs/closure checks only."
+  aif-rules-check:
+    allowed:
+      - rg
+      - context7
+    forbidden:
+      - graphify
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Context7 may support version-sensitive external docs only; generated rules and source evidence remain authoritative."
+  aif-implement:
+    allowed:
+      - rg
+    forbidden:
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Implementation commands must not use optional context providers by default."
+  aif-fix:
+    allowed:
+      - rg
+    forbidden:
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Fix commands must use QA evidence, source files, and canonical OpenSpec context."
+  aif-verify:
+    allowed:
+      - rg
+    forbidden:
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Verification must stay source-grounded and provider-independent."
+  aif-done:
+    allowed:
+      - rg
+    forbidden:
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Done/finalization must not depend on optional provider availability or output."
+  aif-commit:
+    allowed:
+      - rg
+    forbidden:
+      - graphify
+      - context7
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Commit freshness checks may use direct repository and local artifact evidence only."
+permissions:
+  recommend_only:
+    description: "May suggest manual usage; cannot run setup, indexing, MCP registration, sync, hooks, or background services."
+  read_existing_reviewed_output:
+    description: "May read already-created reviewed notes or reports from allowed paths."
+  safe_availability_probe:
+    description: "May run local non-mutating --version, --help, doctor, or status probes."
+  manual_user_owned_execution:
+    description: "User may run manually outside AIFHub command ownership."
+  manual_purged_cli_execution:
+    description: "May run a scoped CLI lifecycle against an explicit project path only when the selection CLI returns the tool for this command, then purge the tool-owned local index before finishing."
+  forbidden:
+    description: "Do not suggest or use for this command."
+tool_permissions:
+  rg:
+    aif-analyze: safe_availability_probe
+    aif-explore: safe_availability_probe
+    aif-plan: safe_availability_probe
+    aif-review: safe_availability_probe
+    aif-rules-check: safe_availability_probe
+    aif-implement: safe_availability_probe
+    aif-fix: safe_availability_probe
+    aif-verify: safe_availability_probe
+    aif-done: safe_availability_probe
+    aif-commit: safe_availability_probe
+  graphify:
+    aif-analyze: recommend_only
+    aif-explore: read_existing_reviewed_output
+    aif-plan: read_existing_reviewed_output
+    aif-review: read_existing_reviewed_output
+    aif-rules-check: forbidden
+    aif-implement: forbidden
+    aif-fix: forbidden
+    aif-verify: forbidden
+    aif-done: forbidden
+    aif-commit: forbidden
+  context7:
+    aif-analyze: recommend_only
+    aif-explore: read_existing_reviewed_output
+    aif-plan: read_existing_reviewed_output
+    aif-review: read_existing_reviewed_output
+    aif-rules-check: read_existing_reviewed_output
+    aif-implement: forbidden
+    aif-fix: forbidden
+    aif-verify: forbidden
+    aif-done: forbidden
+    aif-commit: forbidden
+  codex-agent-mem:
+    aif-analyze: recommend_only
+    aif-explore: read_existing_reviewed_output
+    aif-plan: forbidden
+    aif-review: read_existing_reviewed_output
+    aif-rules-check: forbidden
+    aif-implement: forbidden
+    aif-fix: forbidden
+    aif-verify: forbidden
+    aif-done: forbidden
+    aif-commit: forbidden
+  context-mode:
+    aif-analyze: recommend_only
+    aif-explore: recommend_only
+    aif-plan: forbidden
+    aif-review: forbidden
+    aif-rules-check: forbidden
+    aif-implement: forbidden
+    aif-fix: forbidden
+    aif-verify: forbidden
+    aif-done: forbidden
+    aif-commit: forbidden
+  agent-memory:
+    default: recommend_only_if_user_requests_manual_notes
+  codex-mem:
+    default: forbidden
+  eagle-mem:
+    default: forbidden
+  codegraph:
+    aif-analyze: recommend_only
+    aif-explore: manual_purged_cli_execution
+    default: forbidden
+availability_probes:
+  rg:
+    - rg --version
+  uv:
+    - uv --version
+  graphify:
+    - graphify --version
+    - graphify --help
+  context7:
+    - ctx7 --version
+    - npx --no-install ctx7 --help
+  codex-agent-mem:
+    - codex-agent-mem-policy --help
+    - codex-agent-mem-smoke --help
+  context-mode:
+    - context-mode doctor
+  codegraph:
+    - codegraph --version
+    - codegraph --help
+    - codegraph status
+forbidden_operations:
+  - auto_install
+  - auto_run_setup
+  - auto_index_source
+  - auto_sync_memory
+  - auto_register_mcp
+  - mutate_provider_config
+  - install_hooks
+  - start_background_daemons
+  - rewrite_validation_artifacts
+protected_artifacts:
+  - aif-gate-result
+  - coverage.json
+  - done-readiness.json
+  - openspec/specs/**
+  - openspec/changes/**/specs/**
+  - .ai-factory/rules/generated/openspec-rules-trace-*.json
+  - exact evidence snippets
 project_shape_signals:
   large_legacy:
     description: "Большой legacy проект с плотными интеграциями, большим числом файлов и шумным literal search."
     conditional_tools:
       - graphify
+      - codegraph
     condition: "Предлагать только после baseline rg, если literal search даёт слишком много шума или нужен architecture/impact overview."
     avoid_tools:
       - codex-mem
@@ -21,6 +260,7 @@ project_shape_signals:
     description: "Работа идёт сразу по нескольким репозиториям или нужно понять surface между компонентами."
     suggest_tools:
       - graphify
+      - codegraph
     conditional_tools:
       - codex-agent-mem
     avoid_tools:
@@ -30,12 +270,14 @@ project_shape_signals:
     description: "Крупное web-приложение на framework stack, где нужны architecture/impact вопросы."
     suggest_tools:
       - graphify
+      - codegraph
     conditional_tools:
       - context-mode
   go_service:
     description: "Средний Go сервис с интеграциями."
     conditional_tools:
       - graphify
+      - codegraph
       - codex-agent-mem
     baseline_first:
       - rg
@@ -46,6 +288,7 @@ project_shape_signals:
       - rg
     avoid_tools:
       - graphify
+      - codegraph
       - context-mode
       - codex-mem
       - agent-memory
@@ -56,13 +299,16 @@ task_signals:
       - rg
     avoid:
       - graphify
+      - codegraph
       - context-mode
   architecture_or_impact_discovery:
     recommend:
       - graphify
+      - codegraph
   multirepo_surface_mapping:
     recommend:
       - graphify
+      - codegraph
   resume_previous_work:
     recommend:
       - codex-agent-mem
@@ -95,6 +341,19 @@ tools:
     mcp_status: works_after_installing_python_mcp
     read_scope: explicit_project_path
     purge_path: "delete graphify-out/ or run graphify uninstall --purge if installed"
+    allowed_in:
+      - aif-analyze
+      - aif-explore
+      - aif-plan
+      - aif-review
+    forbidden_in:
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Reads only an explicit project path, but generated graph output can contain source-derived structure and must be reviewed before storage."
     recommended_for:
       project_shapes:
         - multirepo
@@ -115,6 +374,18 @@ tools:
         - exact_file_or_symbol_lookup
         - durable_session_memory
     suggestion_text: "Проект выглядит как large framework или multirepo; можно предложить Graphify как optional repo graph для architecture/impact анализа после baseline поиска через rg. Для legacy/go предлагать только если rg слишком шумный."
+    execution:
+      default:
+        mode: read_existing_reviewed_output
+        allowed_paths:
+          - graphify-out/GRAPH_REPORT.md
+          - graphify-out/graph.json
+          - .ai-factory/references/graphify/GRAPH_REPORT.md
+          - .ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md
+        forbidden_commands:
+          - graphify install
+          - graphify .
+        notes: "Read existing reviewed reports only unless the user runs Graphify outside AIFHub command ownership."
   codex-agent-mem:
     display_name: codex-agent-mem
     doc: codex-agent-mem.md
@@ -128,6 +399,19 @@ tools:
     mcp_status: read_only_mcp_verified
     read_scope: explicit_sqlite_db_path
     purge_path: "delete configured SQLite DB and sidecar files"
+    allowed_in:
+      - aif-analyze
+      - aif-explore
+      - aif-review
+    forbidden_in:
+      - aif-plan
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Reads only the configured SQLite memory DB in read-only/minimal mode; it is not a source code index and cannot satisfy OpenSpec gates."
     recommended_for:
       tasks:
         - resume_previous_work
@@ -145,6 +429,11 @@ tools:
         - exact_file_or_symbol_lookup
         - architecture_graphing
     suggestion_text: "Если нужен resume/open-work context между сессиями, можно предложить codex-agent-mem в read-only MCP mode с explicit DB path."
+    execution:
+      default:
+        mode: read_existing_reviewed_output
+        requires_explicit_path: true
+        notes: "Read only the configured SQLite DB or reviewed continuity notes."
   context-mode:
     display_name: context-mode
     doc: context-mode.md
@@ -158,6 +447,19 @@ tools:
     mcp_status: verified
     read_scope: explicit_indexed_content
     purge_path: "ctx_purge with session or project scope"
+    allowed_in:
+      - aif-analyze
+      - aif-explore
+    forbidden_in:
+      - aif-plan
+      - aif-review
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Everything explicitly indexed becomes retrievable; never compress protected validation artifacts in place and always purge temporary content."
     recommended_for:
       tasks:
         - large_command_output_compression
@@ -169,6 +471,10 @@ tools:
       project_shapes:
         - small_microservice
     suggestion_text: "Если анализ генерирует очень большой output, можно предложить context-mode как manual temporary index с обязательным purge."
+    execution:
+      default:
+        mode: recommend_only
+        notes: "Recommend temporary explicit-output indexing only; do not compress protected artifacts in place."
   context7:
     display_name: Context7
     doc: ../context-providers.md
@@ -182,6 +488,19 @@ tools:
     mcp_status: user_configured_optional
     read_scope: explicit_library_or_docs_query
     purge_path: "delete reviewed notes under .ai-factory/references/context7/ or .ai-factory/state/<change-id>/context7/"
+    allowed_in:
+      - aif-analyze
+      - aif-explore
+      - aif-plan
+      - aif-review
+      - aif-rules-check
+    forbidden_in:
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Queries external documentation by explicit library/query only; do not persist API keys, raw MCP transcripts, or provider diagnostics."
     recommended_for:
       tasks:
         - version_sensitive_library_docs
@@ -192,6 +511,13 @@ tools:
         - validation_gate
         - automatic_mcp_registration
     suggestion_text: "Если вопрос зависит от актуальных library/API docs, можно предложить Context7 как optional docs provider; setup и MCP registration остаются user-owned."
+    execution:
+      default:
+        mode: read_existing_reviewed_output
+        allowed_paths:
+          - .ai-factory/references/context7/
+          - .ai-factory/state/<change-id>/context7/
+        notes: "Use configured docs tools or reviewed notes only; do not run setup or mutate MCP config."
   codex-mem:
     display_name: codex-mem
     doc: codex-mem.md
@@ -205,6 +531,19 @@ tools:
     mcp_status: verified_but_unsafe_by_default
     read_scope: broad_codex_history_unless_fully_isolated
     purge_path: "delete configured SQLite DB and sidecar files"
+    allowed_in: []
+    forbidden_in:
+      - aif-analyze
+      - aif-explore
+      - aif-plan
+      - aif-review
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Default scope can ingest broad Codex history across projects unless fully isolated."
     avoid_reason: "Default scope может ingest cross-project Codex history; isolation слишком fragile для default recommendation."
   agent-memory:
     display_name: agent-memory
@@ -219,6 +558,19 @@ tools:
     mcp_status: not_found
     read_scope: explicit_memory_dir
     purge_path: "delete selected memory directory"
+    allowed_in:
+      - manual_notes_only
+    forbidden_in:
+      - aif-analyze_without_manual_notes_request
+      - aif-plan
+      - aif-review
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Manual markdown notes in an explicit directory only; not a code retrieval or MCP provider."
     recommended_for:
       tasks:
         - manual_durable_notes
@@ -241,7 +593,87 @@ tools:
     mcp_status: not_proven
     read_scope: not_proven
     purge_path: not_proven
+    allowed_in: []
+    forbidden_in:
+      - aif-analyze
+      - aif-explore
+      - aif-plan
+      - aif-review
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Scoped read and purge are not proven, and lifecycle surface includes hooks/background lanes."
     avoid_reason: "Слишком широкий lifecycle surface: hooks, background lanes, user-home runtime и неvalidated purge/read scope."
+  codegraph:
+    display_name: CodeGraph
+    doc: codegraph.md
+    repository: "https://github.com/colbymchenry/codegraph"
+    tested_version: "@colbymchenry/codegraph 0.9.3"
+    decision: manual_cli_only
+    recommendation_action: suggest_manual_cli_for_repo_graph_when_enabled_or_explicit
+    integration_role: manual_cli_repo_graph_provider
+    install_policy: explicit_user_opt_in_only
+    stable_cli: verified_for_version_help_status_init_index_query_uninit
+    mcp_status: not_enabled
+    read_scope: explicit_project_path_verified_for_cli_init_index_status_query
+    purge_path: "codegraph uninit --force <project> verified"
+    allowed_in:
+      - aif-analyze
+      - aif-explore
+    forbidden_in:
+      - aif-plan
+      - aif-review
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Local CLI indexing creates .codegraph/ under the explicit project path until purged; install/MCP/agent configuration mutation surfaces are not accepted."
+    recommended_for:
+      project_shapes:
+        - multirepo
+        - large_framework_app
+      tasks:
+        - architecture_or_impact_discovery
+        - multirepo_surface_mapping
+    conditional_for:
+      project_shapes:
+        - large_legacy
+        - go_service
+      condition: "Только после baseline rg, только для broad repo graph questions, and only with explicit project path plus purge."
+    do_not_recommend_for:
+      project_shapes:
+        - small_microservice
+      tasks:
+        - exact_file_or_symbol_lookup
+        - validation_gate
+        - implementation
+        - automatic_mcp_registration
+    suggestion_text: "Для broad architecture/impact или multirepo mapping можно предложить CodeGraph как manual CLI-only repo graph: probe, run explicit path init/index/query, then purge with codegraph uninit --force <project>. Do not run codegraph install, sync, serve, serve --mcp, or mutate agent config."
+    execution:
+      aif-explore:
+        mode: manual_purged_cli_execution
+        safe_probes:
+          - codegraph --version
+          - codegraph --help
+          - codegraph status
+        commands:
+          - codegraph init <project>
+          - codegraph index --quiet <project>
+          - codegraph query --path <project> --limit 10 --json "<query>"
+          - codegraph uninit --force <project>
+        purge:
+          - codegraph uninit --force <project>
+        forbidden_commands:
+          - codegraph install
+          - codegraph sync
+          - codegraph serve
+          - codegraph serve --mcp
+        pre_existing_state: "If .codegraph/ already exists, treat it as user-owned and do not delete or reinitialize it silently."
 evidence_runs:
   - id: local-anonymous-profiles-2026-05-22
     date: "2026-05-22"
@@ -296,3 +728,127 @@ evidence_runs:
         help_doctor_passed_with_git_bash: 13
         full_install_tested: false
         recommendation_update: "Оставить reject/defer; scoped read and purge evidence not proven."
+  - id: local-real-project-roots-2026-05-23
+    date: "2026-05-23"
+    scope: "5 real local project roots using anonymous profile ids only. rg baseline read source; provider smokes used temp DB/data dirs or temp copies."
+    privacy: "Docs contain only anonymous profile ids, shape labels, counts, timings, and aggregate graph sizes; real project names, paths, snippets, and temp paths are excluded."
+    sanitization:
+      graphify:
+        mode: "temporary copy only"
+        excluded:
+          - ".git"
+          - ".env*"
+          - "node_modules"
+          - "vendor"
+          - "build/cache/storage artifacts"
+          - "lock files"
+        semantic_extraction: false
+      memory_tools:
+        source_indexing: false
+        storage: "explicit temp DB/data dirs per profile"
+    profile_counts:
+      large_legacy_web_app: 1
+      go_service: 1
+      large_framework_app: 1
+      multi_app_workspace: 1
+      small_microservice: 1
+    baseline:
+      tool: rg
+      files_range: "59-874"
+      query_latency_ms_range: "95-294"
+      hit_sample_limit: 80
+      recommendation_update: "rg remains default baseline for exact search and small projects."
+    outcomes:
+      graphify:
+        tested_profiles: 5
+        ast_update_temp_copy_passed: 5
+        semantic_extraction_run: false
+        update_latency_ms_range: "2147-78826"
+        reported_graph_range: "549-16071 nodes / 1247-19382 edges"
+        recommendation_update: "Optional only for broad architecture/impact mapping; do not write graphify-out into real roots without explicit opt-in."
+      codex-agent-mem:
+        tested_profiles: 5
+        smoke_passed: 5
+        source_indexing_run: false
+        recommendation_update: "Safe with explicit DB path; continuity-only recommendation unchanged."
+      context-mode:
+        tested_profiles: 5
+        mcp_index_search_purge_passed: 5
+        source_indexing_run: false
+        recommendation_update: "Manual helper for explicit generated output only; do not install hooks/register MCP automatically."
+      codex-mem:
+        tested_profiles: 5
+        isolated_save_search_stats_passed: 5
+        sync_run: false
+        recommendation_update: "Full isolation works; reject_default remains because default Codex history scope is broad."
+      agent-memory:
+        tested_profiles: 5
+        manual_context_passed: 5
+        cli_caveat: "Global flags must follow the command; validate marker/file content, not exit code alone."
+        recommendation_update: "Docs-only/manual notes; not a project retrieval provider."
+      eagle-mem:
+        safe_probes_only: true
+        direct_wsl_help_passed: true
+        doctor_state: "not installed; SQLite missing; hooks absent"
+        full_install_tested: false
+        recommendation_update: "Reject/defer remains; scoped read, purge, and clean disablement not proven."
+      codegraph:
+        safe_probes_attempted:
+          - "codegraph --version"
+          - "codegraph --help"
+          - "codegraph status"
+        available_on_path: false
+        recommendation_update: "Superseded by local-real-project-codegraph-safety-2026-05-23; enable manual_cli_only recommendations for analyze/explore while keeping install/MCP/agent-config surface forbidden."
+  - id: local-real-project-codegraph-safety-2026-05-23
+    date: "2026-05-23"
+    scope: "29 real local project roots selected as git roots or top-level marker roots under the user-requested project folders."
+    privacy: "Docs contain only anonymous local ids, counts, timings, aggregate index sizes, and mutation outcomes; real project names, local paths, snippets, query output, and temp paths are excluded."
+    project_selection:
+      included:
+        - "git roots"
+        - "top-level marker roots"
+      excluded:
+        - "nested vendor/template/cache/config roots"
+        - "dependency folders"
+        - "installed extension copies"
+    install:
+      command: "npm install -g @colbymchenry/codegraph"
+      user_requested: true
+      version: "0.9.3"
+    per_root_commands:
+      - "codegraph init <project>"
+      - "codegraph index --quiet <project>"
+      - "codegraph status <project>"
+      - "codegraph query --path <project> --limit 3 --json main"
+      - "codegraph uninit --force <project>"
+    not_run:
+      - "codegraph install"
+      - "codegraph sync"
+      - "codegraph serve"
+      - "codegraph serve --mcp"
+      - "agent configuration mutation commands"
+      - "hooks/background services"
+    protected_snapshot_files:
+      - ".mcp.json"
+      - ".codex/config.toml"
+      - ".codex/hooks.json"
+      - ".cursor/mcp.json"
+      - ".cursor/settings.json"
+      - ".opencode.json"
+      - "opencode.json"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+    outcomes:
+      codegraph:
+        roots_tested: 29
+        lifecycle_passed: 29
+        command_failures: 0
+        query_failures: 0
+        protected_config_mutations: 0
+        leftover_codegraph_dirs: 0
+        roots_with_no_recognized_source_nodes: 3
+        index_latency_ms_range: "583-25077"
+        index_latency_ms_average: 6261
+        transient_index_db_mb_range: "0.13-32.65"
+        transient_index_db_mb_total_before_purge: 177.11
+        recommendation_update: "CLI scoped read and purge accepted for explicit user-requested local experiments. Use manual_cli_only for /aif-analyze recommendation and /aif-explore enabled execution; install/MCP/agent configuration mutation remains forbidden and provider output remains noncanonical."

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -1,4 +1,4 @@
-[Previous Page](context-loading-policy.md) | [Back to Documentation](README.md) | [Next Page](openspec-validation.md)
+[Предыдущая страница](context-loading-policy.md) | [К документации](README.md) | [Следующая страница](openspec-validation.md)
 
 # OpenSpec Compatibility
 
@@ -26,7 +26,7 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## Optional Initialization
+## Опциональная Инициализация
 
 Projects may initialize OpenSpec without tool integrations:
 
@@ -54,12 +54,22 @@ paths:
   rules: .ai-factory/rules
 
 utilities:
+  context_tools:
+    enabled: []
   graphify:
     enabled: false
     uv_check: uv --version
     install: uv tool install graphifyy
     activate: graphify install
     report_command: graphify .
+  codegraph:
+    enabled: false
+    command: codegraph
+    status: codegraph status
+    init: codegraph init .
+    index: codegraph index --quiet .
+    query: codegraph query --path . --limit 10 --json
+    purge: codegraph uninit --force .
 ```
 
 OpenSpec-native mode adds the OpenSpec settings and runtime path profile shown below.
@@ -113,9 +123,9 @@ utilities:
     report_command: graphify .
 ```
 
-`installSkills: false` is intentional. AIFHub Extension uses OpenSpec artifacts and `scripts/openspec-runner.mjs` as the optional CLI adapter, not OpenSpec-installed skills or slash commands.
+`installSkills: false` задан намеренно. AIFHub Extension использует OpenSpec artifacts и `scripts/openspec-runner.mjs` как optional CLI adapter, а не OpenSpec-installed skills или slash commands.
 
-The `utilities` section is protocol-neutral. It records optional tool preferences only; Graphify remains manually installed, activated, and run by the user.
+Секция `utilities` protocol-neutral. Она хранит только optional tool preferences. `utilities.context_tools.enabled` хранит user-accepted provider ids из `/aif-analyze`; follow-on skills вызывают `ai-factory aifhub-memory-tools select --from-project --command <skill> --json` и используют только `selected_tools`. Graphify остается manually installed/activated/run пользователем. CodeGraph остается manual CLI-only и может использоваться `/aif-explore` только когда выбран CLI, с purge перед завершением.
 
 On first bootstrap, `/aif-analyze` may create the OpenSpec marker after asking for the artifact protocol. If `.ai-factory/config.yaml` is missing and the user did not explicitly request OpenSpec-native mode, interactive runtimes ask the user to choose `legacy AI Factory-only` or `OpenSpec-native` before writing the config. Existing configs are preserved without prompting. Autonomous/subagent runs do not ask; they default to legacy AI Factory-only and report OpenSpec-native mode as an open question.
 
@@ -171,7 +181,7 @@ When no active changes exist after archive, `/aif-mode sync` still refreshes `.a
 
 For `/aif-mode sync --all`, selected active changes without `openspec/changes/<change-id>/specs/**/spec.md` delta specs are reported as `no-delta-specs` warnings and skipped for sync validation. Changes with delta specs are still validated/statused when the CLI is available.
 
-## Rules Gate
+## Гейт Rules
 
 `/aif-rules-check` is read-only. It uses AIFHub generated rules in OpenSpec-native mode and returns a machine-readable `aif-gate-result` with `gate: "rules"`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-[Back to Documentation](README.md) | [Back to README](../README.md) | [Next Page](context-providers.md)
+[К документации](README.md) | [К README](../README.md) | [Следующая страница](context-providers.md)
 
 # Usage
 
@@ -49,28 +49,40 @@ The `aifhub-extension` package repository stays artifact-light: root `openspec/`
 
 AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
 
-## Optional Context Providers
+## Опциональные Context Providers
 
-Context providers are manual, user-owned research aids. AIFHub may read reviewed provider notes as optional supporting context, but provider availability is degraded behavior and never a validation, verification, review, rules, security, done, or commit gate.
+Context providers - ручные, user-owned research aids. AIFHub может читать reviewed provider notes как optional supporting context, но provider availability всегда degraded behavior и никогда не является validation, verification, review, rules, security, done или commit gate.
 
-See [Context Providers](context-providers.md) for the central policy and [Memory Tool Recommendations](memory-tool-recommendations.md) for local metadata-driven recommendation diagnostics.
+Центральная policy описана в [Context Providers](context-providers.md), local metadata-driven recommendation diagnostics - в [Memory Tool Recommendations](memory-tool-recommendations.md).
 
-Installed projects can inspect optional recommendations with:
+Installed projects могут проверить optional recommendations так:
 
 ```bash
 ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools select --from-project --command aif-explore --json
+ai-factory aifhub-memory-tools select --from-project --command aif-plan --json
 ai-factory aifhub-memory-tools status --json
 ai-factory aifhub-memory-tools metadata --json
 ```
 
-### Graphify
-
-Graphify can be used as a manual, user-owned repository research aid before or during AIFHub work. AIFHub Extension does not require Graphify, does not install `graphifyy`, does not run `graphify`, does not add Graphify to extension dependencies, and does not start or register Graphify MCP automatically.
-
-`/aif-analyze` keeps the Graphify shared utility config only as a backward-compatible preference. New optional tool recommendations come from local `recommendation-metadata.yaml` through the installed wrapper command, not from a provider config abstraction. The compatibility config shape remains:
+`/aif-analyze` записывает user-accepted provider ids в `utilities.context_tools.enabled`. Последующие skills вызывают `select` и используют только `selected_tools` для своей команды:
 
 ```yaml
 utilities:
+  context_tools:
+    enabled: []
+```
+
+### Graphify
+
+Graphify можно использовать как manual, user-owned repository research aid до или во время AIFHub work. AIFHub Extension не требует Graphify, не устанавливает `graphifyy`, не запускает `graphify`, не добавляет Graphify в extension dependencies и не запускает или регистрирует Graphify MCP automatically.
+
+`/aif-analyze` хранит shared utility config Graphify только как backward-compatible preference. Новые optional tool recommendations приходят из local `recommendation-metadata.yaml` через installed wrapper command, а не из provider config abstraction. Compatibility config shape:
+
+```yaml
+utilities:
+  context_tools:
+    enabled: []
   graphify:
     enabled: false
     uv_check: uv --version
@@ -79,9 +91,9 @@ utilities:
     report_command: graphify .
 ```
 
-Set `utilities.graphify.enabled: true` only after the project chooses to use manually generated Graphify reports. The setting does not install Graphify and does not replace metadata-driven recommendations.
+Устанавливайте `utilities.graphify.enabled: true` только после того, как project выбрал использование manually generated Graphify reports. Эта настройка не устанавливает Graphify и не заменяет metadata-driven recommendations.
 
-Manual usage, outside AIFHub command ownership:
+Manual usage вне AIFHub command ownership:
 
 ```powershell
 uv --version
@@ -90,65 +102,94 @@ graphify install
 graphify .
 ```
 
-Use `graphify .` in PowerShell; do not prefix it as `/graphify .`.
+В PowerShell используйте `graphify .`; не добавляйте prefix `/graphify .`.
 
-Graphify writes local outputs under `graphify-out/`, including:
+Graphify пишет local outputs в `graphify-out/`, включая:
 
 - `graphify-out/GRAPH_REPORT.md`
 - `graphify-out/graph.json`
 - `graphify-out/graph.html`
 
-Its CLI may also expose research commands such as `graphify query`, `graphify path`, and `graphify explain`.
+CLI также может expose research commands вроде `graphify query`, `graphify path` и `graphify explain`.
 
-When `graphify-out/GRAPH_REPORT.md` already exists, AIFHub commands may read it as optional supporting context. To keep reviewed output for later context loading, copy it only to:
+Когда `graphify-out/GRAPH_REPORT.md` уже существует, AIFHub commands могут читать его как optional supporting context. Для дальнейшей context loading храните reviewed output только здесь:
 
-- `.ai-factory/references/graphify/` for project-wide reference context.
-- `.ai-factory/state/<change-id>/graphify/` for change-scoped runtime context.
+- `.ai-factory/references/graphify/` для project-wide reference context.
+- `.ai-factory/state/<change-id>/graphify/` для change-scoped runtime context.
 
-Do not store Graphify generated files under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+Не храните Graphify generated files в `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/` или `.ai-factory/qa/<change-id>/`.
 
-Treat Graphify findings as supporting evidence only. Reports can include extracted, inferred, ambiguous, or confidence-labeled relationships, so final plans, review findings, verification status, generated rules, and roadmap completion still need direct repository evidence from canonical OpenSpec artifacts, source files, tests, runtime state, or QA evidence.
+Считайте Graphify findings только supporting evidence. Reports могут включать extracted, inferred, ambiguous или confidence-labeled relationships, поэтому final plans, review findings, verification status, generated rules и roadmap completion все равно требуют direct repository evidence из canonical OpenSpec artifacts, source files, tests, runtime state или QA evidence.
 
-Before copying a report into `.ai-factory/`, review it for sensitive information. Do not persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics, or unreviewed sensitive output in AIFHub artifacts.
+Перед копированием report в `.ai-factory/` проверьте его на sensitive information. Не persist API keys, tokens, raw authorization headers, credential helper output, private backend diagnostics или unreviewed sensitive output в AIFHub artifacts.
+
+### CodeGraph
+
+CodeGraph - manual CLI-only repo graph support для broad architecture, impact или multirepo mapping. `/aif-analyze` может рекомендовать его из local metadata; `/aif-explore` может запускать его только когда `select --command aif-explore --json` возвращает его в `selected_tools` с `manual_purged_cli_execution`.
+
+Protocol-neutral preference shape:
+
+```yaml
+utilities:
+  codegraph:
+    enabled: false
+    command: codegraph
+    status: codegraph status
+    init: codegraph init .
+    index: codegraph index --quiet .
+    query: codegraph query --path . --limit 10 --json
+    purge: codegraph uninit --force .
+```
+
+Разрешенный `/aif-explore` lifecycle:
+
+```bash
+codegraph init <project>
+codegraph index --quiet <project>
+codegraph query --path <project> --limit 10 --json "<query>"
+codegraph uninit --force <project>
+```
+
+Не запускайте `codegraph install`, `codegraph sync`, `codegraph serve`, `codegraph serve --mcp`, hooks, background services или agent configuration mutation. Если pre-existing `.codegraph/` уже существует, считайте его user-owned state и не удаляйте/не reinitialize silently.
 
 ### Context7
 
-Context7 can be used as a manual, user-owned documentation research aid for current library/API docs. AIFHub Extension does not require Context7, does not install `ctx7` or `@upstash/context7-mcp`, does not run `ctx7`, does not run `ctx7 setup`, does not add Context7 to extension dependencies, does not add Context7 MCP templates to `extension.json`, and does not start or register Context7 MCP automatically.
+Context7 можно использовать как manual, user-owned documentation research aid для current library/API docs. AIFHub Extension не требует Context7, не устанавливает `ctx7` или `@upstash/context7-mcp`, не запускает `ctx7`, не запускает `ctx7 setup`, не добавляет Context7 в extension dependencies, не добавляет Context7 MCP templates в `extension.json` и не запускает или регистрирует Context7 MCP automatically.
 
-Use Context7 when version-sensitive API documentation can materially reduce uncertainty during `/aif-explore`, `/aif-plan full`, or `/aif-review`. Examples include framework migrations, deprecations, third-party client behavior, package-specific configuration, or review findings that depend on current upstream docs.
+Используйте Context7, когда version-sensitive API documentation materially снижает неопределенность во время `/aif-explore`, `/aif-plan full` или `/aif-review`. Примеры: framework migrations, deprecations, third-party client behavior, package-specific configuration или review findings, зависящие от current upstream docs.
 
-Manual CLI usage, outside AIFHub command ownership:
+Manual CLI usage вне AIFHub command ownership:
 
 ```bash
 npx ctx7 library <name> <query>
 npx ctx7 docs <libraryId> <query>
 ```
 
-If the user already installed Context7, equivalent local commands may be:
+Если пользователь уже установил Context7, equivalent local commands:
 
 ```bash
 ctx7 library <name> <query>
 ctx7 docs <libraryId> <query>
 ```
 
-Context7 CLI usage requires a suitable local Node.js runtime. If `npx ctx7` or a user-installed `ctx7` is unavailable, too old, unauthenticated, rate-limited, or missing provider access, continue with degraded documentation context and use repository evidence plus local package docs instead.
+Context7 CLI usage требует подходящий local Node.js runtime. Если `npx ctx7` или user-installed `ctx7` недоступен, слишком старый, unauthenticated, rate-limited или без provider access, продолжайте с degraded documentation context и используйте repository evidence плюс local package docs.
 
-Context7 library IDs are provider output and may include forms such as `/org/project`, `/org/project/version`, `/org/project@version`, `/packages/<name>`, or `/websites/<name>`. Treat exact IDs as unstable external references rather than AIFHub schema.
+Context7 library IDs являются provider output и могут иметь формы `/org/project`, `/org/project/version`, `/org/project@version`, `/packages/<name>` или `/websites/<name>`. Treat exact IDs as unstable external references, а не AIFHub schema.
 
-If the user has already configured Context7 MCP, agents may use it as optional read-only documentation context. The usual MCP flow is `resolve-library-id` followed by a docs retrieval tool; depending on client/server version, that docs retrieval tool may be named `get-library-docs` or `query-docs`.
+Если пользователь уже настроил Context7 MCP, agents могут использовать его как optional read-only documentation context. Обычный MCP flow: `resolve-library-id`, затем docs retrieval tool; в зависимости от client/server version tool может называться `get-library-docs` или `query-docs`.
 
-Do not run `ctx7 setup` from AIFHub commands or sidecars. It can mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills. AIFHub guidance may mention it only as user-owned setup.
+Не запускайте `ctx7 setup` из AIFHub commands или sidecars. Он может mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules или agent skills. AIFHub guidance может упоминать его только как user-owned setup.
 
-To keep reviewed Context7 notes for later context loading, write concise summaries only to:
+Для будущего context loading пишите concise summaries reviewed Context7 notes только сюда:
 
-- `.ai-factory/references/context7/` for project-wide documentation context.
-- `.ai-factory/state/<change-id>/context7/` for change-scoped runtime context.
+- `.ai-factory/references/context7/` для project-wide documentation context.
+- `.ai-factory/state/<change-id>/context7/` для change-scoped runtime context.
 
-Do not store raw Context7 output, MCP transcripts, API responses, setup output, or generated provider configuration under `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/`, or `.ai-factory/qa/<change-id>/`.
+Не храните raw Context7 output, MCP transcripts, API responses, setup output или generated provider configuration в `openspec/changes/<change-id>/`, `openspec/specs/`, `.ai-factory/rules/generated/` или `.ai-factory/qa/<change-id>/`.
 
-Treat Context7 output as supporting evidence only. Plans, review findings, verification status, generated rules, and completion decisions must remain source-grounded in direct repository evidence from canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules, or package files in the repository.
+Считайте Context7 output только supporting evidence. Plans, review findings, verification status, generated rules и completion decisions должны оставаться source-grounded в direct repository evidence из canonical OpenSpec artifacts, source files, tests, runtime state, QA evidence, generated rules или package files в repository.
 
-Do not persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics, or unreviewed sensitive output in AIFHub artifacts.
+Не persist `CONTEXT7_API_KEY`, API keys, tokens, raw authorization headers, credential helper output, private provider diagnostics, private backend diagnostics или unreviewed sensitive output в AIFHub artifacts.
 
 ## Bug Fix Workflows
 
@@ -298,7 +339,7 @@ If localization questions run first, `/aif-analyze` carries those answers forwar
 
 The selected artifact protocol owns its config profile. Legacy `artifactProtocol: ai-factory` configs do not include `aifhub.openspec` settings or OpenSpec runtime path defaults; OpenSpec-native `artifactProtocol: openspec` configs include those settings and paths explicitly.
 
-Shared protocol-neutral settings such as `utilities.graphify.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency. Optional memory/context tool recommendations are resolved from local installed metadata with `ai-factory aifhub-memory-tools recommend --from-project --json`; missing metadata is degraded context and leaves `rg` as the baseline.
+Shared protocol-neutral settings such as `utilities.context_tools.enabled`, `utilities.graphify.enabled`, and `utilities.codegraph.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency. Optional memory/context tool recommendations are resolved from local installed metadata with `ai-factory aifhub-memory-tools recommend --from-project --json`; runtime tool selection uses `ai-factory aifhub-memory-tools select --from-project --command <skill> --json`. Missing metadata is degraded context and leaves `rg` as the baseline.
 
 ### `/aif-plan full`
 

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lee-to/ai-factory/2.x/schemas/extension.schema.json",
   "name": "aifhub-extension",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Upstream-first extension for AI Factory 2.11+: bootstrap remains extension-owned; `aif-plan`, `aif-implement`, `aif-verify`, and `aif-fix` connect through injections; upstream `aif-rules-check` is augmented by the AIFHub OpenSpec generated-rules injection; `aif-done` and `aif-mode` remain extension-owned finalizers/orchestrators; Codex and Claude runtime files publish through top-level `agentFiles`.",
   "commands": [
     {

--- a/injections/core/aif-explore-plan-folder.md
+++ b/injections/core/aif-explore-plan-folder.md
@@ -34,10 +34,20 @@ Allowed read context:
 - optional reviewed Graphify outputs such as `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `.ai-factory/references/graphify/GRAPH_REPORT.md`, and `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`
 - optional reviewed Context7 notes under `.ai-factory/references/context7/` and `.ai-factory/state/<change-id>/context7/`
 
+Enabled optional tool use:
+
+- Before using any optional provider, call the installed wrapper when available: `ai-factory aifhub-memory-tools select --from-project --command aif-explore --json`.
+- The wrapper reads `utilities.context_tools.enabled`, compatibility utility flags, local `recommendation-metadata.yaml`, command-specific `tool_permissions`, and project/task signals.
+- Use only entries returned in `selected_tools`. For each selected entry, follow its `tool_id`, `permission`, `execution`, `forbidden_operations`, `protected_artifacts`, read scope, purge path, and privacy caveat.
+- Do not use tools that are absent from `selected_tools`, including tools listed in `not_selected_tools`, tools missing from config, tools forbidden for `/aif-explore`, or tools whose execution guidance is unavailable.
+- If no optional provider is selected, continue with the rg baseline and source/OpenSpec evidence.
+- Optional provider output is supporting context only; conclusions must remain grounded in source files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
+
 Optional Graphify context:
 
+- This provider-specific boundary applies only when `selected_tools` includes Graphify, or when reading already reviewed Graphify output that exists in an allowed context path.
 - Graphify is optional supporting context for large repository architecture/relation discovery.
-- `/aif-explore` may recommend that the user run Graphify manually outside AIFHub command ownership, but it must not install `graphifyy`, run `graphify`, add Graphify dependencies, or start/register Graphify MCP automatically.
+- `/aif-explore` may recommend that the user run Graphify manually outside AIFHub command ownership only when the selection output allows Graphify, but it must not install `graphifyy`, run `graphify`, add Graphify dependencies, or start/register Graphify MCP automatically.
 - Missing Graphify or missing `graphify-out/GRAPH_REPORT.md` is degraded context, not an exploration failure.
 - When existing Graphify output is available, treat extracted, inferred, ambiguous, or confidence-labeled relationships as hypotheses for direct repository inspection.
 - Research conclusions must remain grounded in source files, canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or other direct repository evidence.
@@ -47,8 +57,9 @@ Optional Graphify context:
 
 Optional Context7 context:
 
+- This provider-specific boundary applies only when `selected_tools` includes Context7, or when reading already reviewed Context7 notes that exist in an allowed context path.
 - Context7 is optional supporting documentation context for current library/API docs.
-- `/aif-explore` may recommend that the user run Context7 manually outside AIFHub command ownership with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
+- `/aif-explore` may recommend that the user run Context7 manually outside AIFHub command ownership only when the selection output allows Context7, with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
 - Missing Context7, missing Node.js runtime support, missing provider access, or missing reviewed notes is degraded context, not an exploration failure.
 - If the user already configured Context7 MCP, available tools may include `resolve-library-id` plus a docs retrieval tool named `get-library-docs` or `query-docs`; use them only as optional read-only documentation context.
 - Do not install `ctx7` or `@upstash/context7-mcp`, run `ctx7`, run `ctx7 setup`, add Context7 dependencies or manifest entries, add Context7 MCP templates to `extension.json`, mutate `.mcp.json`, `.cursor/mcp.json`, `.opencode.json`, agent rules, or agent skills, or start/register Context7 MCP automatically.

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -31,10 +31,18 @@ Do not create legacy `.ai-factory/plans` plan files or companion folders in this
 
 If the task is docs/tooling-only and does not change product or workflow behavior, a delta spec may be omitted only when the plan explicitly explains why no delta spec is needed.
 
+#### Enabled optional tool use
+
+- Before using any optional provider, call the installed wrapper when available: `ai-factory aifhub-memory-tools select --from-project --command aif-plan --json`.
+- Use only entries returned in `selected_tools`. For each selected entry, follow its `tool_id`, `permission`, `execution`, `forbidden_operations`, `protected_artifacts`, read scope, purge path, and privacy caveat.
+- Do not use tools that are absent from `selected_tools`, including tools listed in `not_selected_tools`, tools missing from config, tools forbidden for `/aif-plan`, or tools whose execution guidance is unavailable.
+- If no optional provider is selected, continue with the rg baseline and direct repository/OpenSpec evidence.
+
 #### Optional Graphify context
 
 Graphify is optional supporting context for integration discovery before creating or refining a canonical OpenSpec change.
 
+- This provider-specific boundary applies only when `selected_tools` includes Graphify, or when reading already reviewed Graphify output that exists in an allowed context path.
 - `/aif-plan full` may read existing reviewed Graphify outputs such as `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `.ai-factory/references/graphify/GRAPH_REPORT.md`, and `.ai-factory/state/<change-id>/graphify/GRAPH_REPORT.md`.
 - Missing Graphify or missing reports are degraded context, not planning failure.
 - Do not install `graphifyy`, run `graphify`, add Graphify dependencies or manifest entries, or start/register Graphify MCP automatically.
@@ -48,7 +56,8 @@ Graphify is optional supporting context for integration discovery before creatin
 
 Context7 is optional supporting documentation context for current library/API docs before creating or refining a canonical OpenSpec change.
 
-- `/aif-plan full` may recommend that the user run Context7 manually outside AIFHub command ownership with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
+- This provider-specific boundary applies only when `selected_tools` includes Context7, or when reading already reviewed Context7 notes that exist in an allowed context path.
+- `/aif-plan full` may recommend that the user run Context7 manually outside AIFHub command ownership only when the selection output allows Context7, with commands such as `npx ctx7 library <name> <query>` and `npx ctx7 docs <libraryId> <query>`, or user-installed equivalents `ctx7 library <name> <query>` and `ctx7 docs <libraryId> <query>`.
 - `/aif-plan full` may read reviewed Context7 notes under `.ai-factory/references/context7/` and `.ai-factory/state/<change-id>/context7/`.
 - Missing Context7, missing Node.js runtime support, missing provider access, or missing reviewed notes is degraded context, not planning failure.
 - If the user already configured Context7 MCP, available tools may include `resolve-library-id` plus a docs retrieval tool named `get-library-docs` or `query-docs`; use them only as optional read-only documentation context.

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -146,6 +146,7 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       '### Step 2.1: Optional Context/Memory Tool Recommendations',
       'recommendation-metadata.yaml',
       'ai-factory aifhub-memory-tools recommend --from-project --json',
+      'ai-factory aifhub-memory-tools select --from-project --command aif-explore --json',
       'ai-factory aifhub-memory-tools status --json',
       'ai-factory aifhub-memory-tools metadata --json',
       'exact_file_or_symbol_lookup',
@@ -153,25 +154,80 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       'resume_previous_work',
       'large_command_output_compression',
       'version_sensitive_library_docs',
+      'codegraph',
       'codex-mem',
       'eagle-mem',
       'Provider output is supporting context only, never canonical OpenSpec evidence.',
+      'allowed command scopes',
+      'forbidden command scopes',
+      'command-specific permission',
+      'execution guidance',
+      'privacy caveat',
+      'protected validation artifacts',
+      'utilities.context_tools.enabled',
+      'accepted tool ids',
+      'selected_tools',
       'utilities.graphify.enabled',
+      'utilities.codegraph.enabled',
       'backward-compatible preference',
       'uv --version',
       'uv tool install graphifyy',
       'graphify install',
       'graphify .',
       'utilities:',
+      'context_tools:',
+      'enabled: []',
       'graphify:',
       'enabled: false',
       'uv_check: uv --version',
       'install: uv tool install graphifyy',
       'activate: graphify install',
       'report_command: graphify .',
+      'codegraph:',
+      'command: codegraph',
+      'status: codegraph status',
+      'init: codegraph init .',
+      'index: codegraph index --quiet .',
+      'query: codegraph query --path . --limit 10 --json',
+      'purge: codegraph uninit --force .',
       'Do not install `graphifyy`, run `graphify`'
     ]) {
       assertIncludes(combined, expected, 'aif-analyze Graphify utility guidance');
+    }
+  });
+
+  it('documents compression guardrails and CodeGraph manual CLI-only status', async () => {
+    const combined = [
+      await readRepoFile('skills/aif-analyze/SKILL.md'),
+      await readRepoFile('docs/context-providers.md'),
+      await readRepoFile('docs/context-loading-policy.md'),
+      await readRepoFile('docs/memory-tool-recommendations.md'),
+      await readRepoFile('docs/memory-tools-research/README.md')
+    ].join('\n');
+
+    for (const expected of [
+      'CodeGraph',
+      'manual_cli_only',
+      'suggest_manual_cli_for_repo_graph_when_enabled_or_explicit',
+      'codegraph --version',
+      'codegraph --help',
+      'codegraph status',
+      'codegraph init <project>',
+      'codegraph index --quiet <project>',
+      'codegraph query --path <project>',
+      'codegraph uninit --force <project>',
+      'Do not run `codegraph install`',
+      'serve --mcp',
+      'aif-gate-result',
+      'coverage.json',
+      'done-readiness.json',
+      'openspec/specs/**',
+      'generated-rules traces',
+      'exact evidence snippets',
+      'must not rewrite validation artifacts',
+      'must not compress protected artifacts in place'
+    ]) {
+      assertIncludes(combined, expected, 'context/memory provider guardrails');
     }
   });
 

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -1638,12 +1638,22 @@ function renderBlockOrDefault(blocks, key, fallback) {
 function renderUtilitiesBlock(blocks) {
   const fallback = [
     'utilities:',
+    '  context_tools:',
+    '    enabled: []',
     '  graphify:',
     '    enabled: false',
     '    uv_check: uv --version',
     '    install: uv tool install graphifyy',
     '    activate: graphify install',
-    '    report_command: graphify .'
+    '    report_command: graphify .',
+    '  codegraph:',
+    '    enabled: false',
+    '    command: codegraph',
+    '    status: codegraph status',
+    '    init: codegraph init .',
+    '    index: codegraph index --quiet .',
+    '    query: codegraph query --path . --limit 10 --json',
+    '    purge: codegraph uninit --force .'
   ].join('\n');
   const existing = blocks.find((block) => block.key === 'utilities')?.text.trimEnd();
 
@@ -1655,18 +1665,43 @@ function renderUtilitiesBlock(blocks) {
     return existing;
   }
 
-  if (/^  graphify:(?:\s|$)/m.test(existing)) {
+  const additions = [];
+  if (!/^  context_tools:(?:\s|$)/m.test(existing)) {
+    additions.push(
+      '  context_tools:',
+      '    enabled: []'
+    );
+  }
+  if (!/^  graphify:(?:\s|$)/m.test(existing)) {
+    additions.push(
+      '  graphify:',
+      '    enabled: false',
+      '    uv_check: uv --version',
+      '    install: uv tool install graphifyy',
+      '    activate: graphify install',
+      '    report_command: graphify .'
+    );
+  }
+  if (!/^  codegraph:(?:\s|$)/m.test(existing)) {
+    additions.push(
+      '  codegraph:',
+      '    enabled: false',
+      '    command: codegraph',
+      '    status: codegraph status',
+      '    init: codegraph init .',
+      '    index: codegraph index --quiet .',
+      '    query: codegraph query --path . --limit 10 --json',
+      '    purge: codegraph uninit --force .'
+    );
+  }
+
+  if (additions.length === 0) {
     return existing;
   }
 
   return [
     existing,
-    '  graphify:',
-    '    enabled: false',
-    '    uv_check: uv --version',
-    '    install: uv tool install graphifyy',
-    '    activate: graphify install',
-    '    report_command: graphify .'
+    ...additions
   ].join('\n');
 }
 

--- a/scripts/aif-explore-improve-openspec-artifacts.test.mjs
+++ b/scripts/aif-explore-improve-openspec-artifacts.test.mjs
@@ -220,6 +220,42 @@ describe('aif-explore and aif-improve OpenSpec-native contracts', () => {
     }
   });
 
+  it('lets /aif-explore use enabled optional tools only within metadata permissions', async () => {
+    const injection = await readRepoFile('injections/core/aif-explore-plan-folder.md');
+    const openspec = extractSection(injection, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'Enabled optional tool use',
+      'recommendation-metadata.yaml',
+      'ai-factory aifhub-memory-tools select --from-project --command aif-explore --json',
+      'utilities.context_tools.enabled',
+      'selected_tools',
+      'not_selected_tools',
+      'tool_id',
+      'permission',
+      'execution',
+      'forbidden_operations',
+      'protected_artifacts',
+      'Do not use tools that are absent from `selected_tools`',
+      'If no optional provider is selected, continue with the rg baseline',
+      'This provider-specific boundary applies only when `selected_tools` includes Graphify',
+      'This provider-specific boundary applies only when `selected_tools` includes Context7'
+    ]) {
+      assertIncludes(openspec, expected, 'aif-explore enabled optional tool use');
+    }
+
+    for (const unexpected of [
+      'codegraph init <project>',
+      'codegraph index --quiet <project>',
+      'codegraph query --path <project>',
+      'codegraph uninit --force <project>',
+      'utilities.codegraph.enabled: true',
+      'utilities.graphify.enabled: true'
+    ]) {
+      assertNotIncludes(openspec, unexpected, 'aif-explore should rely on CLI-selected tool execution');
+    }
+  });
+
   it('keeps Codex and IDE planning-mode guidance capability-gated', async () => {
     for (const relativePath of [
       'injections/core/aif-explore-plan-folder.md',

--- a/scripts/aif-plan-openspec-artifacts.test.mjs
+++ b/scripts/aif-plan-openspec-artifacts.test.mjs
@@ -174,4 +174,25 @@ describe('aif-plan OpenSpec-native planning contract', () => {
       'docs/openspec-compatibility.md'
     );
   });
+
+  it('uses CLI-selected optional tools for /aif-plan instead of a prompt-owned provider list', async () => {
+    const injection = await readRepoFile('injections/core/aif-plan-plan-folder.md');
+
+    for (const expected of [
+      'Enabled optional tool use',
+      'ai-factory aifhub-memory-tools select --from-project --command aif-plan --json',
+      'selected_tools',
+      'not_selected_tools',
+      'tool_id',
+      'permission',
+      'execution',
+      'forbidden_operations',
+      'protected_artifacts',
+      'Do not use tools that are absent from `selected_tools`',
+      'This provider-specific boundary applies only when `selected_tools` includes Graphify',
+      'This provider-specific boundary applies only when `selected_tools` includes Context7'
+    ]) {
+      assertIncludes(injection, expected, 'aif-plan enabled optional tool use');
+    }
+  });
 });

--- a/scripts/memory-tool-recommender.mjs
+++ b/scripts/memory-tool-recommender.mjs
@@ -744,7 +744,7 @@ async function probeCommand(command, args) {
     };
   } catch (err) {
     if (process.platform === 'win32' && (err?.code === 'ENOENT' || err?.code === 'EINVAL')) {
-      return probeWindowsShellCommand(command, args, commandLabel, err.code);
+      return probeWindowsShellCommand(command, args, commandLabel);
     }
     return {
       availability: err?.code === 'ENOENT' ? 'not_installed' : 'unknown',
@@ -754,7 +754,7 @@ async function probeCommand(command, args) {
   }
 }
 
-async function probeWindowsShellCommand(command, args, commandLabel, originalCode = null) {
+async function probeWindowsShellCommand(command, args, commandLabel) {
   const shell = process.env.ComSpec || 'cmd.exe';
   const commandLine = [command, ...args].map(quoteWindowsShellArg).join(' ');
   try {
@@ -769,14 +769,17 @@ async function probeWindowsShellCommand(command, args, commandLabel, originalCod
     };
   } catch (err) {
     const output = `${err?.stdout ?? ''}\n${err?.stderr ?? ''}`;
-    const notFound = /not recognized|cannot find|not found/i.test(output);
-    const directSpawnCouldNotResolve = originalCode === 'ENOENT' || originalCode === 'EINVAL';
+    const notFound = isWindowsShellCommandNotFound(output);
     return {
-      availability: notFound || directSpawnCouldNotResolve ? 'not_installed' : 'unknown',
+      availability: notFound ? 'not_installed' : 'unknown',
       command: commandLabel,
-      reason: notFound || directSpawnCouldNotResolve ? 'command-not-found' : 'probe-failed'
+      reason: notFound ? 'command-not-found' : 'probe-failed'
     };
   }
+}
+
+export function isWindowsShellCommandNotFound(output) {
+  return /not recognized|cannot find|not found/i.test(String(output ?? ''));
 }
 
 function quoteWindowsShellArg(value) {

--- a/scripts/memory-tool-recommender.mjs
+++ b/scripts/memory-tool-recommender.mjs
@@ -1148,13 +1148,49 @@ function parseScalar(value) {
   }
 
   const lower = trimmed.toLowerCase();
-  if (trimmed === '[]') return [];
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return parseInlineList(trimmed);
+  }
   if (lower === 'true') return true;
   if (lower === 'false') return false;
   if (lower === 'null') return null;
   if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
 
   return trimmed;
+}
+
+function parseInlineList(value) {
+  const body = String(value ?? '').trim().slice(1, -1).trim();
+  if (!body) return [];
+  return splitInlineListItems(body).map((item) => parseScalar(item));
+}
+
+function splitInlineListItems(value) {
+  const items = [];
+  let quote = null;
+  let current = '';
+  const raw = String(value ?? '');
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if ((char === '"' || char === "'") && (index === 0 || raw[index - 1] !== '\\')) {
+      quote = quote === char ? null : quote ?? char;
+      current += char;
+      continue;
+    }
+    if (char === ',' && quote === null) {
+      items.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.trim().length > 0) {
+    items.push(current.trim());
+  }
+
+  return items;
 }
 
 function stripInlineComment(value) {

--- a/scripts/memory-tool-recommender.mjs
+++ b/scripts/memory-tool-recommender.mjs
@@ -12,9 +12,11 @@ const execFileAsync = promisify(execFile);
 export const RECOMMENDATION_RESULT_SCHEMA = 'aifhub.memory_tools.recommendation_result.v1';
 export const METADATA_RESULT_SCHEMA = 'aifhub.memory_tools.metadata_result.v1';
 export const STATUS_RESULT_SCHEMA = 'aifhub.memory_tools.status_result.v1';
+export const SELECTION_RESULT_SCHEMA = 'aifhub.memory_tools.selection_result.v1';
 export const ERROR_SCHEMA = 'aifhub.memory_tools.error.v1';
 
 const METADATA_RELATIVE_PATH = path.join('docs', 'memory-tools-research', 'recommendation-metadata.yaml');
+const PROJECT_CONFIG_RELATIVE_PATH = path.join('.ai-factory', 'config.yaml');
 const INSTALLED_EXTENSION_PARTS = ['.ai-factory', 'extensions', 'aifhub-extension'];
 const VALID_PROJECT_SHAPES = new Set([
   'large_legacy',
@@ -24,6 +26,7 @@ const VALID_PROJECT_SHAPES = new Set([
   'small_microservice'
 ]);
 const DEFAULT_TASK_SIGNAL = 'architecture_or_impact_discovery';
+const DEFAULT_COMMAND = 'aif-analyze';
 const ALWAYS_REJECTED_TOOLS = new Set(['codex-mem', 'eagle-mem']);
 const MANUAL_ONLY_TASKS = new Map([
   ['agent-memory', new Set(['manual_durable_notes'])]
@@ -92,6 +95,41 @@ export async function runMemoryToolRecommender(args = [], options = {}) {
         metadata: loaded.metadata,
         projectShape,
         taskSignals,
+        command: parsed.flags.command,
+        checkDocsProvider: Boolean(parsed.flags.checkDocsProvider),
+        probeRunner: options.probeRunner
+      });
+      return emitResult(body, 0, { ...options, json });
+    }
+
+    if (parsed.command === 'select') {
+      const loaded = await tryLoadMetadata(parsed, cwd, options);
+      const taskSignals = parsed.flags.task.length > 0 ? parsed.flags.task : [DEFAULT_TASK_SIGNAL];
+      const projectShape = parsed.flags.fromProject
+        ? await classifyProjectShape(cwd)
+        : normalizeProjectShape(parsed.flags.shape);
+      const config = await loadProjectToolConfig({
+        cwd,
+        metadata: loaded.ok ? loaded.metadata : null
+      });
+
+      if (!loaded.ok) {
+        const body = degradedSelectionResult({
+          metadataError: loaded,
+          config,
+          projectShape,
+          taskSignals,
+          command: parsed.flags.command
+        });
+        return emitResult(body, 0, { ...options, json });
+      }
+
+      const body = await buildSelectionResult({
+        metadata: loaded.metadata,
+        config,
+        projectShape,
+        taskSignals,
+        command: parsed.flags.command,
         checkDocsProvider: Boolean(parsed.flags.checkDocsProvider),
         probeRunner: options.probeRunner
       });
@@ -192,10 +230,47 @@ export async function resolveMetadataPath(options = {}) {
   return metadataMissing(candidates, 'Local recommendation metadata was not found.');
 }
 
+export async function loadProjectToolConfig(options = {}) {
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const configPath = path.join(cwd, PROJECT_CONFIG_RELATIVE_PATH);
+
+  if (!await pathExists(configPath)) {
+    return {
+      source_kind: 'missing',
+      source_path: configPath,
+      enabled_tools: [],
+      warnings: [{
+        code: 'config-missing',
+        message: 'Project config .ai-factory/config.yaml was not found.'
+      }]
+    };
+  }
+
+  try {
+    const raw = await readFile(configPath, 'utf8');
+    const parsed = parseSimpleYaml(raw);
+    return normalizeProjectToolConfig(parsed, {
+      sourcePath: configPath,
+      metadata: options.metadata
+    });
+  } catch (err) {
+    return {
+      source_kind: 'invalid',
+      source_path: configPath,
+      enabled_tools: [],
+      warnings: [{
+        code: 'config-unreadable',
+        message: `Project config could not be read: ${err?.message ?? String(err)}`
+      }]
+    };
+  }
+}
+
 export async function buildRecommendationResult(options = {}) {
   const metadata = options.metadata;
   const projectShape = normalizeProjectShape(options.projectShape);
   const taskSignals = normalizeTaskSignals(options.taskSignals);
+  const command = normalizeCommand(options.command);
   const baseline = [metadata?.default_policy?.baseline_tool ?? 'rg'];
   const warnings = [];
   const candidates = collectCandidateTools(metadata, projectShape, taskSignals);
@@ -205,6 +280,8 @@ export async function buildRecommendationResult(options = {}) {
     const tool = metadata.tools?.[toolId];
     if (!tool || isRejectedTool(toolId, tool)) continue;
     if (!isAllowedForRequest(toolId, tool, projectShape, taskSignals, metadata)) continue;
+    const permission = permissionForTool(metadata, toolId, command);
+    if (commandBoundaryReason(tool, command, permission)) continue;
 
     const probe = await runProbeForTool(toolId, {
       checkDocsProvider: Boolean(options.checkDocsProvider),
@@ -213,6 +290,8 @@ export async function buildRecommendationResult(options = {}) {
     recommendations.push(buildRecommendation(toolId, tool, {
       projectShape,
       taskSignals,
+      command,
+      permission,
       availability: probe.availability,
       command: probe.command
     }));
@@ -227,7 +306,102 @@ export async function buildRecommendationResult(options = {}) {
     baseline,
     recommendations: dedupeRecommendations(recommendations),
     do_not_recommend: buildDoNotRecommend(metadata, projectShape, taskSignals),
+    protected_artifacts: asArray(metadata.protected_artifacts),
+    forbidden_operations: asArray(metadata.forbidden_operations),
     warnings
+  };
+}
+
+export async function buildSelectionResult(options = {}) {
+  const metadata = options.metadata;
+  const projectShape = normalizeProjectShape(options.projectShape);
+  const taskSignals = normalizeTaskSignals(options.taskSignals);
+  const command = normalizeCommand(options.command);
+  const config = options.config ?? {
+    source_kind: 'missing',
+    source_path: null,
+    enabled_tools: [],
+    warnings: []
+  };
+  const baseline = [metadata?.default_policy?.baseline_tool ?? 'rg'];
+  const selectedTools = [];
+  const notSelectedTools = [];
+
+  for (const toolId of asArray(config.enabled_tools)) {
+    const tool = metadata.tools?.[toolId];
+    if (!tool) {
+      notSelectedTools.push({
+        tool_id: toolId,
+        reason: 'unknown tool id in project config'
+      });
+      continue;
+    }
+
+    const permission = permissionForTool(metadata, toolId, command);
+    const boundaryReason = commandBoundaryReason(tool, command, permission);
+    if (boundaryReason) {
+      notSelectedTools.push({
+        tool_id: toolId,
+        reason: boundaryReason,
+        permission
+      });
+      continue;
+    }
+
+    if (isRejectedTool(toolId, tool)) {
+      notSelectedTools.push({
+        tool_id: toolId,
+        reason: tool.avoid_reason ?? `${tool.display_name ?? toolId} is rejected by local metadata.`,
+        permission
+      });
+      continue;
+    }
+
+    if (!isAllowedForRequest(toolId, tool, projectShape, taskSignals, metadata)) {
+      notSelectedTools.push({
+        tool_id: toolId,
+        reason: `${tool.display_name ?? toolId} is not applicable for ${projectShape} + ${taskSignals.join(', ')}.`,
+        permission
+      });
+      continue;
+    }
+
+    const probe = await runProbeForTool(toolId, {
+      checkDocsProvider: Boolean(options.checkDocsProvider),
+      probeRunner: options.probeRunner
+    });
+    selectedTools.push({
+      ...buildRecommendation(toolId, tool, {
+        projectShape,
+        taskSignals,
+        command,
+        permission,
+        availability: probe.availability,
+        command: probe.command
+      }),
+      configured: true,
+      execution: executionForTool(tool, command)
+    });
+  }
+
+  return {
+    schema: SELECTION_RESULT_SCHEMA,
+    metadata_available: true,
+    metadata_source: metadata.source_path ?? null,
+    config: {
+      source_kind: config.source_kind,
+      source_path: config.source_path ? toPosix(path.normalize(config.source_path)) : null,
+      enabled_tools: asArray(config.enabled_tools)
+    },
+    command,
+    project_shape: projectShape,
+    task_signals: taskSignals,
+    baseline,
+    selected_tools: dedupeRecommendations(selectedTools),
+    not_selected_tools: notSelectedTools,
+    protected_artifacts: asArray(metadata.protected_artifacts),
+    forbidden_operations: asArray(metadata.forbidden_operations),
+    warnings: asArray(config.warnings)
   };
 }
 
@@ -263,7 +437,12 @@ function metadataSummary(metadata) {
       recommendation_action: tool.recommendation_action ?? null,
       install_policy: tool.install_policy ?? metadata.default_policy?.install_policy ?? null,
       read_scope: tool.read_scope ?? null,
-      purge_path: tool.purge_path ?? null
+      purge_path: tool.purge_path ?? null,
+      allowed_in: asArray(tool.allowed_in),
+      forbidden_in: asArray(tool.forbidden_in),
+      privacy_caveat: tool.privacy_caveat ?? null,
+      permissions: metadata.tool_permissions?.[toolId] ?? null,
+      execution: tool.execution ?? null
     };
   }
 
@@ -273,6 +452,11 @@ function metadataSummary(metadata) {
     metadata_available: true,
     metadata_source: metadata.source_path ?? null,
     default_policy: metadata.default_policy ?? {},
+    skill_usage_matrix: metadata.skill_usage_matrix ?? {},
+    tool_permissions: metadata.tool_permissions ?? {},
+    availability_probes: metadata.availability_probes ?? {},
+    forbidden_operations: asArray(metadata.forbidden_operations),
+    protected_artifacts: asArray(metadata.protected_artifacts),
     project_shape_signals: Object.keys(metadata.project_shape_signals ?? {}),
     task_signals: Object.keys(metadata.task_signals ?? {}),
     tools
@@ -290,6 +474,31 @@ function degradedRecommendationResult(options = {}) {
     recommendations: [],
     do_not_recommend: [],
     warnings: [metadataWarning(options.metadataError)]
+  };
+}
+
+function degradedSelectionResult(options = {}) {
+  return {
+    schema: SELECTION_RESULT_SCHEMA,
+    metadata_available: false,
+    metadata_source: options.metadataError?.path ?? null,
+    config: {
+      source_kind: options.config?.source_kind ?? 'missing',
+      source_path: options.config?.source_path ? toPosix(path.normalize(options.config.source_path)) : null,
+      enabled_tools: asArray(options.config?.enabled_tools)
+    },
+    command: normalizeCommand(options.command),
+    project_shape: normalizeProjectShape(options.projectShape),
+    task_signals: normalizeTaskSignals(options.taskSignals),
+    baseline: ['rg'],
+    selected_tools: [],
+    not_selected_tools: [],
+    protected_artifacts: [],
+    forbidden_operations: [],
+    warnings: [
+      metadataWarning(options.metadataError),
+      ...asArray(options.config?.warnings)
+    ]
   };
 }
 
@@ -373,6 +582,20 @@ function isRejectedTool(toolId, tool) {
     || /^do_not_/.test(String(tool.recommendation_action ?? ''));
 }
 
+function commandBoundaryReason(tool, command, permission) {
+  if (permission === 'forbidden') {
+    return `${tool.display_name ?? 'Tool'} is forbidden for ${command}.`;
+  }
+  if (asArray(tool.forbidden_in).includes(command)) {
+    return `${tool.display_name ?? 'Tool'} is forbidden for ${command}.`;
+  }
+  const allowedIn = asArray(tool.allowed_in).filter((scope) => String(scope).startsWith('aif-'));
+  if (allowedIn.length > 0 && !allowedIn.includes(command)) {
+    return `${tool.display_name ?? 'Tool'} is not allowed for ${command}.`;
+  }
+  return null;
+}
+
 function buildRecommendation(toolId, tool, context) {
   const installPolicy = tool.install_policy ?? 'explicit_user_opt_in_only';
   return {
@@ -384,8 +607,18 @@ function buildRecommendation(toolId, tool, context) {
     install_policy: installPolicy,
     read_scope: tool.read_scope ?? 'unknown',
     purge_path: tool.purge_path ?? 'unknown',
+    allowed_in: asArray(tool.allowed_in),
+    forbidden_in: asArray(tool.forbidden_in),
+    permission: context.permission ?? null,
+    privacy_caveat: tool.privacy_caveat ?? null,
     next_step: nextStepForTool(toolId, tool)
   };
+}
+
+function executionForTool(tool, command) {
+  const execution = tool?.execution;
+  if (!execution || typeof execution !== 'object') return null;
+  return execution[command] ?? execution.default ?? null;
 }
 
 function nextStepForTool(toolId, tool) {
@@ -400,6 +633,9 @@ function nextStepForTool(toolId, tool) {
   }
   if (toolId === 'context7') {
     return 'Use only as optional user-owned docs lookup for version-sensitive library/API questions.';
+  }
+  if (toolId === 'codegraph') {
+    return 'Use rg first; for broad repo graph questions only, run codegraph init <project>, codegraph index --quiet <project>, codegraph query --path <project> ... --json, then codegraph uninit --force <project>. Do not run codegraph install, sync, serve, serve --mcp, or mutate agent config.';
   }
   if (toolId === 'agent-memory') {
     return 'Use only as a manual markdown notebook when the user explicitly asks for durable notes.';
@@ -468,6 +704,13 @@ async function runProbeForTool(toolId, options = {}) {
     }
     return probeAny([['ctx7', ['--version']], ['npx', ['--no-install', 'ctx7', '--help']]]);
   }
+  if (toolId === 'codegraph') {
+    return probeAny([
+      ['codegraph', ['--version']],
+      ['codegraph', ['--help']],
+      ['codegraph', ['status']]
+    ]);
+  }
 
   return {
     availability: 'unknown',
@@ -500,12 +743,46 @@ async function probeCommand(command, args) {
       command: commandLabel
     };
   } catch (err) {
+    if (process.platform === 'win32' && (err?.code === 'ENOENT' || err?.code === 'EINVAL')) {
+      return probeWindowsShellCommand(command, args, commandLabel, err.code);
+    }
     return {
       availability: err?.code === 'ENOENT' ? 'not_installed' : 'unknown',
       command: commandLabel,
       reason: err?.code === 'ENOENT' ? 'command-not-found' : 'probe-failed'
     };
   }
+}
+
+async function probeWindowsShellCommand(command, args, commandLabel, originalCode = null) {
+  const shell = process.env.ComSpec || 'cmd.exe';
+  const commandLine = [command, ...args].map(quoteWindowsShellArg).join(' ');
+  try {
+    await execFileAsync(shell, ['/d', '/s', '/c', commandLine], {
+      windowsHide: true,
+      timeout: 5000,
+      maxBuffer: 64 * 1024
+    });
+    return {
+      availability: 'installed',
+      command: commandLabel
+    };
+  } catch (err) {
+    const output = `${err?.stdout ?? ''}\n${err?.stderr ?? ''}`;
+    const notFound = /not recognized|cannot find|not found/i.test(output);
+    const directSpawnCouldNotResolve = originalCode === 'ENOENT' || originalCode === 'EINVAL';
+    return {
+      availability: notFound || directSpawnCouldNotResolve ? 'not_installed' : 'unknown',
+      command: commandLabel,
+      reason: notFound || directSpawnCouldNotResolve ? 'command-not-found' : 'probe-failed'
+    };
+  }
+}
+
+function quoteWindowsShellArg(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9._:=+/@%-]+$/.test(text)) return text;
+  return `"${text.replaceAll('"', '\\"')}"`;
 }
 
 function normalizeProbeResult(probe) {
@@ -642,6 +919,7 @@ function parseArgs(args) {
     checkDocsProvider: false,
     shape: null,
     task: [],
+    command: null,
     metadata: null
   };
 
@@ -657,6 +935,8 @@ function parseArgs(args) {
       flags.shape = rest[++index];
     } else if (token === '--task') {
       flags.task.push(rest[++index]);
+    } else if (token === '--command') {
+      flags.command = rest[++index];
     } else if (token === '--metadata') {
       flags.metadata = rest[++index];
     }
@@ -668,6 +948,49 @@ function parseArgs(args) {
   };
 }
 
+function normalizeProjectToolConfig(parsed, options = {}) {
+  const metadataTools = Object.keys(options.metadata?.tools ?? {});
+  const utilities = isPlainObject(parsed.utilities) ? parsed.utilities : {};
+  const contextTools = firstPlainObject(
+    utilities.context_tools,
+    utilities.optional_context_tools,
+    utilities.memory_tools
+  );
+  const enabled = [];
+
+  for (const toolId of asArray(contextTools.enabled)) {
+    addNormalizedToolId(enabled, toolId);
+  }
+
+  for (const toolId of metadataTools) {
+    const utility = utilities[toolId];
+    if (utility === true || (isPlainObject(utility) && utility.enabled === true)) {
+      addNormalizedToolId(enabled, toolId);
+    }
+  }
+
+  return {
+    source_kind: 'project-config',
+    source_path: options.sourcePath ?? null,
+    enabled_tools: enabled,
+    warnings: []
+  };
+}
+
+function firstPlainObject(...values) {
+  return values.find((value) => isPlainObject(value)) ?? {};
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function addNormalizedToolId(target, value) {
+  const text = String(value ?? '').trim();
+  if (!text || target.includes(text)) return;
+  target.push(text);
+}
+
 function normalizeProjectShape(shape) {
   const normalized = String(shape ?? 'large_framework_app').trim();
   return VALID_PROJECT_SHAPES.has(normalized) ? normalized : 'large_framework_app';
@@ -676,6 +999,17 @@ function normalizeProjectShape(shape) {
 function normalizeTaskSignals(signals) {
   const normalized = asArray(signals).map((signal) => String(signal).trim()).filter(Boolean);
   return normalized.length > 0 ? [...new Set(normalized)] : [DEFAULT_TASK_SIGNAL];
+}
+
+function normalizeCommand(command) {
+  const normalized = String(command ?? DEFAULT_COMMAND).trim();
+  return normalized || DEFAULT_COMMAND;
+}
+
+function permissionForTool(metadata, toolId, command) {
+  const permissions = metadata?.tool_permissions?.[toolId];
+  if (!permissions || typeof permissions !== 'object') return null;
+  return permissions[command] ?? permissions.default ?? null;
 }
 
 function dedupeRecommendations(recommendations) {
@@ -811,6 +1145,7 @@ function parseScalar(value) {
   }
 
   const lower = trimmed.toLowerCase();
+  if (trimmed === '[]') return [];
   if (lower === 'true') return true;
   if (lower === 'false') return false;
   if (lower === 'null') return null;

--- a/scripts/memory-tool-recommender.test.mjs
+++ b/scripts/memory-tool-recommender.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   buildRecommendationResult,
+  isWindowsShellCommandNotFound,
   loadRecommendationMetadata,
   parseRecommendationMetadata,
   resolveMetadataPath,
@@ -566,6 +567,21 @@ describe('CLI behavior', () => {
 
     const graphify = result.recommendations.find((item) => item.tool_id === 'graphify');
     assert.equal(graphify.availability, 'not_installed');
+  });
+
+  it('classifies Windows shell fallback failures only from explicit not-found output', () => {
+    assert.equal(
+      isWindowsShellCommandNotFound("'codegraph' is not recognized as an internal or external command."),
+      true
+    );
+    assert.equal(
+      isWindowsShellCommandNotFound('Error: project index is missing. Run codegraph init first.'),
+      false
+    );
+    assert.equal(
+      isWindowsShellCommandNotFound('The CLI returned exit code 1 because workspace state is invalid.'),
+      false
+    );
   });
 
   it('detects Windows npm command shims during status probes', { skip: process.platform !== 'win32' }, async () => {

--- a/scripts/memory-tool-recommender.test.mjs
+++ b/scripts/memory-tool-recommender.test.mjs
@@ -437,6 +437,44 @@ describe('recommendation results', () => {
     assert.match(skippedCodegraph.reason, /forbidden/i);
   });
 
+  it('selects enabled tools from inline YAML config lists', async () => {
+    await mkdir(path.join(tmpDir, '.ai-factory'), { recursive: true });
+    await writeFile(
+      path.join(tmpDir, '.ai-factory', 'config.yaml'),
+      [
+        'utilities:',
+        '  context_tools:',
+        '    enabled: [codegraph, graphify]',
+        ''
+      ].join('\n'),
+      'utf8'
+    );
+
+    const result = await runMemoryToolRecommender([
+      'select',
+      '--shape',
+      'large_framework_app',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--command',
+      'aif-explore',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ], {
+      cwd: tmpDir,
+      stdout: [],
+      stderr: [],
+      exit: false,
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.body.config.enabled_tools, ['codegraph', 'graphify']);
+    assert.ok(result.body.selected_tools.some((item) => item.tool_id === 'codegraph'));
+    assert.ok(result.body.selected_tools.some((item) => item.tool_id === 'graphify'));
+  });
+
   it('selects legacy utility-enabled tools as compatibility config', async () => {
     await mkdir(path.join(tmpDir, '.ai-factory'), { recursive: true });
     await writeFile(

--- a/scripts/memory-tool-recommender.test.mjs
+++ b/scripts/memory-tool-recommender.test.mjs
@@ -60,12 +60,19 @@ describe('recommendation metadata parsing', () => {
     assert.equal(metadata.default_policy.install_policy, 'explicit_user_opt_in_only');
     assert.equal(metadata.default_policy.require_explicit_paths, true);
     assert.equal(metadata.default_policy.require_purge_path, true);
+    assert.ok(metadata.skill_usage_matrix['aif-analyze']);
+    assert.equal(metadata.tool_permissions.graphify['aif-analyze'], 'recommend_only');
+    assert.equal(metadata.availability_probes.graphify[0], 'graphify --version');
+    assert.ok(metadata.forbidden_operations.includes('auto_install'));
+    assert.ok(metadata.protected_artifacts.includes('aif-gate-result'));
+    assert.ok(metadata.protected_artifacts.includes('coverage.json'));
     assert.equal(metadata.tools.graphify.decision, 'optional');
     assert.equal(metadata.tools['codex-agent-mem'].read_scope, 'explicit_sqlite_db_path');
     assert.equal(metadata.tools['context-mode'].decision, 'manual_helper_only');
     assert.equal(metadata.tools['codex-mem'].decision, 'reject_default');
     assert.equal(metadata.tools['eagle-mem'].decision, 'reject_defer');
     assert.equal(metadata.tools.context7.decision, 'optional');
+    assert.equal(metadata.tools.codegraph.decision, 'manual_cli_only');
   });
 });
 
@@ -136,7 +143,106 @@ describe('recommendation results', () => {
     assert.equal(graphify.status, 'optional');
     assert.equal(graphify.install_policy, 'explicit_user_opt_in_only');
     assert.equal(graphify.read_scope, 'explicit_project_path');
+    assert.deepEqual(graphify.allowed_in, ['aif-analyze', 'aif-explore', 'aif-plan', 'aif-review']);
+    assert.ok(graphify.forbidden_in.includes('aif-implement'));
+    assert.equal(graphify.permission, 'recommend_only');
+    assert.match(graphify.privacy_caveat, /explicit project path/i);
     assert.match(graphify.next_step, /Use rg first/i);
+  });
+
+  it('surfaces protected artifacts and matrix policy in metadata JSON', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const result = await runMemoryToolRecommender([
+      'metadata',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ], {
+      cwd: REPO_ROOT,
+      stdout: [],
+      stderr: [],
+      exit: false
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.body.schema, 'aifhub.memory_tools.metadata_result.v1');
+    assert.deepEqual(result.body.skill_usage_matrix['aif-analyze'].allowed, [
+      'rg',
+      'graphify',
+      'context7',
+      'codex-agent-mem',
+      'context-mode',
+      'codegraph'
+    ]);
+    assert.equal(result.body.tool_permissions.graphify['aif-implement'], 'forbidden');
+    assert.equal(result.body.tool_permissions.codegraph['aif-analyze'], 'recommend_only');
+    assert.equal(result.body.tool_permissions.codegraph['aif-explore'], 'manual_purged_cli_execution');
+    assert.match(JSON.stringify(result.body.tools.codegraph.execution), /codegraph init <project>/);
+    assert.match(JSON.stringify(result.body.tools.graphify.execution), /read_existing_reviewed_output/);
+    assert.ok(result.body.forbidden_operations.includes('auto_register_mcp'));
+    assert.ok(result.body.protected_artifacts.includes('done-readiness.json'));
+    assert.ok(result.body.protected_artifacts.includes('openspec/specs/**'));
+    assert.equal(metadata.tools.codegraph.recommendation_action, 'suggest_manual_cli_for_repo_graph_when_enabled_or_explicit');
+  });
+
+  it('allows CodeGraph only as scoped manual CLI for analyze recommendations and enabled explore use', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const codegraph = metadata.tools.codegraph;
+
+    assert.equal(codegraph.display_name, 'CodeGraph');
+    assert.equal(codegraph.decision, 'manual_cli_only');
+    assert.equal(codegraph.recommendation_action, 'suggest_manual_cli_for_repo_graph_when_enabled_or_explicit');
+    assert.equal(codegraph.install_policy, 'explicit_user_opt_in_only');
+    assert.equal(codegraph.stable_cli, 'verified_for_version_help_status_init_index_query_uninit');
+    assert.equal(codegraph.read_scope, 'explicit_project_path_verified_for_cli_init_index_status_query');
+    assert.equal(codegraph.purge_path, 'codegraph uninit --force <project> verified');
+    assert.deepEqual(codegraph.allowed_in, ['aif-analyze', 'aif-explore']);
+    assert.ok(!codegraph.forbidden_in.includes('aif-analyze'));
+    assert.ok(!codegraph.forbidden_in.includes('aif-explore'));
+    assert.ok(codegraph.forbidden_in.includes('aif-implement'));
+    assert.equal(metadata.tool_permissions.codegraph['aif-analyze'], 'recommend_only');
+    assert.equal(metadata.tool_permissions.codegraph['aif-explore'], 'manual_purged_cli_execution');
+    assert.equal(metadata.tool_permissions.codegraph.default, 'forbidden');
+    assert.deepEqual(metadata.availability_probes.codegraph, [
+      'codegraph --version',
+      'codegraph --help',
+      'codegraph status'
+    ]);
+    assert.match(codegraph.privacy_caveat, /\.codegraph/i);
+    assert.match(codegraph.privacy_caveat, /purged/i);
+  });
+
+  it('records CodeGraph real-root lifecycle evidence for manual CLI use', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const run = metadata.evidence_runs.find((item) => item.id === 'local-real-project-codegraph-safety-2026-05-23');
+
+    assert.ok(run);
+    assert.equal(run.install.user_requested, true);
+    assert.equal(run.install.version, '0.9.3');
+    assert.ok(run.not_run.includes('codegraph install'));
+    assert.ok(run.not_run.includes('codegraph serve --mcp'));
+    assert.equal(run.outcomes.codegraph.roots_tested, 29);
+    assert.equal(run.outcomes.codegraph.lifecycle_passed, 29);
+    assert.equal(run.outcomes.codegraph.command_failures, 0);
+    assert.equal(run.outcomes.codegraph.query_failures, 0);
+    assert.equal(run.outcomes.codegraph.protected_config_mutations, 0);
+    assert.equal(run.outcomes.codegraph.leftover_codegraph_dirs, 0);
+    assert.deepEqual(metadata.tools.codegraph.allowed_in, ['aif-analyze', 'aif-explore']);
+  });
+
+  it('declares explicit allowed scopes for rejected providers', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+
+    for (const toolId of ['codex-mem', 'eagle-mem']) {
+      assert.deepEqual(
+        metadata.tools[toolId].allowed_in,
+        [],
+        `${toolId} should declare allowed_in: [] instead of relying on an absent field`
+      );
+      assert.ok(metadata.tools[toolId].forbidden_in.length > 0);
+      assert.equal(metadata.tools[toolId].install_policy, 'do_not_auto_install');
+      assert.match(metadata.tools[toolId].privacy_caveat, /\S/);
+    }
   });
 
   it('recommends codex-agent-mem only for continuity tasks', async () => {
@@ -183,9 +289,189 @@ describe('recommendation results', () => {
 
     assert.deepEqual(result.baseline, ['rg']);
     assert.equal(result.recommendations.some((item) => item.tool_id === 'graphify'), false);
+    assert.equal(result.recommendations.some((item) => item.tool_id === 'codegraph'), false);
     assert.equal(result.recommendations.some((item) => item.tool_id === 'context-mode'), false);
     assert.ok(result.do_not_recommend.some((item) => item.tool_id === 'codex-mem'));
     assert.ok(result.do_not_recommend.some((item) => item.tool_id === 'eagle-mem'));
+  });
+
+  it('recommends CodeGraph for broad repo graph questions with command-specific permissions', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const analyzeResult = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['architecture_or_impact_discovery'],
+      command: 'aif-analyze',
+      probeRunner: async (toolId) => ({
+        availability: 'installed',
+        command: toolId === 'codegraph' ? 'codegraph --version' : `${toolId} --version`
+      })
+    });
+    const exploreResult = await buildRecommendationResult({
+      metadata,
+      projectShape: 'multirepo',
+      taskSignals: ['multirepo_surface_mapping'],
+      command: 'aif-explore',
+      probeRunner: async () => ({ availability: 'installed', command: 'codegraph --version' })
+    });
+
+    const analyzeCodegraph = analyzeResult.recommendations.find((item) => item.tool_id === 'codegraph');
+    const exploreCodegraph = exploreResult.recommendations.find((item) => item.tool_id === 'codegraph');
+
+    assert.ok(analyzeCodegraph);
+    assert.equal(analyzeCodegraph.status, 'manual_cli_only');
+    assert.equal(analyzeCodegraph.permission, 'recommend_only');
+    assert.equal(analyzeCodegraph.install_policy, 'explicit_user_opt_in_only');
+    assert.equal(analyzeCodegraph.availability, 'installed');
+    assert.match(analyzeCodegraph.next_step, /codegraph init <project>/i);
+    assert.match(analyzeCodegraph.next_step, /codegraph uninit --force <project>/i);
+    assert.ok(!analyzeResult.do_not_recommend.some((item) => item.tool_id === 'codegraph'));
+    assert.ok(exploreCodegraph);
+    assert.equal(exploreCodegraph.permission, 'manual_purged_cli_execution');
+  });
+
+  it('does not recommend tools forbidden for the current command', async () => {
+    const metadata = await loadRecommendationMetadata({ metadataPath: REAL_METADATA });
+    const planResult = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['architecture_or_impact_discovery'],
+      command: 'aif-plan',
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+    const reviewResult = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['architecture_or_impact_discovery'],
+      command: 'aif-review',
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+    const compressionForPlan = await buildRecommendationResult({
+      metadata,
+      projectShape: 'large_framework_app',
+      taskSignals: ['large_command_output_compression'],
+      command: 'aif-plan',
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+
+    assert.ok(planResult.recommendations.some((item) => item.tool_id === 'graphify'));
+    assert.equal(planResult.recommendations.some((item) => item.tool_id === 'codegraph'), false);
+    assert.equal(reviewResult.recommendations.some((item) => item.tool_id === 'codegraph'), false);
+    assert.equal(compressionForPlan.recommendations.some((item) => item.tool_id === 'context-mode'), false);
+    for (const result of [planResult, reviewResult, compressionForPlan]) {
+      assert.equal(result.recommendations.some((item) => item.permission === 'forbidden'), false);
+    }
+  });
+
+  it('selects enabled tools from project config per command without prompt-specific tool lists', async () => {
+    await mkdir(path.join(tmpDir, '.ai-factory'), { recursive: true });
+    await writeFile(
+      path.join(tmpDir, '.ai-factory', 'config.yaml'),
+      [
+        'utilities:',
+        '  context_tools:',
+        '    enabled:',
+        '      - codegraph',
+        '      - graphify',
+        ''
+      ].join('\n'),
+      'utf8'
+    );
+
+    const explore = await runMemoryToolRecommender([
+      'select',
+      '--shape',
+      'large_framework_app',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--command',
+      'aif-explore',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ], {
+      cwd: tmpDir,
+      stdout: [],
+      stderr: [],
+      exit: false,
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+    const plan = await runMemoryToolRecommender([
+      'select',
+      '--shape',
+      'large_framework_app',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--command',
+      'aif-plan',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ], {
+      cwd: tmpDir,
+      stdout: [],
+      stderr: [],
+      exit: false,
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+
+    assert.equal(explore.exitCode, 0);
+    assert.equal(explore.body.schema, 'aifhub.memory_tools.selection_result.v1');
+    assert.deepEqual(explore.body.config.enabled_tools, ['codegraph', 'graphify']);
+    const exploreCodegraph = explore.body.selected_tools.find((item) => item.tool_id === 'codegraph');
+    const exploreGraphify = explore.body.selected_tools.find((item) => item.tool_id === 'graphify');
+    assert.ok(exploreCodegraph);
+    assert.ok(exploreGraphify);
+    assert.equal(exploreCodegraph.permission, 'manual_purged_cli_execution');
+    assert.equal(exploreGraphify.permission, 'read_existing_reviewed_output');
+    assert.match(JSON.stringify(exploreCodegraph.execution), /codegraph init <project>/);
+    assert.match(JSON.stringify(exploreCodegraph.execution), /codegraph uninit --force <project>/);
+
+    assert.equal(plan.exitCode, 0);
+    assert.equal(plan.body.schema, 'aifhub.memory_tools.selection_result.v1');
+    assert.ok(plan.body.selected_tools.some((item) => item.tool_id === 'graphify'));
+    assert.equal(plan.body.selected_tools.some((item) => item.tool_id === 'codegraph'), false);
+    const skippedCodegraph = plan.body.not_selected_tools.find((item) => item.tool_id === 'codegraph');
+    assert.ok(skippedCodegraph);
+    assert.match(skippedCodegraph.reason, /forbidden/i);
+  });
+
+  it('selects legacy utility-enabled tools as compatibility config', async () => {
+    await mkdir(path.join(tmpDir, '.ai-factory'), { recursive: true });
+    await writeFile(
+      path.join(tmpDir, '.ai-factory', 'config.yaml'),
+      [
+        'utilities:',
+        '  codegraph:',
+        '    enabled: true',
+        ''
+      ].join('\n'),
+      'utf8'
+    );
+
+    const result = await runMemoryToolRecommender([
+      'select',
+      '--shape',
+      'large_framework_app',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--command',
+      'aif-explore',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ], {
+      cwd: tmpDir,
+      stdout: [],
+      stderr: [],
+      exit: false,
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.body.config.enabled_tools, ['codegraph']);
+    assert.equal(result.body.config.source_kind, 'project-config');
+    assert.ok(result.body.selected_tools.some((item) => item.tool_id === 'codegraph'));
   });
 
   it('only recommends agent-memory for explicit manual durable notes tasks', async () => {
@@ -227,6 +513,25 @@ describe('CLI behavior', () => {
     assert.ok(result.recommendations.some((item) => item.tool_id === 'graphify'));
   });
 
+  it('accepts command context so skills receive their own tool permissions', async () => {
+    const result = await runCli([
+      'recommend',
+      '--shape',
+      'large_framework_app',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--command',
+      'aif-explore',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ]);
+
+    const codegraph = result.recommendations.find((item) => item.tool_id === 'codegraph');
+    assert.ok(codegraph);
+    assert.equal(codegraph.permission, 'manual_purged_cli_execution');
+  });
+
   it('degrades recommend output when metadata is unavailable', async () => {
     const result = await runMemoryToolRecommender([
       'recommend',
@@ -261,5 +566,35 @@ describe('CLI behavior', () => {
 
     const graphify = result.recommendations.find((item) => item.tool_id === 'graphify');
     assert.equal(graphify.availability, 'not_installed');
+  });
+
+  it('detects Windows npm command shims during status probes', { skip: process.platform !== 'win32' }, async () => {
+    await writeFile(
+      path.join(tmpDir, 'codegraph.cmd'),
+      '@echo off\r\necho 0.9.3\r\nexit /b 0\r\n',
+      'utf8'
+    );
+
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${tmpDir}${path.delimiter}${previousPath}`;
+    try {
+      const result = await runMemoryToolRecommender([
+        'status',
+        '--metadata',
+        REAL_METADATA,
+        '--json'
+      ], {
+        cwd: REPO_ROOT,
+        stdout: [],
+        stderr: [],
+        exit: false
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.body.probes.codegraph.availability, 'installed');
+      assert.equal(result.body.probes.codegraph.command, 'codegraph --version');
+    } finally {
+      process.env.PATH = previousPath;
+    }
   });
 });

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -281,7 +281,6 @@ function assertGraphifyOptionalContextGuidance(source, label) {
     '.ai-factory/qa/<change-id>/',
     'supporting',
     'degraded',
-    'extracted, inferred, ambiguous, or confidence-labeled',
     'direct repository evidence',
     'API keys',
     'tokens',
@@ -291,9 +290,14 @@ function assertGraphifyOptionalContextGuidance(source, label) {
     assertIncludes(source, expected, label);
   }
 
-  assert.match(source, /do(?:es)? not .*install `?graphifyy`?|must not .*install `?graphifyy`?/i, `${label} should forbid automatic graphifyy install`);
-  assert.match(source, /do(?:es)? not .*run `?graphify`?|must not .*run `?graphify`?/i, `${label} should forbid automatic graphify execution`);
-  assert.match(source, /Graphify MCP automatically/i, `${label} should forbid automatic Graphify MCP registration`);
+  assert.match(
+    source,
+    /extracted, inferred, ambiguous, or confidence-labeled|extracted, inferred, ambiguous или confidence-labeled/i,
+    `${label} should warn that Graphify relationships are hypotheses`
+  );
+  assert.match(source, /do(?:es)? not .*install `?graphifyy`?|must not .*install `?graphifyy`?|не (?:устанавливает|устанавливайте|должны.*устанавливать).*`?graphifyy`?/i, `${label} should forbid automatic graphifyy install`);
+  assert.match(source, /do(?:es)? not .*run `?graphify`?|must not .*run `?graphify`?|не (?:запускает|запускайте|должны.*запускать).*`?graphify`?/i, `${label} should forbid automatic graphify execution`);
+  assert.match(source, /Graphify MCP automatically|регистрировать Graphify MCP automatically|регистрирует Graphify MCP automatically/i, `${label} should forbid automatic Graphify MCP registration`);
 }
 
 function assertContext7OptionalDocumentationGuidance(source, label) {
@@ -328,9 +332,21 @@ function assertContext7OptionalDocumentationGuidance(source, label) {
     assertIncludes(source, expected, label);
   }
 
-  assert.match(source, /do(?:es)? not .*install `?ctx7`?|must not .*install `?ctx7`?/i, `${label} should forbid automatic Context7 CLI install`);
-  assert.match(source, /do(?:es)? not .*run `?ctx7 setup`?|must not .*run `?ctx7 setup`?/i, `${label} should forbid automatic Context7 setup`);
-  assert.match(source, /Context7 MCP automatically|automatic(?:ally)? .*Context7 MCP/i, `${label} should forbid automatic Context7 MCP registration`);
+  assert.match(
+    source,
+    /do(?:es)? not .*install `?ctx7`?|must not .*install `?ctx7`?|не (?:устанавливайте|устанавливает|должны.*устанавливать).*`?ctx7`?/i,
+    `${label} should forbid automatic Context7 CLI install`
+  );
+  assert.match(
+    source,
+    /do(?:es)? not .*run `?ctx7 setup`?|must not .*run `?ctx7 setup`?|не (?:запускайте|запускает|должны.*запускать).*`?ctx7 setup`?/i,
+    `${label} should forbid automatic Context7 setup`
+  );
+  assert.match(
+    source,
+    /Context7 MCP automatically|automatic(?:ally)? .*Context7 MCP|не .*регистрируйте Context7 MCP|не .*регистрирует Context7 MCP/i,
+    `${label} should forbid automatic Context7 MCP registration`
+  );
 }
 
 describe('OpenSpec-native prompt asset contract', () => {
@@ -533,7 +549,7 @@ describe('OpenSpec-native prompt asset contract', () => {
       'uv tool install graphifyy',
       'graphify install',
       'graphify .',
-      'do not prefix it as `/graphify .`',
+      'не добавляйте prefix `/graphify .`',
       'graphify-out/graph.html',
       'graphify query',
       'graphify path',
@@ -543,8 +559,8 @@ describe('OpenSpec-native prompt asset contract', () => {
       'install: uv tool install graphifyy',
       'activate: graphify install',
       'report_command: graphify .',
-      'AIFHub Extension does not require Graphify',
-      'does not add Graphify to extension dependencies'
+      'AIFHub Extension не требует Graphify',
+      'не добавляет Graphify в extension dependencies'
     ]) {
       assertIncludes(usage, expected, 'docs/usage.md');
     }

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -104,7 +104,7 @@ Do not rewrite or delete those folders automatically in this skill.
 
 ### Step 2.1: Optional Context/Memory Tool Recommendations
 
-Use local recommendation metadata to suggest optional context and memory tools during repository inspection.
+Use local recommendation metadata to suggest optional context and memory tools during repository inspection. This skill recommends the needed tools; it does not execute provider setup, indexing, MCP registration, or agent configuration.
 
 Read metadata from the installed extension path when available:
 
@@ -122,6 +122,7 @@ Installed-project diagnostics should use the wrapper command:
 
 ```bash
 ai-factory aifhub-memory-tools recommend --from-project --json
+ai-factory aifhub-memory-tools select --from-project --command aif-explore --json
 ai-factory aifhub-memory-tools status --json
 ai-factory aifhub-memory-tools metadata --json
 ```
@@ -152,10 +153,26 @@ Recommendation rules:
 - `rg` remains the baseline for exact file/symbol lookup, small projects, and first-pass literal search.
 - Recommend only tools allowed by local metadata.
 - Prefer installed/local tools in recommendations; non-installed tools may be described as optional manual install only when metadata allows.
+- Include enriched recommendation details when metadata provides them: allowed command scopes, forbidden command scopes, command-specific permission, execution guidance, privacy caveat, read scope, purge path, availability, and explicit opt-in install policy.
+- Ask the user which recommended tools to enable. Write only accepted tool ids to `utilities.context_tools.enabled`; do not enable a tool just because it was recommended.
+- After config is updated, follow-on skills should call `ai-factory aifhub-memory-tools select --from-project --command <skill> --json` and use only `selected_tools`. Do not hard-code provider-specific tool lists into follow-on skills.
 - Never auto-install, run setup, start MCP, register MCP, index source, sync memory, install hooks, start background daemons, or persist provider output.
 - Provider output is supporting context only, never canonical OpenSpec evidence.
 - `codex-mem` and `eagle-mem` are not recommended by default.
 - `agent-memory` is recommended only when the user explicitly asks for manual durable notes.
+- `CodeGraph` is `manual_cli_only` with `suggest_manual_cli_for_repo_graph_when_enabled_or_explicit`: explicit CLI scoped read/purge is verified for broad repo graph questions, but `install`/MCP/agent configuration mutation surface is not accepted. `/aif-analyze` may recommend it; `/aif-explore` may use it only when `select --command aif-explore --json` returns it in `selected_tools` and the run can purge with the returned purge command.
+- Treat protected validation artifacts as off limits for context/compression rewriting. Optional tools must not rewrite validation artifacts and must not compress protected artifacts in place, including `aif-gate-result`, `coverage.json`, `done-readiness.json`, `openspec/specs/**`, generated-rules traces, and exact evidence snippets.
+
+CodeGraph manual CLI lifecycle is metadata-owned execution guidance for a later selected explore run:
+
+```bash
+codegraph init <project>
+codegraph index --quiet <project>
+codegraph query --path <project> --limit 10 --json "<query>"
+codegraph uninit --force <project>
+```
+
+Do not run `codegraph install`, `codegraph sync`, `codegraph serve`, `codegraph serve --mcp`, agent configuration commands, hooks, or background services.
 
 Safe local availability probes are limited to:
 
@@ -167,6 +184,9 @@ graphify --help
 codex-agent-mem-policy --help
 codex-agent-mem-smoke --help
 context-mode doctor
+codegraph --version
+codegraph --help
+codegraph status
 ctx7 --version
 npx --no-install ctx7 --help
 ```
@@ -213,16 +233,27 @@ Resolve the bootstrap/config mode before creating directories:
 - Preserve existing `language.ui`, `language.artifacts`, and `language.technical_terms` values. If `language.technical_terms` is missing, default it to `keep`; accepted values are `keep | translate | mixed`.
 - If localization answers were collected while config was missing, write those pending config values into the selected legacy `ai-factory` or `openspec-native` config shape.
 - Keep schema consistent with nested sections: `language`, `aifhub`, `paths`, `utilities`, `rules`, `workflow`.
-- Ensure the shared optional utility config is present in both legacy `ai-factory` and `openspec-native` modes, preserving existing user values. `utilities.graphify` is a backward-compatible preference shim only; new optional memory/context recommendations come from local `recommendation-metadata.yaml`, not from a generic provider config abstraction:
+- Ensure the shared optional utility config is present in both legacy `ai-factory` and `openspec-native` modes, preserving existing user values. `utilities.context_tools.enabled` is the stable user-accepted tool id list. `utilities.graphify.enabled` and `utilities.codegraph.enabled` are backward-compatible preference shims. New optional memory/context recommendations come from local `recommendation-metadata.yaml`, not from a generic provider config abstraction:
 
 ```yaml
 utilities:
+  context_tools:
+    # accepted tool ids from /aif-analyze recommendations
+    enabled: []
   graphify:
     enabled: false
     uv_check: uv --version
     install: uv tool install graphifyy
     activate: graphify install
     report_command: graphify .
+  codegraph:
+    enabled: false
+    command: codegraph
+    status: codegraph status
+    init: codegraph init .
+    index: codegraph index --quiet .
+    query: codegraph query --path . --limit 10 --json
+    purge: codegraph uninit --force .
 ```
 
 - In legacy `ai-factory` mode:
@@ -384,7 +415,9 @@ openspec init --tools none
 - Report the resolved bootstrap mode.
 - Report the bootstrap mode selection source: existing config, explicit user request, first-bootstrap answer, or autonomous default.
 - Report whether config values were created or preserved.
-- Report optional local tool recommendations from `ai-factory aifhub-memory-tools recommend --from-project --json` when the installed wrapper is available, or from source-tree metadata only when running inside the AIFHub extension repository. Include baseline `rg`, recommended tools with availability/read scope/purge path, and not-recommended tools such as `codex-mem` and `eagle-mem`. If metadata is unavailable, report a degraded note and continue.
+- Report optional local tool recommendations from `ai-factory aifhub-memory-tools recommend --from-project --json` when the installed wrapper is available, or from source-tree metadata only when running inside the AIFHub extension repository. Include baseline `rg`, recommended tools with availability/read scope/purge path, and not-recommended tools such as `codex-mem` and `eagle-mem`. Ask which recommendations to enable and write accepted tool ids to `utilities.context_tools.enabled`. If metadata is unavailable, report a degraded note and continue.
+- Report the selected tool view from `ai-factory aifhub-memory-tools select --from-project --command aif-explore --json` after config is updated, including `selected_tools` and any `not_selected_tools`.
+- When the recommender output includes enriched fields, include allowed command scopes, forbidden command scopes, command-specific permission, execution guidance, privacy caveat, and protected validation artifacts in the concise recommendation summary when relevant.
 - Report the backward-compatible Graphify utility setting and `uv` availability only as compatibility context. If `utilities.graphify.enabled` is missing or `false`, Graphify may still be recommended only through local metadata; show manual setup commands only as explicit opt-in guidance: `uv --version`, `uv tool install graphifyy`, `graphify install`, and `graphify .`.
 - If autonomous/subagent mode defaulted to legacy `ai-factory` because the artifact protocol question could not be asked, report OpenSpec-native mode selection as an open question/blocker.
 - Report the active path set.

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -53,6 +53,10 @@ paths:
 # ============================================================================
 # Optional, user-owned tools that can provide extra context.
 utilities:
+  context_tools:
+    # User-accepted optional context tool ids from /aif-analyze recommendations.
+    # Follow-on skills call aifhub-memory-tools select and use only selected_tools.
+    enabled: []
   graphify:
     # Recommended for large or unfamiliar repositories.
     # AIFHub never installs or runs Graphify automatically.
@@ -61,6 +65,16 @@ utilities:
     install: uv tool install graphifyy
     activate: graphify install
     report_command: graphify .
+  codegraph:
+    # Manual CLI-only repo graph preference for broad /aif-explore research.
+    # AIFHub never runs codegraph install, MCP serving, or agent config mutation.
+    enabled: false
+    command: codegraph
+    status: codegraph status
+    init: codegraph init .
+    index: codegraph index --quiet .
+    query: codegraph query --path . --limit 10 --json
+    purge: codegraph uninit --force .
 
 # ============================================================================
 # WORKFLOW SETTINGS


### PR DESCRIPTION
## Summary
- Добавлен follow-up `close-context-memory-tools` для доведения context/memory tools до acceptance criteria.
- Расширены metadata/recommender contracts: skill usage matrix, permissions, safe probes, protected artifacts, privacy/allowed/forbidden output fields.
- Добавлен CodeGraph как manual CLI-only candidate с проверенными scoped read/purge boundaries и без auto install/MCP/agent-config recommendation.
- Обновлены skill/injection flows: `aif-analyze` рекомендует инструменты через CLI metadata, follow-on skills используют `select` и config-selected tools без prompt-owned provider list.
- Документация по memory tools переведена и распределена: README содержит сводку, детальные результаты лежат в файлах инструментов.

## Issue References
Closed #83, #85, #86, #100, #101, #102, #103, #104, #105, #107.

## Test Plan
- `git diff --check`
- `openspec validate close-context-memory-tools --type change --strict --json --no-interactive --no-color`
- `npm run validate`
- `node --test scripts\memory-tool-recommender.test.mjs scripts\aif-analyze-openspec-bootstrap.test.mjs scripts\aifhub-command-wrappers-contract.test.mjs scripts\openspec-prompt-assets.test.mjs scripts\aif-explore-improve-openspec-artifacts.test.mjs scripts\aif-plan-openspec-artifacts.test.mjs` (79 tests)
- `npm test` (411 tests)
- `node scripts\memory-tool-recommender.mjs metadata --json`
- `node scripts\memory-tool-recommender.mjs status --json`
- `node scripts\memory-tool-recommender.mjs recommend --shape large_framework_app --task architecture_or_impact_discovery --command aif-review --metadata docs\memory-tools-research\recommendation-metadata.yaml --json`
- `node scripts\memory-tool-recommender.mjs select --command aif-verify --config .ai-factory\config.yaml --json`

## Notes
- `aif-verify` gate: pass.
- `rules` gate evidence was produced locally for `close-context-memory-tools` before PR creation.
- Issue closure comments should be posted after merge with PR evidence links.
