### PR TITLE
Fix done rules gate remediation

### DIFF
--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -86,7 +86,7 @@ Missing verification evidence suggests:
 
 Doctor also reports `effectivePolicy` from `scripts/openspec-policy.mjs`, including CLI, generated-rules, rules-gate, spec-coverage, and `allowWarnOnDone` settings. Human diagnostics show whether missing or warning evidence is only degraded or blocking under the current policy.
 
-`/aif-done` runs `scripts/openspec-done-readiness.mjs` before archive and writes `.ai-factory/qa/<change-id>/done-readiness.json`. The readiness gate checks OpenSpec validate, OpenSpec status, artifact contract, generated rules freshness, rules gate evidence, coverage, verify gate evidence, and dirty workspace state. Blocking failures refuse archive and include an exact suggested next command, such as `/aif-mode sync --change <change-id>`, `/aif-rules-check`, `/aif-verify <change-id>`, or `/aif-done <change-id> --record-dirty-state`.
+`/aif-done` runs `scripts/openspec-done-readiness.mjs` before archive and writes `.ai-factory/qa/<change-id>/done-readiness.json`. The readiness gate checks OpenSpec validate, OpenSpec status, artifact contract, generated rules freshness, rules gate evidence, coverage, verify gate evidence, and dirty workspace state. Blocking failures refuse archive and include an exact suggested next command, such as `/aif-mode sync --change <change-id>`, `ai-factory aifhub-write-gate-evidence --change <change-id> --gate rules --from <rules-output.md>`, `/aif-verify <change-id>`, or `/aif-done <change-id> --record-dirty-state`.
 
 When `requireRulesPassForDone` is true, save the final `/aif-rules-check` output, or at least its final `aif-gate-result` block, to `.ai-factory/qa/<change-id>/rules.md` before `/aif-done`:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -771,7 +771,7 @@ Use `--skip-specs` for docs/tooling-only changes where no accepted spec update i
 
 A dirty workspace is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` when the current dirty state should be recorded in final QA evidence before archive. For docs/tooling-only finalization, preserve both public flags with `/aif-done <change-id> --skip-specs --record-dirty-state`.
 
-If `requireRulesPassForDone` is true and readiness reports missing rules gate evidence, rerun `/aif-rules-check` and persist the final output with `ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules --from /tmp/aif-rules-check-output.md`, or save at least the final `aif-gate-result` block to `.ai-factory/qa/<change-id>/rules.md`.
+If `requireRulesPassForDone` is true and readiness reports missing rules gate evidence, `suggested_next.command` points to `ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules --from <rules-output.md>`. The accompanying reason tells you to rerun `/aif-rules-check` first and persist its final output, or at least the final `aif-gate-result` block, to `.ai-factory/qa/<change-id>/rules.md`.
 
 Next steps after `/aif-done`:
 

--- a/scripts/openspec-done-readiness.mjs
+++ b/scripts/openspec-done-readiness.mjs
@@ -589,6 +589,7 @@ async function inspectRulesGate(changeId, options) {
   const acceptedWarn = status === 'warn' && allowWarn;
   const blocking = acceptedWarn ? false : required;
   const error = rulesGate?.errors?.[0];
+  const evidencePath = rulesGate?.path ?? toPosix(path.join(DEFAULT_QA_DIR, changeId, 'rules.md'));
   return checkResult({
     check: 'rules_gate',
     level: blocking ? 'fail' : 'warn',
@@ -599,11 +600,17 @@ async function inspectRulesGate(changeId, options) {
       : error?.message ?? `Rules gate evidence is ${status}.`,
     path: rulesGate?.path,
     value: rulesGate,
-    suggestedNext: {
-      command: '/aif-rules-check',
-      reason: 'rules gate evidence must pass before done finalization'
-    }
+    suggestedNext: createRulesGateSuggestedNext(changeId, evidencePath)
   });
+}
+
+function createRulesGateSuggestedNext(changeId, evidencePath) {
+  const rulesEvidencePath = toPosix(evidencePath ?? path.join(DEFAULT_QA_DIR, changeId, 'rules.md'));
+
+  return {
+    command: `ai-factory aifhub-write-gate-evidence --change ${changeId} --gate rules --from <rules-output.md>`,
+    reason: `Run /aif-rules-check, save its final rules output, then persist it to ${rulesEvidencePath} before /aif-done.`
+  };
 }
 
 async function inspectCoverage(changeId, options) {

--- a/scripts/openspec-done-readiness.test.mjs
+++ b/scripts/openspec-done-readiness.test.mjs
@@ -194,6 +194,22 @@ function generatedRules(overrides = {}) {
   };
 }
 
+function missingRulesGateEvidence() {
+  return {
+    exists: false,
+    ok: false,
+    status: 'missing',
+    path: '.ai-factory/qa/add-oauth/rules.md',
+    gateResult: null,
+    warnings: [],
+    errors: [{
+      code: 'rules-gate-evidence-missing',
+      message: 'Rules gate evidence is missing.',
+      path: '.ai-factory/qa/add-oauth/rules.md'
+    }]
+  };
+}
+
 function passingOptions(overrides = {}) {
   return {
     detectOpenSpec: async () => availableCliDetection(),
@@ -260,6 +276,118 @@ describe('OpenSpec done readiness gate', () => {
     assert.equal(readiness.status, 'fail');
     assert.equal(readiness.checks.generated_rules, 'fail');
     assert.equal(readiness.suggested_next.command, '/aif-mode sync --change add-oauth');
+  });
+
+  it('blocks missing rules_gate evidence with write-gate-evidence remediation', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        readOpenSpecRulesGateEvidence: async () => missingRulesGateEvidence()
+      })
+    });
+
+    assert.equal(readiness.status, 'fail');
+    assert.equal(readiness.checks.rules_gate, 'fail');
+    assert.equal(
+      readiness.suggested_next.command,
+      'ai-factory aifhub-write-gate-evidence --change add-oauth --gate rules --from <rules-output.md>',
+      'rules_gate should route to the durable write-gate-evidence helper'
+    );
+    assert.match(readiness.suggested_next.reason, /\/aif-rules-check/);
+    assert.match(readiness.suggested_next.reason, /\.ai-factory\/qa\/add-oauth\/rules\.md/);
+  });
+
+  it('blocks disallowed allowWarnOnDone.rules warnings with write-gate-evidence remediation', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        readOpenSpecRulesGateEvidence: async () => rulesGateEvidence('warn')
+      })
+    });
+
+    assert.equal(readiness.status, 'fail');
+    assert.equal(readiness.checks.rules_gate, 'fail');
+    assert.equal(
+      readiness.suggested_next.command,
+      'ai-factory aifhub-write-gate-evidence --change add-oauth --gate rules --from <rules-output.md>',
+      'allowWarnOnDone.rules=false should still route rules_gate to durable evidence persistence'
+    );
+    assert.match(readiness.suggested_next.reason, /\/aif-rules-check/);
+  });
+
+  it('renders rules_gate write-gate-evidence remediation in human output', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const readiness = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        readOpenSpecRulesGateEvidence: async () => missingRulesGateEvidence()
+      })
+    });
+    const summary = summarizeOpenSpecDoneReadiness(readiness);
+
+    assert.match(
+      summary,
+      /Suggested next: ai-factory aifhub-write-gate-evidence --change add-oauth --gate rules --from <rules-output\.md>/,
+      summary
+    );
+    assert.match(summary, /\/aif-rules-check/, summary);
+    assert.match(summary, /final .*rules.* output/i, summary);
+  });
+
+  it('keeps suggested_next priority for generated_rules, rules_gate, and coverage blockers', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+
+    const rulesAndCoverage = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        readOpenSpecRulesGateEvidence: async () => missingRulesGateEvidence(),
+        readOpenSpecCoverageMatrix: async () => coverageEvidence({ status: 'fail' })
+      })
+    });
+
+    assert.equal(rulesAndCoverage.checks.rules_gate, 'fail');
+    assert.equal(rulesAndCoverage.checks.coverage, 'fail');
+    assert.equal(
+      rulesAndCoverage.suggested_next.command,
+      'ai-factory aifhub-write-gate-evidence --change add-oauth --gate rules --from <rules-output.md>',
+      'rules_gate should have priority over coverage blockers'
+    );
+
+    const generatedRulesAndRules = await buildOpenSpecDoneReadiness({
+      rootDir,
+      changeId: 'add-oauth',
+      ...passingOptions({
+        collectGeneratedRules: async () => generatedRules({
+          warnings: [{
+            code: 'generated-rules-stale',
+            message: 'Generated rules are stale.',
+            path: '.ai-factory/rules/generated/openspec-merged-add-oauth.md'
+          }]
+        }),
+        readOpenSpecRulesGateEvidence: async () => missingRulesGateEvidence()
+      })
+    });
+
+    assert.equal(generatedRulesAndRules.checks.generated_rules, 'fail');
+    assert.equal(generatedRulesAndRules.checks.rules_gate, 'fail');
+    assert.equal(
+      generatedRulesAndRules.suggested_next.command,
+      '/aif-mode sync --change add-oauth',
+      'generated_rules should keep priority over rules_gate blockers'
+    );
   });
 
   it('requires artifact contract pass instead of accepting warnings', async () => {

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -34,7 +34,7 @@ OpenSpec-native mode finalizes the verified change state through `scripts/opensp
 - Always run the pre-archive readiness gate through `scripts/openspec-done-readiness.mjs` before archive and persist `.ai-factory/qa/<change-id>/done-readiness.json`.
 - If verification has not run or verdict is `fail`, stop and suggest `/aif-verify` or `/aif-fix`.
 - If the verify gate result is missing, invalid, or `fail`, stop and suggest rerunning `/aif-verify <change-id>` or `/aif-fix <change-id>`.
