### PR TITLE
feat(aifhub): add architecture utility boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ AI Factory UX + OpenSpec artifact protocol
 - Preserves legacy AI Factory-only plan folders as compatibility and migration input only.
 - Publishes namespaced Codex CLI and Claude agent files through the extension manifest for explicit user or orchestrator invocation.
 - Publishes an optional `aifhub` MCP server whose settings are rendered by AI Factory per runtime.
+- Documents upstream project-context utilities such as `/aif-architecture`, `/aif-roadmap`, `/aif-docs`, `/aif-qa`, `/aif-archive`, and `/aif-distillation` with AIFHub write-boundary guardrails.
 - Does not install OpenSpec skills or slash commands.
 
 ## Quick Start
@@ -112,6 +113,8 @@ AI Factory 2.13+ owns generic active plan `## Commit Plan` grouping in `/aif-com
 The AIFHub `aif-commit` injection is only a read-only roadmap/GitHub freshness overlay. In OpenSpec-native mode, if an active OpenSpec change is available, commit planning should use `openspec/changes/<change-id>/tasks.md` as the source that may contain `## Commit Plan`. If no active change/plan resolves, keep upstream staged-diff behavior.
 
 AI Factory 2.13+ includes `/aif-distillation`. It is an upstream utility skill for turning books, docs, folders, or URLs into reusable Agent Skills. It is not an AIFHub lifecycle stage, does not create OpenSpec changes, and must not write `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/qa/**`, or `.ai-factory/rules/generated/**`. It writes generated skill packages to the current agent skills directory.
+
+Upstream project-context utilities remain available with AIFHub guardrails. `/aif-architecture` writes project-level architecture context at `paths.architecture` plus limited pointers in `paths.description` and root `AGENTS.md`. `/aif-docs` writes the root `README.md`, the configured `paths.docs` directory, and documentation entries in `AGENTS.md`. `/aif-qa` writes upstream manual QA artifacts under `paths.qa/<branch-slug>/`, distinct from AIFHub verification/finalization evidence under `.ai-factory/qa/<change-id>/`. These commands are not required per-change OpenSpec lifecycle gates and must not create canonical OpenSpec changes/specs, generated rules, or AIFHub runtime evidence.
 
 AI Factory 2.14+ includes upstream `/aif-archive` and `paths.archive`, with default archive root `.ai-factory/archive/`. That command is legacy AI Factory-only plan cleanup: completed `paths.plans/*.md` files move to `paths.archive/plans/*.md`, optional roadmap snapshots can be written under `paths.archive/roadmap/`, and archived plans are excluded from active sequential plan numbering and discovery. AIFHub does not route `/aif-archive` to `openspec archive`, and `/aif-archive` must not write `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/qa/**`, `.ai-factory/state/**`, or `.ai-factory/rules/generated/**`.
 
@@ -319,11 +322,11 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | Guide | Description |
 |---|---|
 | [Documentation Index](docs/README.md) | Reading order and docs map |
-| [Usage](docs/usage.md) | Full command flow, read/write boundaries, examples, and troubleshooting |
+| [Usage](docs/usage.md) | Full command flow, read/write boundaries, upstream project-context utilities, examples, and troubleshooting |
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
-| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, optional provider context, GitHub-aware roadmap evidence, ownership, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline, `/aif-archive` boundary, and capability flags |
+| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline, upstream project-context utility boundaries, `/aif-archive` boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -9,7 +9,7 @@
       "version": "2.15.0",
       "baselineVersion": "2.15.0",
       "lastSync": "2026-06-08",
-      "notes": "Validated against upstream 2.15.0 on the 2.x branch. Reviewed baseline preserves AI Factory 2.13.x plan-aware /aif-commit Commit Plan grouping and /aif-distillation for reusable Agent Skills, includes AI Factory 2.14 /aif-archive with paths.archive and archive-aware sequential plan behavior, and includes AI Factory 2.15 managed agent config preservation plus interactive newly available built-in skill update behavior."
+      "notes": "Validated against upstream 2.15.0 on the 2.x branch. Reviewed baseline preserves AI Factory 2.13.x plan-aware /aif-commit Commit Plan grouping and /aif-distillation for reusable Agent Skills, includes AI Factory 2.14 /aif-archive with paths.archive and archive-aware sequential plan behavior, includes config-aware project utilities /aif-architecture, /aif-docs, and /aif-qa as upstream-owned context outputs, and includes AI Factory 2.15 managed agent config preservation plus interactive newly available built-in skill update behavior."
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,11 +15,11 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 ## Порядок Чтения
 
 1. [Project README](../README.md) - landing page, quick start, artifact layout, compatibility summary, migration summary и troubleshooting summary.
