### PR TITLE
Sync OpenSpec reviewed baseline to 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
+The reviewed OpenSpec baseline is OpenSpec `1.4.1`, while the compatible CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the OpenSpec 1.4.1 reviewed baseline, `openspec update` boundary, and adapter-only ownership notes.
+
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
 If the OpenSpec CLI is present but outside `>=1.3.1 <2.0.0`, update or reinstall the CLI before relying on validation/archive. The bootstrap still reports this as degraded capability rather than an install failure.
@@ -321,7 +323,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, optional provider context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, AI Factory 2.15 baseline, `/aif-archive` boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline, `/aif-archive` boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,13 +13,13 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.3.1",
+      "version": "1.4.1",
       "supportedRange": ">=1.3.1 <2.0.0",
-      "lastSync": "2026-04-25",
+      "lastSync": "2026-06-10",
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "OpenSpec is used as an optional artifact protocol and CLI validation/archive adapter for v1. OpenSpec skills are not installed by this extension."
+      "notes": "Validated against upstream OpenSpec 1.4.1 while keeping the supported CLI range >=1.3.1 <2.0.0. Reviewed baseline includes the 1.4.1 openspec update workspace.yaml fix and the 1.4.0 Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, workspace beta state, or openspec update."
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 3. [Context Providers](context-providers.md) - optional Graphify context, CodeGraph manual CLI context, Context7 documentation provider guidance, reviewed-note paths, degraded behavior и user-owned setup boundaries.
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Context Loading Policy](context-loading-policy.md) - consumer context, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream archive/distillation utilities, commit handoff и legacy path rules.
-6. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, AI Factory 2.15 baseline compatibility, upstream `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` and `/aif-distillation` compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+6. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline compatibility, upstream `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` and `/aif-distillation` compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 7. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 8. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 9. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -45,7 +45,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Context Providers](context-providers.md) | Optional Graphify context, CodeGraph manual CLI context и Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety и user-owned setup boundaries |
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, AI Factory 2.15 baseline compatibility, upstream `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline compatibility, upstream `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -78,6 +78,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - AI Factory 2.15 reviewed baseline, including upstream `/aif-archive`, `paths.archive`, archive-aware sequential plan behavior, and managed agent config update preservation
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
+- OpenSpec 1.4.1 reviewed baseline and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,6 +26,20 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
+## OpenSpec 1.4.1 Reviewed Baseline
+
+AIFHub metadata records OpenSpec `1.4.1` as the reviewed upstream baseline while keeping the supported CLI range `>=1.3.1 <2.0.0`.
+
+Reviewed upstream behavior:
+
+- OpenSpec `1.4.1` includes an `openspec update` fix for projects that already have their own `workspace.yaml`.
+- OpenSpec `1.4.0` includes Kimi CLI support, Mistral Vibe support, sync skills by default through `/opsx:sync`, case-insensitive requirement headers, and clearer validation hints.
+- OpenSpec workspace beta view state is OpenSpec-owned and lives under `.openspec-workspace/view.yaml`.
+
+AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, Kimi CLI or Mistral Vibe integrations, OpenSpec workspace beta state, or `openspec update`. AIFHub does not install or manage Kimi CLI or Mistral Vibe integrations, does not own OpenSpec workspace beta state, and does not run or manage `openspec update`.
+
+`openspec update` is upstream OpenSpec behavior. `/aif-mode sync` compiles AIFHub generated rules and requests OpenSpec validate/status through the adapter when configured and available.
+
 ## Опциональная Инициализация
 
 Projects may initialize OpenSpec without tool integrations:
@@ -158,7 +172,7 @@ In short: archived legacy plans are excluded from active plan discovery, while O
 | `/aif-verify` | `openspec validate`, optional `openspec status` evidence, policy-derived diagnostics, coverage, and final `aif-gate-result` with `"gate": "verify"` |
 | `/aif-rules-check` | Upstream rules gate plus AIFHub generated-rules overlay for OpenSpec specs/deltas |
 | `/aif-done` | AIFHub artifact contract check, then `openspec archive <change> --yes` when archive is required |