-- If coverage, generated rules, or rules gate evidence is missing, invalid, stale, failed, or warning-only when policy does not allow the warning, stop and suggest the owning command (`/aif-mode sync --change <change-id>`, `/aif-rules-check`, or `/aif-verify <change-id>`).
+- If coverage, generated rules, or rules gate evidence is missing, invalid, stale, failed, or warning-only when policy does not allow the warning, stop on the readiness result and show its `suggested_next.command` and `suggested_next.reason` exactly. For rules gate blockers, the command may be the installed durable evidence writer, not `/aif-rules-check` alone.
 - If readiness reports a blocking failure, refuse archive and show `suggested_next.command` and `suggested_next.reason` exactly.
 - Refuse unverified changes; do not accept `Code verification: PENDING` as final verification.
 - Dirty workspace state is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun the public route `/aif-done <change-id> --record-dirty-state` to record dirty state in final QA evidence before archive.

--- a/test/fixtures/openspec-rule-violation/expected.json
+++ b/test/fixtures/openspec-rule-violation/expected.json
@@ -78,6 +78,6 @@
     "diagnostic_codes": [
       "rules-gate-fail"
     ],
-    "suggested_next": "/aif-rules-check"
+    "suggested_next": "ai-factory aifhub-write-gate-evidence --change fixture-change --gate rules --from <rules-output.md>"
   }
 }


### PR DESCRIPTION
## Summary

- Route blocking `rules_gate` done-readiness remediation to the installed durable evidence writer.
- Keep `/aif-rules-check` as the capture step and make the required persistence path explicit.
- Update AIFHub docs, `aif-done` guidance, readiness tests, and fixture expectations.

## Why

Issue #125 left strict OpenSpec-native `/aif-done` in a dead-end: readiness pointed users at read-only `/aif-rules-check`, but strict done finalization requires durable rules gate evidence under `.ai-factory/qa/<change-id>/rules.md`.

## Validation

- `npm run validate`
- `npm test` (496 passed, 0 failed)
- `openspec validate fix-aif-done-rules-gate-remediation --type change --strict --no-interactive --no-color`
- `git diff --check`
- `/aif-rules-check` saved via `ai-factory aifhub-write-gate-evidence`
- `/aif-done fix-aif-done-rules-gate-remediation --record-dirty-state`

Fixes #125