-2. [Usage](usage.md) - полный command flow, `/aif-mode` switching and sync, rules/review/security gates, verification/fix/finalization tail, AI Factory 2.15 baseline notes, upstream `/aif-archive` legacy cleanup boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` utility boundaries, commit/evolve handoff, OAuth example, troubleshooting и smoke checks.
+2. [Usage](usage.md) - полный command flow, `/aif-mode` switching and sync, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa` project-context utility boundaries, rules/review/security gates, verification/fix/finalization tail, AI Factory 2.15 baseline notes, upstream `/aif-archive` legacy cleanup boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` utility boundaries, commit/evolve handoff, OAuth example, troubleshooting и smoke checks.
 3. [Context Providers](context-providers.md) - optional Graphify context, CodeGraph manual CLI context, Context7 documentation provider guidance, reviewed-note paths, degraded behavior и user-owned setup boundaries.
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
-5. [Context Loading Policy](context-loading-policy.md) - consumer context, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream archive/distillation utilities, commit handoff и legacy path rules.
-6. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline compatibility, upstream `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` and `/aif-distillation` compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+5. [Context Loading Policy](context-loading-policy.md) - consumer context, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
+6. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline compatibility, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `paths.archive` boundaries, AI Factory 2.13+ `/aif-commit` and `/aif-distillation` compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 7. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 8. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 9. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -41,11 +41,11 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 
 | Guide | Назначение |
 |---|---|
-| [Usage](usage.md) | Полный OpenSpec-native command flow, optional Graphify/CodeGraph/Context7 guidance, gates, finalization tail, AI Factory 2.15 archive boundary, parent-owned commit grouping, upstream distillation utility и examples |
+| [Usage](usage.md) | Полный OpenSpec-native command flow, optional Graphify/CodeGraph/Context7 guidance, upstream architecture/docs/QA utility boundaries, gates, finalization tail, AI Factory 2.15 archive boundary, parent-owned commit grouping, upstream distillation utility и examples |
 | [Context Providers](context-providers.md) | Optional Graphify context, CodeGraph manual CLI context и Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety и user-owned setup boundaries |
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline compatibility, upstream `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.15 baseline compatibility, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `paths.archive` boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -76,6 +76,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - optional rules, review и security gates
 - verification, fix, done, post-archive sync, commit и evolve handoff
 - AI Factory 2.15 reviewed baseline, including upstream `/aif-archive`, `paths.archive`, archive-aware sequential plan behavior, and managed agent config update preservation
+- upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
 - OpenSpec 1.4.1 reviewed baseline and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -190,7 +190,10 @@ GitHub access is non-blocking. If `gh`, connector data, network access, authenti
 |---|---|---|
 | `/aif-mode` | skeleton only; never manual `openspec/specs/**` mutations | mode reports, generated rules, optional migration/export outputs |
 | `/aif-analyze` | Optional `openspec/` skeleton only when configured | capability/config setup |
+| `/aif-architecture` | no | no |
 | `/aif-roadmap` | no | no |
+| `/aif-docs` | no | no |
+| `/aif-qa` | no | upstream manual QA artifacts under `paths.qa/<branch-slug>/`; not AIFHub `.ai-factory/qa/<change-id>/` evidence |
 | `/aif-plan full` | `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md` | optional `.ai-factory/state/<change-id>/` |
 | `/aif-explore` | no | `.ai-factory/RESEARCH.md`, `.ai-factory/state/<change-id>/` |
 | `/aif-improve` | `proposal.md`, `design.md`, `tasks.md`, `specs/**/spec.md` | optional `.ai-factory/state/<change-id>/` |
@@ -206,7 +209,13 @@ GitHub access is non-blocking. If `gh`, connector data, network access, authenti
 | `/aif-distillation` | no | no |
 | `/aif-evolve` | no | skill-context or evolution artifacts only |
 
+`/aif-architecture` writes only project-level architecture context: resolved `paths.architecture`, an architecture pointer in resolved `paths.description`, and an architecture row in root `AGENTS.md`.
+
 `/aif-roadmap` writes only the configured roadmap artifact, `.ai-factory/ROADMAP.md` by default.
+
+`/aif-docs` writes documentation output only: root `README.md`, the resolved `paths.docs` directory, optional `docs-html/` output when explicitly requested, and the Documentation section in `AGENTS.md`.
+
+`/aif-qa` writes upstream manual QA artifacts under `paths.qa/<branch-slug>/`, such as `change-summary.md`, `test-plan.md`, and `test-cases.md`. This is distinct from AIFHub verification and finalization evidence under `.ai-factory/qa/<change-id>/`, which remains owned by `/aif-verify` and `/aif-done`.
 
 ## Quality Gates and Finalization Tail
 
@@ -223,7 +232,15 @@ OpenSpec-native quality gates:
 | `/aif-distillation` | books, docs, folders, or URLs | generated skill packages in the current agent skills directory |
 | `/aif-evolve` | patches, evidence, skill-context inputs | skill-context/evolution artifacts |
 
-`/aif-done` owns OpenSpec lifecycle finalization. `/aif-commit` owns git commit creation. `/aif-evolve` owns learning/evolution.
+`/aif-done` owns OpenSpec lifecycle finalization. `/aif-commit` owns git commit creation. `/aif-evolve` owns learning/evolution. `/aif-architecture`, `/aif-docs`, and `/aif-qa` are upstream project-context utilities, not OpenSpec-native quality/finalization gates.
+
+Adjacent upstream project-context utilities:
+
+| Command | Reads | Writes |
+|---|---|---|
+| `/aif-architecture` | project description, source structure, optional OpenSpec context | project architecture context only |
+| `/aif-docs` | project description, architecture, source/docs | README and docs directory |
+| `/aif-qa` | git diff, description, architecture, source/docs | upstream manual QA artifacts under `paths.qa/<branch-slug>/` |
 
 Upstream `/aif-archive` is not part of the OpenSpec-native quality/finalization tail. It owns legacy AI Factory-only cleanup from `paths.plans/*.md` to `paths.archive/plans/*.md` and optional roadmap snapshots under `paths.archive/roadmap/*.md`. It must not write `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/qa/**`, `.ai-factory/state/**`, or `.ai-factory/rules/generated/**`, and it must not run `openspec archive <change-id> --yes`.
 