-| `/aif-mode sync` | generated-rule compile plus validate/status according to sync flags |
+| `/aif-mode sync` | generated-rule compile plus validate/status according to sync flags; generated-rule compilation may call `openspec show <item> --json` through `scripts/openspec-rules-compiler.mjs` and `showOpenSpecItem()` |
 | `/aif-mode doctor` | CLI, Node, active change, effective policy, generated rules, latest verify gate, rules gate, coverage, AIFHub artifact contract, and archive readiness diagnostics |
 
 Do not route users to OpenSpec slash commands such as `/opsx:propose`, `/opsx:apply`, or `/opsx:archive`.

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -477,6 +477,58 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
+  it('documents the OpenSpec 1.4.1 reviewed baseline and adapter-only boundaries', async () => {
+    const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
+    const readme = await readRepoFile('README.md');
+    const compatibility = await readRepoFile('docs/openspec-compatibility.md');
+    const docsIndex = await readRepoFile('docs/README.md');
+    const openspec = metadata.sources.openspec;
+    const combinedDocs = [readme, compatibility, docsIndex].join('\n');
+
+    assert.equal(openspec.version, '1.4.1');
+    assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(openspec.lastSync, '2026-06-10');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.4.1', 'aifhub-extension.json');
+    assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
+
+    assertIncludes(readme, 'OpenSpec 1.4.1', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.4.1', 'docs/README.md');
+
+    for (const expected of [
+      'OpenSpec 1.4.1 Reviewed Baseline',
+      'OpenSpec `1.4.1`',
+      '`openspec update`',
+      'Kimi CLI',
+      'Mistral Vibe',
+      'sync skills',
+      'case-insensitive requirement headers',
+      'clearer validation hints',
+      '.openspec-workspace/view.yaml',
+      '/opsx:*',
+      'adapter-only',
+      'does not install or manage OpenSpec skills',
+      'does not install or manage Kimi CLI or Mistral Vibe integrations',
+      'does not own OpenSpec workspace beta state',
+      'does not run or manage `openspec update`',
+      '`openspec show <item> --json`',
+      '`openspec update` is upstream OpenSpec behavior',
+      '`/aif-mode sync` compiles AIFHub generated rules'
+    ]) {
+      assertIncludes(combinedDocs, expected, 'OpenSpec 1.4.1 docs baseline');
+    }
+
+    for (const forbiddenClaim of [
+      'AIFHub installs OpenSpec skills',
+      'AIFHub manages /opsx',
+      'AIFHub manages Kimi',
+      'AIFHub manages Mistral',
+      'AIFHub owns workspace beta state',
+      'AIFHub runs openspec update'
+    ]) {
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.4.1 docs ownership boundaries');
+    }
+  });
+
   it('documents Codex app flows with skill invocations and keeps slash commands runtime-specific', async () => {
     const usage = await readRepoFile('docs/usage.md');
     const planMode = await readRepoFile('docs/codex-plan-mode.md');

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -67,6 +67,21 @@ describe('detectOpenSpec', () => {
     assert.deepEqual(result.errors, []);
   });
 
+  it('returns available capabilities for version 1.4.1 on supported Node', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.4.1\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.4.1');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.reason, null);
+  });
+
   it('returns degraded capabilities when CLI is missing', async () => {
     const result = await detectOpenSpec({
       executor: async () => {

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,13 +78,13 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.3.1',
+        version: '1.4.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        lastSync: '2026-04-25',
+        lastSync: '2026-06-10',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'OpenSpec is used as an optional artifact protocol.'
+        notes: 'Validated against upstream OpenSpec 1.4.1; AIFHub remains adapter-only.'
       }
     },
     ...extra


### PR DESCRIPTION
## Summary
- Record OpenSpec 1.4.1 as the reviewed upstream baseline while preserving the supported CLI range `>=1.3.1 <2.0.0`.
- Document adapter-only boundaries for `openspec update`, `/opsx:*`, Kimi CLI, Mistral Vibe, and OpenSpec workspace beta state.
- Add regression coverage for OpenSpec 1.4.1 capability detection, metadata validation, and docs ownership boundaries.

## Issue
- Closes #118

## Validation
- `git diff --check`
- `node --test scripts/openspec-runner.test.mjs scripts/docs-workflow-contract.test.mjs scripts/validate-extension.test.mjs`
- `npm run validate`