--- a/docs/memory-tools-research/recommendation-metadata.yaml
+++ b/docs/memory-tools-research/recommendation-metadata.yaml
@@ -33,6 +33,18 @@ skill_usage_matrix:
       - codex-mem
       - eagle-mem
     notes: "Read existing reviewed provider output, or use explicitly enabled tools only when metadata grants command-specific permission and purge is defined."
+  aif-architecture:
+    allowed:
+      - rg
+      - graphify
+      - context7
+    forbidden:
+      - codex-agent-mem
+      - context-mode
+      - codex-mem
+      - eagle-mem
+      - codegraph
+    notes: "Project-level architecture context only; optional provider output is supporting reviewed context and must not drive OpenSpec writes."
   aif-plan:
     allowed:
       - rg
@@ -146,6 +158,7 @@ tool_permissions:
   rg:
     aif-analyze: safe_availability_probe
     aif-explore: safe_availability_probe
+    aif-architecture: safe_availability_probe
     aif-plan: safe_availability_probe
     aif-review: safe_availability_probe
     aif-rules-check: safe_availability_probe
@@ -157,6 +170,7 @@ tool_permissions:
   graphify:
     aif-analyze: recommend_only
     aif-explore: read_existing_reviewed_output
+    aif-architecture: read_existing_reviewed_output
     aif-plan: read_existing_reviewed_output
     aif-review: read_existing_reviewed_output
     aif-rules-check: forbidden
@@ -168,6 +182,7 @@ tool_permissions:
   context7:
     aif-analyze: recommend_only
     aif-explore: read_existing_reviewed_output
+    aif-architecture: read_existing_reviewed_output
     aif-plan: read_existing_reviewed_output
     aif-review: read_existing_reviewed_output
     aif-rules-check: read_existing_reviewed_output
@@ -179,6 +194,7 @@ tool_permissions:
   codex-agent-mem:
     aif-analyze: recommend_only
     aif-explore: read_existing_reviewed_output
+    aif-architecture: forbidden
     aif-plan: forbidden
     aif-review: read_existing_reviewed_output
     aif-rules-check: forbidden
@@ -190,6 +206,7 @@ tool_permissions:
   context-mode:
     aif-analyze: recommend_only
     aif-explore: recommend_only
+    aif-architecture: forbidden
     aif-plan: forbidden
     aif-review: forbidden
     aif-rules-check: forbidden
@@ -207,6 +224,7 @@ tool_permissions:
   codegraph:
     aif-analyze: recommend_only
     aif-explore: manual_purged_cli_execution
+    aif-architecture: forbidden
     default: forbidden
 availability_probes:
   rg:
@@ -477,6 +495,7 @@ tools:
     allowed_in:
       - aif-analyze
       - aif-explore
+      - aif-architecture
       - aif-plan
       - aif-review
     forbidden_in:
@@ -548,6 +567,7 @@ tools:
       - aif-explore
       - aif-review
     forbidden_in:
+      - aif-architecture
       - aif-plan
       - aif-rules-check
       - aif-implement
@@ -596,6 +616,7 @@ tools:
       - aif-analyze
       - aif-explore
     forbidden_in:
+      - aif-architecture
       - aif-plan
       - aif-review
       - aif-rules-check
@@ -637,6 +658,7 @@ tools:
     allowed_in:
       - aif-analyze
       - aif-explore
+      - aif-architecture
       - aif-plan
       - aif-review
       - aif-rules-check
@@ -682,6 +704,7 @@ tools:
     forbidden_in:
       - aif-analyze
       - aif-explore
+      - aif-architecture
       - aif-plan
       - aif-review
       - aif-rules-check
@@ -746,6 +769,7 @@ tools:
     forbidden_in:
       - aif-analyze
       - aif-explore
+      - aif-architecture
       - aif-plan
       - aif-review
       - aif-rules-check
@@ -774,6 +798,7 @@ tools:
       - aif-analyze
       - aif-explore
     forbidden_in:
+      - aif-architecture
       - aif-plan
       - aif-review
       - aif-rules-check

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -202,9 +202,20 @@ Examples:
 /aif-distillation docs/context-providers.md --name aifhub-context-providers
 ```
 
+## Upstream Project-Context Utilities
+
+Upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, and `/aif-roadmap` remain project-context utilities with AIFHub guardrails. They are not required per-change OpenSpec lifecycle gates.
+
+- `/aif-architecture` owns project-level architecture context generation at `paths.architecture`, plus the architecture pointer in resolved `paths.description` and the architecture row in root `AGENTS.md`.
+- `/aif-docs` owns the root `README.md`, the resolved `paths.docs` directory, generated docs site output when explicitly requested, and the Documentation section in `AGENTS.md`.
+- `/aif-qa` owns upstream manual QA artifacts under `paths.qa/<branch-slug>/`, including `change-summary.md`, `test-plan.md`, and `test-cases.md`.
+- `/aif-roadmap` owns only the configured roadmap artifact, `.ai-factory/ROADMAP.md` by default.
+
+These utilities must not create or mutate `openspec/changes/**`, `openspec/specs/**`, `.ai-factory/state/**`, `.ai-factory/rules/generated/**`, or AIFHub verification/finalization evidence under `.ai-factory/qa/<change-id>/`. `/aif-qa` may use the same configured `paths.qa` root as AIFHub, but upstream manual QA artifacts use branch slugs while `/aif-verify` and `/aif-done` evidence use OpenSpec `change-id` directories.
+
 ## AI Factory 2.15 Reviewed Baseline
 
-The reviewed AI Factory `2.15.0` baseline includes AI Factory `2.14.0` archive behavior and AI Factory `2.15.0` update behavior.
+The reviewed AI Factory `2.15.0` baseline includes AI Factory `2.14.0` archive behavior, config-aware project-context utilities, and AI Factory `2.15.0` update behavior.
 
 AI Factory 2.14+ includes upstream `/aif-archive` and `paths.archive`. AIFHub treats `/aif-archive` as legacy AI Factory-only cleanup, not as OpenSpec-native finalization:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,6 +45,8 @@ finalization:
 
 OpenSpec-native mode uses OpenSpec artifacts as canonical planning/spec artifacts and AI Factory paths for runtime state, QA evidence, and generated rules in user projects.
 
+Upstream project-context utilities such as `/aif-architecture`, `/aif-roadmap`, `/aif-docs`, `/aif-qa`, `/aif-archive`, and `/aif-distillation` remain available with AIFHub guardrails. They are not required per-change OpenSpec lifecycle gates.
+
 The `aifhub-extension` package repository stays artifact-light: root `openspec/`, `.ai-factory/state/`, `.ai-factory/qa/`, `.ai-factory/plans/`, and `.ai-factory/rules/generated/` are not extension package source. Root `.ai-factory/rules/generated/` is derived in user projects and safe to regenerate. OpenSpec examples may be committed only under fixture paths such as `test/fixtures/` or `scripts/fixtures/`.
 
 AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
@@ -366,6 +368,92 @@ If localization questions run first, `/aif-analyze` carries those answers forwar
 The selected artifact protocol owns its config profile. Legacy `artifactProtocol: ai-factory` configs do not include `aifhub.openspec` settings or OpenSpec runtime path defaults; OpenSpec-native `artifactProtocol: openspec` configs include those settings and paths explicitly.
 
 Shared protocol-neutral settings such as `utilities.context_tools.enabled`, `utilities.graphify.enabled`, and `utilities.codegraph.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency. Optional memory/context tool recommendations are resolved from local installed metadata with `ai-factory aifhub-memory-tools recommend --from-project --json`; runtime tool selection uses `ai-factory aifhub-memory-tools select --from-project --command <skill> --json`. Missing metadata is degraded context and leaves `rg` as the baseline.
+
+### `/aif-architecture`
+
+`/aif-architecture` is an upstream project-level architecture context utility. It is not an OpenSpec canonical change/spec generation command.
+
+Reads:
+
+- `.ai-factory/config.yaml`
+- resolved `paths.description`
+- project files and source structure
+- `.ai-factory/skill-context/aif-architecture/SKILL.md` when present
+- optional OpenSpec context, generated rules, runtime state, and QA evidence as read-only supporting evidence
+- selected optional provider context only when command-specific metadata allows it
+
+Writes:
+
+- resolved `paths.architecture`, `.ai-factory/ARCHITECTURE.md` by default
+- an architecture pointer in resolved `paths.description`
+- an architecture row in root `AGENTS.md`
+
+Does not write:
+
+- `openspec/changes/**`
+- `openspec/specs/**`
+- `.ai-factory/state/**`
+- `.ai-factory/qa/**`
+- `.ai-factory/rules/generated/**`
+- provider notes, MCP config, provider config, or provider setup files
+
+When architecture work would change product or workflow behavior, capture it through `/aif-plan full <request>` instead of writing OpenSpec deltas from `/aif-architecture`.
+
+### `/aif-docs`
+
+`/aif-docs` is an upstream documentation utility. It is not an OpenSpec lifecycle gate.
+
+Reads:
+
+- `.ai-factory/config.yaml`
+- resolved `paths.description`
+- resolved `paths.architecture`
+- current README, docs, source files, comments, routes, and APIs
+- `.ai-factory/skill-context/aif-docs/SKILL.md` when present
+
+Writes:
+
+- root `README.md`
+- the resolved `paths.docs` directory, `docs/` by default
+- optional `docs-html/` when the user explicitly requests web docs
+- the Documentation section in `AGENTS.md`
+
+Does not write:
+
+- `openspec/changes/**`
+- `openspec/specs/**`
+- `.ai-factory/state/**`
+- `.ai-factory/qa/**`
+- `.ai-factory/rules/generated/**`
+
+### `/aif-qa`
+
+`/aif-qa` is an upstream manual QA artifact utility. It is distinct from AIFHub `/aif-verify` and `/aif-done` evidence.
+
+Reads:
+
+- git diff and changed files
+- resolved `paths.description`
+- resolved `paths.architecture`
+- source files, docs, and existing QA context
+- `.ai-factory/skill-context/aif-qa/SKILL.md` when present
+
+Writes:
+
+- upstream manual QA artifacts under `paths.qa/<branch-slug>/`
+- `change-summary.md`
+- `test-plan.md`
+- `test-cases.md`
+
+Does not write:
+
+- `openspec/changes/**`
+- `openspec/specs/**`
+- `.ai-factory/state/**`
+- `.ai-factory/rules/generated/**`
+- AIFHub verification or finalization evidence under `.ai-factory/qa/<change-id>/`
+
+In OpenSpec-native mode, use `/aif-verify <change-id>` for authoritative verification evidence and `/aif-done <change-id>` for finalization evidence.
 
 ### `/aif-plan full`
 

--- a/extension.json
+++ b/extension.json
@@ -171,6 +171,11 @@
       "file": "./injections/core/aif-roadmap-maturity-audit.md"
     },
     {
+      "target": "aif-architecture",
+      "position": "prepend",
+      "file": "./injections/core/aif-architecture-context-boundary.md"
+    },
+    {
       "target": "aif-commit",
       "position": "prepend",
       "file": "./injections/core/aif-commit-roadmap-freshness.md"

--- a/injections/core/aif-architecture-context-boundary.md
+++ b/injections/core/aif-architecture-context-boundary.md
@@ -1,0 +1,93 @@
+## AIFHub Architecture Context Boundary
+
+Apply this block before the upstream `aif-architecture` body. When any rule below conflicts with the upstream body, this block wins.
+
+Follow `skills/shared/LANGUAGE-POLICY.md` before producing user-facing responses or generated artifacts.
+
+### Goal
+
+Keep upstream `/aif-architecture` as the command owner while adding AIFHub/OpenSpec artifact-boundary guidance.
+
+Do not create or use an extension-owned `skills/aif-architecture/` directory. The upstream skill remains responsible for architecture analysis, recommendation, artifact generation, and project-specific `.ai-factory/skill-context/aif-architecture/SKILL.md` loading.
+
+### Mode Detection
+
+Before resolving architecture scope, read `.ai-factory/config.yaml` when it exists.
+
+- If the config contains `aifhub.artifactProtocol: openspec`, use **OpenSpec-native mode**.
+- Otherwise, use **Legacy AI Factory-only mode**.
+- If the config is missing, continue with upstream defaults and state that no AIFHub artifact protocol was detected.
+
+Always respect upstream config resolution for:
+
+- `paths.description`
+- `paths.architecture`
+- `language.ui`
+- `language.artifacts`
+- `language.technical_terms`
+
+### OpenSpec-native mode
+
+When `.ai-factory/config.yaml` declares `aifhub.artifactProtocol: openspec`, `/aif-architecture` still writes project-level AI Factory architecture context, not canonical OpenSpec lifecycle artifacts.
+
+Allowed writes are limited to:
+
+- the resolved `paths.architecture` artifact;
+- an architecture pointer in the resolved `paths.description` artifact;
+- an architecture row in the root `AGENTS.md` context table.
+
+Read-only context may include:
+
+- `openspec/specs/**`;
+- `openspec/changes/<change-id>/proposal.md`;
+- `openspec/changes/<change-id>/design.md`;
+- `openspec/changes/<change-id>/tasks.md`;
+- `openspec/changes/<change-id>/specs/**/spec.md`;
+- `.ai-factory/rules/generated/openspec-merged-<change-id>.md`;
+- `.ai-factory/rules/generated/openspec-change-<change-id>.md`;
+- `.ai-factory/rules/generated/openspec-base.md`;
+- `.ai-factory/state/<change-id>/`;
+- `.ai-factory/qa/<change-id>/`;
+- the resolved roadmap, rules, research, and description artifacts.
+
+Do not write:
+
+- `openspec/changes/**`;
+- `openspec/specs/**`;
+- `.ai-factory/state/**`;
+- `.ai-factory/qa/**`;
+- `.ai-factory/rules/generated/**`;
+- provider notes, MCP config, provider config, or provider setup files.
+
+If an architecture decision would change product or workflow behavior, route that work through `/aif-plan full <request>` instead of writing OpenSpec delta specs directly from `/aif-architecture`.
+
+### Optional Context Providers
+
+Before using optional context providers, call the installed selector when it is available:
+
+```bash
+ai-factory aifhub-memory-tools select --from-project --command aif-architecture --json
+```
+
+Use only tools returned in `selected_tools`. If the selector is unavailable, fails, or returns no selected tools, continue with the `rg` baseline and direct repository evidence.
+
+For `/aif-architecture`, optional providers are supporting context only:
+
+- `rg` may be used as a safe availability probe and direct repository search baseline.
+- Graphify may be read only from existing reviewed outputs in allowed project or change context paths.
+- Context7 may be read only from existing reviewed notes in allowed project or change context paths.
+- `codex-agent-mem`, `context-mode`, `codex-mem`, `eagle-mem`, and CodeGraph are forbidden for this command.
+
+Do not install providers, run provider setup, index source, sync memory, register MCP servers, start background services, or execute CodeGraph from `/aif-architecture`.
+
+Treat optional provider output as hypotheses or supporting notes. Final architecture guidance must remain grounded in direct repository evidence, resolved AI Factory config, existing canonical OpenSpec artifacts, generated rules, runtime state, QA evidence, or reviewed provider notes from allowed paths.
+
+### Legacy AI Factory-only mode
+
+When OpenSpec-native mode is not enabled, preserve upstream `/aif-architecture` behavior and keep the same project-level write boundaries:
+
+- resolved `paths.architecture`;
+- architecture pointer in resolved `paths.description`;
+- architecture row in root `AGENTS.md`.
+
+Do not write OpenSpec artifacts, runtime state, QA evidence, generated rules, provider notes, MCP config, provider config, or provider setup files.

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -379,8 +379,12 @@ describe('complete OpenSpec workflow documentation contract', () => {
     assertIncludes(metadata.sources['ai-factory'].notes, 'Commit Plan grouping', 'aifhub-extension.json');
     assertIncludes(metadata.sources['ai-factory'].notes, '/aif-distillation', 'aifhub-extension.json');
     assertIncludes(metadata.sources['ai-factory'].notes, '/aif-archive', 'aifhub-extension.json');
+    assertIncludes(metadata.sources['ai-factory'].notes, '/aif-architecture', 'aifhub-extension.json');
+    assertIncludes(metadata.sources['ai-factory'].notes, '/aif-docs', 'aifhub-extension.json');
+    assertIncludes(metadata.sources['ai-factory'].notes, '/aif-qa', 'aifhub-extension.json');
     assertIncludes(metadata.sources['ai-factory'].notes, 'paths.archive', 'aifhub-extension.json');
     assertIncludes(metadata.sources['ai-factory'].notes, 'archive-aware sequential plan behavior', 'aifhub-extension.json');
+    assertIncludes(metadata.sources['ai-factory'].notes, 'config-aware project utilities', 'aifhub-extension.json');
     assertIncludes(metadata.sources['ai-factory'].notes, 'managed agent config preservation', 'aifhub-extension.json');
     assertIncludes(metadata.sources['ai-factory'].notes, 'Agent Skills', 'aifhub-extension.json');
 
@@ -393,6 +397,19 @@ describe('complete OpenSpec workflow documentation contract', () => {
     for (const expected of [
       'AI Factory 2.15 Reviewed Baseline',
       'AI Factory `2.15.0`',
+      'config-aware project-context utilities',
+      'project-context utilities',
+      '/aif-architecture',
+      '/aif-docs',
+      '/aif-qa',
+      'paths.architecture',
+      'paths.docs',
+      'paths.qa/<branch-slug>/',
+      'not required per-change OpenSpec lifecycle gates',
+      'upstream project-level architecture context',
+      'OpenSpec canonical change/spec generation',
+      'upstream manual QA artifacts',
+      'distinct from AIFHub verification and finalization evidence',
       '/aif-archive',
       'paths.archive',
       '.ai-factory/archive/',
@@ -448,7 +465,27 @@ describe('complete OpenSpec workflow documentation contract', () => {
     ]) {
       assertNotIncludes(combinedDocs, forbiddenClaim, 'docs must not assign OpenSpec finalization to /aif-archive');
     }
+    for (const forbiddenClaim of [
+      '`/aif-architecture` is required per-change',
+      '`/aif-docs` is required per-change',
+      '`/aif-qa` is required per-change',
+      '`/aif-architecture` writes OpenSpec changes',
+      '`/aif-docs` writes OpenSpec changes',
+      '`/aif-qa` writes OpenSpec finalization evidence',
+      '/aif-architecture is required per-change',
+      '/aif-docs is required per-change',
+      '/aif-qa is required per-change',
+      '/aif-architecture writes OpenSpec changes',
+      '/aif-docs writes OpenSpec changes',
+      '/aif-qa writes OpenSpec finalization evidence'
+    ]) {
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'docs must keep project utilities out of required OpenSpec lifecycle gates');
+    }
 
+    assertIncludes(contextPolicy, '| `/aif-architecture` | no | no |', 'docs/context-loading-policy.md Command Ownership');
+    assertIncludes(contextPolicy, '| `/aif-docs` | no | no |', 'docs/context-loading-policy.md Command Ownership');
+    assertIncludes(contextPolicy, '| `/aif-qa` | no | upstream manual QA artifacts under `paths.qa/<branch-slug>/`; not AIFHub `.ai-factory/qa/<change-id>/` evidence |', 'docs/context-loading-policy.md Command Ownership');
+    assertIncludes(contextPolicy, 'Adjacent upstream project-context utilities:', 'docs/context-loading-policy.md Quality Gates and Finalization Tail');
     assertIncludes(contextPolicy, '| `/aif-archive` | no | `paths.archive/plans/*.md` and `paths.archive/roadmap/*.md` only in legacy AI Factory-only cleanup |', 'docs/context-loading-policy.md Command Ownership');
     assertIncludes(handoff, 'legacy-only path и не описывает OpenSpec-native finalization', 'docs/handoff.md');
     assertIncludes(handoff, 'Не используйте `/aif-archive` для OpenSpec-native Done.', 'docs/handoff.md');

--- a/scripts/memory-tool-recommender.test.mjs
+++ b/scripts/memory-tool-recommender.test.mjs
@@ -63,6 +63,14 @@ describe('recommendation metadata parsing', () => {
     assert.equal(metadata.default_policy.require_explicit_paths, true);
     assert.equal(metadata.default_policy.require_purge_path, true);
     assert.ok(metadata.skill_usage_matrix['aif-analyze']);
+    assert.deepEqual(metadata.skill_usage_matrix['aif-architecture'].allowed, ['rg', 'graphify', 'context7']);
+    assert.deepEqual(metadata.skill_usage_matrix['aif-architecture'].forbidden, [
+      'codex-agent-mem',
+      'context-mode',
+      'codex-mem',
+      'eagle-mem',
+      'codegraph'
+    ]);
     assert.deepEqual(metadata.project_dimensions.languages, ['php', 'go', 'js', 'python', 'rust', 'multi']);
     assert.deepEqual(metadata.project_dimensions.volume, ['mini', 'standard', 'large']);
     assert.deepEqual(metadata.project_dimensions.complexity, ['mini', 'framework', 'legacy', 'integration_heavy']);
@@ -80,6 +88,11 @@ describe('recommendation metadata parsing', () => {
     assert.ok(metadata.evidence_runs.some((run) => run.id === 'codegraph-forced-benchmark-2026-05-26'));
     assert.ok(metadata.evidence_runs.some((run) => run.id === 'codegraph-screening-preinit-nosipout-gpt54mini-2026-05-27'));
     assert.equal(metadata.tool_permissions.graphify['aif-analyze'], 'recommend_only');
+    assert.equal(metadata.tool_permissions.graphify['aif-architecture'], 'read_existing_reviewed_output');
+    assert.equal(metadata.tool_permissions.context7['aif-architecture'], 'read_existing_reviewed_output');
+    assert.equal(metadata.tool_permissions['codex-agent-mem']['aif-architecture'], 'forbidden');
+    assert.equal(metadata.tool_permissions['context-mode']['aif-architecture'], 'forbidden');
+    assert.equal(metadata.tool_permissions.codegraph['aif-architecture'], 'forbidden');
     assert.equal(metadata.availability_probes.graphify[0], 'graphify --version');
     assert.ok(metadata.forbidden_operations.includes('auto_install'));
     assert.ok(metadata.protected_artifacts.includes('aif-gate-result'));
@@ -92,9 +105,12 @@ describe('recommendation metadata parsing', () => {
     assert.equal(metadata.tools['codex-mem'].decision, 'reject_default');
     assert.equal(metadata.tools['eagle-mem'].decision, 'reject_defer');
     assert.equal(metadata.tools.context7.decision, 'optional');
+    assert.ok(metadata.tools.context7.allowed_in.includes('aif-architecture'));
+    assert.ok(metadata.tools.graphify.allowed_in.includes('aif-architecture'));
     assert.equal(metadata.tools.codegraph.decision, 'manual_cli_only');
     assert.equal(metadata.tools.codegraph.screening_policy.default_decision, 'avoid_by_default');
     assert.equal(metadata.tools.codegraph.screening_policy.aggregate.rows_executed, 300);
+    assert.ok(metadata.tools.codegraph.forbidden_in.includes('aif-architecture'));
   });
 });
 
@@ -172,7 +188,7 @@ describe('recommendation results', () => {
     assert.equal(graphify.status, 'manual_quality_experiment_only');
     assert.equal(graphify.install_policy, 'explicit_user_opt_in_only');
     assert.equal(graphify.read_scope, 'explicit_project_path');
-    assert.deepEqual(graphify.allowed_in, ['aif-analyze', 'aif-explore', 'aif-plan', 'aif-review']);
+    assert.deepEqual(graphify.allowed_in, ['aif-analyze', 'aif-explore', 'aif-architecture', 'aif-plan', 'aif-review']);
     assert.ok(graphify.forbidden_in.includes('aif-implement'));
     assert.equal(graphify.permission, 'recommend_only');
     assert.match(graphify.privacy_caveat, /explicit project path/i);
@@ -620,6 +636,86 @@ describe('recommendation results', () => {
     assert.ok(implement.body.not_selected_tools.some((item) => item.tool_id === 'codegraph'));
     assert.ok(implement.body.not_selected_tools.some((item) => item.tool_id === 'graphify'));
     assert.ok(implement.body.not_selected_tools.every((item) => /forbidden|not applicable/i.test(item.reason)));
+  });
+
+  it('selects architecture context providers only through command-specific policy', async () => {
+    await mkdir(path.join(tmpDir, '.ai-factory'), { recursive: true });
+    await writeFile(
+      path.join(tmpDir, '.ai-factory', 'config.yaml'),
+      [
+        'utilities:',
+        '  context_tools:',
+        '    enabled:',
+        '      - codegraph',
+        '      - graphify',
+        '      - context7',
+        '      - codex-agent-mem',
+        '      - context-mode',
+        ''
+      ].join('\n'),
+      'utf8'
+    );
+
+    const result = await runMemoryToolRecommender([
+      'select',
+      '--shape',
+      'large_framework_app',
+      '--language',
+      'js',
+      '--volume',
+      'large',
+      '--complexity',
+      'framework',
+      '--repo-shape',
+      'single_repo',
+      '--artifact-mode',
+      'openspec_native',
+      '--task',
+      'architecture_or_impact_discovery',
+      '--command',
+      'aif-architecture',
+      '--metadata',
+      REAL_METADATA,
+      '--json'
+    ], {
+      cwd: tmpDir,
+      stdout: [],
+      stderr: [],
+      exit: false,
+      probeRunner: async () => ({ availability: 'installed', command: 'tool --version' })
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.body.schema, 'aifhub.memory_tools.selection_result.v1');
+    assert.deepEqual(result.body.config.enabled_tools, [
+      'codegraph',
+      'graphify',
+      'context7',
+      'codex-agent-mem',
+      'context-mode'
+    ]);
+
+    const selectedIds = result.body.selected_tools.map((item) => item.tool_id);
+    assert.deepEqual(selectedIds, ['context7']);
+    assert.equal(result.body.selected_tools[0].permission, 'read_existing_reviewed_output');
+    assert.equal(result.body.selected_tools.some((item) => item.permission === 'forbidden'), false);
+
+    for (const toolId of ['codegraph', 'codex-agent-mem', 'context-mode']) {
+      assert.equal(
+        result.body.selected_tools.some((item) => item.tool_id === toolId),
+        false,
+        `${toolId} should not be selected for aif-architecture`
+      );
+      const skipped = result.body.not_selected_tools.find((item) => item.tool_id === toolId);
+      assert.ok(skipped, `${toolId} should appear in not_selected_tools`);
+      assert.equal(skipped.permission, 'forbidden');
+      assert.match(skipped.reason, /forbidden/i, `${toolId} should be skipped by command boundary`);
+    }
+
+    const skippedGraphify = result.body.not_selected_tools.find((item) => item.tool_id === 'graphify');
+    assert.ok(skippedGraphify);
+    assert.equal(skippedGraphify.permission, 'read_existing_reviewed_output');
+    assert.match(skippedGraphify.reason, /not applicable|avoided/i);
   });
 
   it('selects enabled tools from inline YAML config lists', async () => {

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -1,6 +1,7 @@
 // openspec-prompt-assets.test.mjs - instruction-level tests for OpenSpec-native prompt assets
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, normalize, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -72,6 +73,7 @@ const SIDECAR_PROMPT_ASSETS = [
 ];
 
 const ROADMAP_PROMPT_ASSET = 'injections/core/aif-roadmap-maturity-audit.md';
+const ARCHITECTURE_PROMPT_ASSET = 'injections/core/aif-architecture-context-boundary.md';
 const COMMIT_PROMPT_ASSET = 'injections/core/aif-commit-roadmap-freshness.md';
 
 const GRAPHIFY_CONTEXT_DOC_ASSETS = [
@@ -359,6 +361,7 @@ describe('OpenSpec-native prompt asset contract', () => {
       SHARED_LANGUAGE_POLICY_ASSET,
       'injections/core/aif-rules-check-openspec-generated-rules.md',
       ROADMAP_PROMPT_ASSET,
+      ARCHITECTURE_PROMPT_ASSET,
       COMMIT_PROMPT_ASSET,
       ...ROADMAP_REFERENCE_ASSETS,
       'injections/core/aif-implement-plan-folder.md',
@@ -384,6 +387,43 @@ describe('OpenSpec-native prompt asset contract', () => {
     assert.equal(injection.position, 'prepend');
     assert.equal(normalizeManifestPath(injection.file), COMMIT_PROMPT_ASSET);
     await readRepoFile(COMMIT_PROMPT_ASSET);
+  });
+
+  it('registers the architecture context boundary injection in the manifest', async () => {
+    const manifest = await loadManifest();
+    const injections = (manifest.injections ?? []).filter((entry) => entry.target === 'aif-architecture');
+
+    assert.equal(injections.length, 1, 'extension.json should include exactly one aif-architecture injection');
+    assert.equal(injections[0].position, 'prepend');
+    assert.equal(normalizeManifestPath(injections[0].file), ARCHITECTURE_PROMPT_ASSET);
+
+    const asset = await readRepoFile(ARCHITECTURE_PROMPT_ASSET);
+    for (const expected of [
+      'upstream `/aif-architecture`',
+      '`skills/shared/LANGUAGE-POLICY.md`',
+      'Do not create or use an extension-owned `skills/aif-architecture/` directory',
+      'OpenSpec-native mode',
+      'paths.architecture',
+      'paths.description',
+      'AGENTS.md',
+      'openspec/changes/**',
+      'openspec/specs/**',
+      '.ai-factory/state/**',
+      '.ai-factory/qa/**',
+      '.ai-factory/rules/generated/**',
+      'ai-factory aifhub-memory-tools select --from-project --command aif-architecture --json',
+      'Graphify',
+      'Context7',
+      'CodeGraph'
+    ]) {
+      assertIncludes(asset, expected, ARCHITECTURE_PROMPT_ASSET);
+    }
+
+    assert.equal(
+      existsSync(join(REPO_ROOT, 'skills', 'aif-architecture')),
+      false,
+      'AIFHub should not copy or own skills/aif-architecture'
+    );
   });
 
   it('requires active prompt assets to reference the shared language policy', async () => {

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -43,6 +43,12 @@ paths:
   plans: .ai-factory/plans
   specs: .ai-factory/specs
 
+  # Upstream AI Factory optional path defaults remain available when omitted.
+  # Examples: paths.docs -> docs/, paths.qa -> .ai-factory/qa,
+  # paths.archive -> .ai-factory/archive.
+  # paths.architecture stays project-level AI Factory context; do not point it
+  # at canonical OpenSpec paths such as openspec/specs or openspec/changes.
+
   # OpenSpec-native mode writes its own path profile only when selected.
   
   # Rules directory (base.md required, area files optional)


### PR DESCRIPTION
Align upstream project-context utility docs and manifest injection for /aif-architecture, /aif-docs, and /aif-qa so they remain outside OpenSpec lifecycle artifacts.

Add command-specific optional provider selection coverage for aif-architecture and guard against forbidden memory tools.

Closed #119