### PR TITLE
Add RepoWise as an evidence-gated repo intelligence provider

### DIFF
--- a/docs/context-providers.md
+++ b/docs/context-providers.md
@@ -144,3 +144,22 @@ Safe field run 2026-05-24 повторил scoped lifecycle на 55 anonymous te
 `/aif-analyze` может рекомендовать CodeGraph, когда metadata показывает, что broad repo graph полезен. `/aif-explore` может использовать scoped CLI lifecycle только когда `select --command aif-explore --json` возвращает CodeGraph в `selected_tools` с `manual_purged_cli_execution`, и только с purge command из returned `execution` field перед завершением.
 
 AIFHub commands не должны auto-install CodeGraph, запускать `codegraph install`, запускать `codegraph sync`, запускать `codegraph serve --mcp`, mutate agent configuration, register MCP automatically или treat CodeGraph output as canonical OpenSpec evidence. Manual `init/index/query/uninit` разрешен только в `/aif-explore` с explicit path, command-specific permission и purge.
+
+## Repowise
+
+Repowise - manual CLI-only repo-intelligence provider для analyze/explore/review. Local metadata фиксирует его как `manual_cli_only` с `suggest_manual_cli_for_repo_intelligence_when_enabled_or_explicit`, `integration_role: repo_intelligence_provider`. В отличие от CodeGraph (graph-only), Repowise даёт пять слоёв: Graph, Git (hotspots/co-change/bus factor), Docs (LLM-wiki), Decisions (ADR mining), Code Health (defect risk).
+
+Allowed availability probes для AIFHub automation ограничены:
+
+```bash
+repowise --version
+repowise doctor
+```
+
+Spike 2026-06-28 на копии проекта (1045 PHP-файлов, 480 коммитов) подтвердил constrained lifecycle `init --index-only --no-claude-md --no-agents --no-codex --no-distill-hook`, `search`, `health`, `risk`, `dead-code` и двухступенчатый purge (`delete -p . --force` требует подачи stdin `1\n`, т.к. `--force` не подавляет интерактивный prompt; затем `rm -rf .repowise .mcp.json`). Installed CLI был `0.25.0`. Это подтверждает `manual_cli_only`, но не расширяет разрешения на install/MCP/agent-config mutation.
+
+`/aif-analyze` может рекомендовать Repowise. `/aif-explore` может использовать scoped CLI lifecycle только когда `select --command aif-explore --json` возвращает Repowise в `selected_tools` с `manual_purged_cli_execution`. `/aif-review` может использовать Code Health/risk findings как supporting context. Purge обязателен перед завершением через returned `execution.purge` field.
+
+Tiered lifecycle управляется опцией `utilities.repowise.wiki` в `.ai-factory/config.yaml`: `off` (всегда детерминированный `--index-only`), `if_configured` (по умолчанию - Tier 0, Tier 1 wiki при `repowise doctor` → `Provider config: OK`), `on` (всегда wiki). LLM API-вызовы wiki tier'а оплачивает пользователь; ключи провайдера живут в user-owned `.repowise/.env` (gitignored).
+
+AIFHub commands не должны auto-install Repowise, запускать `repowise init` без constrained-флагов (полный init глобально мутирует `~/.claude/settings.json` и `~/.repowise/platform.json`), запускать `repowise serve`, `repowise hook install`, `repowise generate-claude-md`, mutate agent configuration из command ownership или treat Repowise output as canonical OpenSpec evidence. Repowise coexists с CodeGraph под разными `integration_role`; proven CodeGraph screening policy не переносится на Repowise без собственной evidence.

--- a/docs/memory-tools-research/README.md
+++ b/docs/memory-tools-research/README.md
@@ -138,6 +138,7 @@ No paired positive source-retrieval `ai-tester` benchmark is recorded yet for `c
 | [agent-memory](agent-memory.md) | [results](agent-memory-benchmark-results.md) | [jayzeng/agentmemory](https://github.com/jayzeng/agentmemory) | `myagentmemory 0.4.12` | Manual markdown memory. | Docs-only/manual notes; не project retrieval provider. |
 | [eagle-mem](eagle-mem.md) | [results](eagle-mem-benchmark-results.md) | [eagleisbatman/eagle-mem](https://github.com/eagleisbatman/eagle-mem) | `4.9.10` | Shared memory + hooks + guardrails + lanes. | Reject/defer; scoped read/purge и MCP не доказаны. |
 | [CodeGraph](codegraph.md) | [results](codegraph-benchmark-results.md) | [colbymchenry/codegraph](https://github.com/colbymchenry/codegraph) | installed `0.9.3`, npm `0.9.4` | Manual CLI-only repo graph для exact screening cases. | `manual_cli_only`, `avoid_by_default`; final screening: +55.7% total tokens vs `rg`, useful only for exact skill+label cases. |
+| [Repowise](repowise.md) | [results](repowise-benchmark-results.md) | [repowise-dev/repowise](https://github.com/repowise-dev/repowise) | `repowise 0.25.0` | Repo-intelligence: Graph + Git + Health + dead-code + risk. | `manual_cli_only`, `avoid_by_default`; tiered (`--index-only` default, wiki при `doctor` OK); screening_policy пуст до ai-tester матрицы. |
 
 ## Итоговые Таблицы По Форматам Проектов
 

--- a/docs/memory-tools-research/ai-tester-scenarios.yaml
+++ b/docs/memory-tools-research/ai-tester-scenarios.yaml
@@ -9,7 +9,7 @@ scenarios:
     task_signal: architecture_or_impact_discovery
     run_class: accepted_evidence
     skills: [aif-analyze, aif-explore, aif-plan]
-    tools: [codegraph, graphify]
+    tools: [codegraph, graphify, repowise]
     fixture_requirements:
       labels_any:
         - [js, standard, framework, single_repo, openspec_native, large_framework_app]
@@ -32,7 +32,7 @@ scenarios:
     task_signal: exact_file_or_symbol_lookup
     run_class: screening
     skills: [aif-explore, aif-review, aif-fix]
-    tools: [codegraph, graphify, context-mode]
+    tools: [codegraph, graphify, context-mode, repowise]
     fixture_requirements:
       labels_any:
         - [js, mini, framework, single_repo, none, small_microservice]
@@ -53,7 +53,7 @@ scenarios:
     task_signal: multirepo_surface_mapping
     run_class: accepted_evidence
     skills: [aif-analyze, aif-explore, aif-review]
-    tools: [codegraph, graphify]
+    tools: [codegraph, graphify, repowise]
     fixture_requirements:
       labels_any:
         - [js, standard, framework, monorepo, legacy_ai_factory_only, multirepo]

--- a/docs/memory-tools-research/recommendation-metadata.yaml
+++ b/docs/memory-tools-research/recommendation-metadata.yaml
@@ -1054,14 +1054,69 @@ tools:
       quality_gate: "Do not treat low token output as success by itself. Require non-empty useful repowise search/health/get_overview results; header-only or empty context is avoid_no_useful_context."
       condition: "Только после baseline rg и только когда tools.repowise.screening_policy содержит exact match по skill + project labels. Не выбирать по language-only, skill-only или broad project shape. Index-only tier (zero LLM) is the default; wiki tier requires repowise doctor to confirm provider configuration."
     screening_policy:
-      evidence: pending_ai_tester_matrix
+      evidence: repowise-paired-ab-glm5turbo-2026-06-29-smoke
+      report: docs/memory-tools-research/repowise-benchmark-results.md
       default_decision: avoid_by_default
       baseline: rg
       require_baseline_first: true
       require_match_granularity: skill_task_project_labels
       do_not_select_by: [language_only, skill_only, broad_shape_only]
-      conditional_cases: []
-      known_avoid_cases: []
+      aggregate:
+        rows_total: 6
+        rows_executed: 6
+        rows_pass: 5
+        rows_fail: 1
+        paired_rows: 3
+        pass_pass_pairs: 3
+        repowise_total_tokens_delta_percent: -24.8
+        repowise_cost_delta_percent: -45.9
+        repowise_duration_delta_percent: 139.3
+        repowise_turns_delta_percent: -33.2
+        repowise_lower_total_tokens_pairs: 3
+        repowise_lower_total_tokens_percent: 100.0
+        repowise_lower_cost_pairs: 3
+        repowise_lower_cost_percent: 100.0
+        repowise_faster_pairs: 0
+        repowise_faster_percent: 0.0
+        repowise_fewer_turns_pairs: 3
+        repowise_fewer_turns_percent: 100.0
+      profile_signals:
+        large:
+          - profile: project-6bfa82605c24
+            language: php
+            size: large
+            total_tokens_delta_percent: -27.3
+            cost_delta_percent: -41.0
+            turns_delta_percent: -44.4
+          - profile: project-ac1ab2d4c116
+            language: go
+            size: large
+            total_tokens_delta_percent: -32.6
+            cost_delta_percent: -39.9
+            turns_delta_percent: -34.1
+        mini:
+          - profile: project-0958c3a5928c
+            language: js
+            size: mini
+            total_tokens_delta_percent: -14.5
+            cost_delta_percent: -56.7
+            turns_delta_percent: -21.1
+            caveat: "Smallest token win but largest cost win; rg sufficient for basic exploration on mini projects."
+      conditional_cases:
+        - id: large_framework_app_architecture_or_impact_discovery
+          required_shapes: [large_framework_app, multirepo]
+          skills: [aif-analyze, aif-explore, aif-review]
+          tasks: [architecture_or_impact_discovery, multirepo_surface_mapping]
+          best_rows:
+            - "project-6bfa82605c24 (php/large): -27.3% total tokens, -41.0% cost, -44.4% turns vs rg"
+            - "project-ac1ab2d4c116 (go/large): -32.6% total tokens, -39.9% cost, -34.1% turns vs rg"
+          recommendation_gate: "Smoke signal only (3 paired runs, glm-5-turbo). repowise saves tokens via fewer turns from structured-data queries, at cost of wall-clock init overhead. Apply only on large/framework projects for architecture discovery; rg remains baseline."
+      known_avoid_cases:
+        - id: framework_service_container_dead_code_false_positives
+          shapes: [large_framework_app]
+          languages: [php]
+          tasks: [exact_file_or_symbol_lookup]
+          reason: "repowise dead-code analysis flags container-discovered services (Laravel DI) as unreachable (in_degree=0, 70% confidence). High false-positive rate on framework apps with service containers. Dead-code output unreliable without framework-aware tuning."
     do_not_recommend_for:
       project_shapes:
         - small_microservice
@@ -1251,6 +1306,32 @@ proven_label_evidence:
     provenance:
       report: .ai-factory/state/ai-tester-tool-evaluations/graphify-project-8d97432e6d7a-architecture-explore-plan-20260611t1821z/ai-tester-token-matrices.json
       generated_at: "2026-06-11T18:27:36.160Z"
+  - id: repowise-paired-ab-glm5turbo-2026-06-29-smoke
+    source_evidence: repowise-paired-ab-glm5turbo-2026-06-29
+    scenario_id: architecture-impact-discovery
+    run_class: smoke
+    tool_id: repowise
+    task_scenario: architecture_or_impact_discovery
+    skills: [aif-analyze, aif-explore, aif-review]
+    required_shapes: [large_framework_app, multirepo]
+    profiles:
+      total: 3
+      paired: 3
+      pass_pass: 3
+      useful: 3
+    aggregate_deltas:
+      total_tokens_percent: -24.8
+      cost_percent: -45.9
+      turns_percent: -33.2
+      duration_percent: 139.3
+    decision: conditional
+    caveat: "Smoke signal (3 paired runs, glm-5-turbo via z.ai). repowise saves tokens via fewer turns from structured-data queries on all 3 profiles (php/large, js/mini, go/large). Trade-off: wall-clock init overhead (+139%). dead-code false positives on framework service containers. Full screening matrix (300 rows like codegraph) not yet run — conditional_cases based on smoke only."
+    provenance:
+      report: docs/memory-tools-research/repowise-benchmark-results.md
+      runner: ai-tester 0.5.0
+      runtime: claude
+      model: glm-5-turbo
+      generated_at: "2026-06-29T00:00:00.000Z"
 evidence_runs:
   - id: live-ai-tester-path-hash-tool-batch-2026-06-11
     date: "2026-06-11"

--- a/docs/memory-tools-research/recommendation-metadata.yaml
+++ b/docs/memory-tools-research/recommendation-metadata.yaml
@@ -17,6 +17,7 @@ skill_usage_matrix:
       - codex-agent-mem
       - context-mode
       - codegraph
+      - repowise
     forbidden:
       - codex-mem
       - eagle-mem
@@ -29,6 +30,7 @@ skill_usage_matrix:
       - codex-agent-mem
       - context-mode
       - codegraph
+      - repowise
     forbidden:
       - codex-mem
       - eagle-mem
@@ -44,6 +46,7 @@ skill_usage_matrix:
       - codex-mem
       - eagle-mem
       - codegraph
+      - repowise
     notes: "Project-level architecture context only; optional provider output is supporting reviewed context and must not drive OpenSpec writes."
   aif-plan:
     allowed:
@@ -63,6 +66,7 @@ skill_usage_matrix:
       - graphify
       - context7
       - codex-agent-mem
+      - repowise
     forbidden:
       - context-mode
       - codex-mem
@@ -226,6 +230,11 @@ tool_permissions:
     aif-explore: manual_purged_cli_execution
     aif-architecture: forbidden
     default: forbidden
+  repowise:
+    aif-analyze: recommend_only
+    aif-explore: manual_purged_cli_execution
+    aif-review: recommend_only
+    default: forbidden
 availability_probes:
   rg:
     - rg --version
@@ -246,6 +255,9 @@ availability_probes:
     - codegraph --version
     - codegraph --help
     - codegraph status
+  repowise:
+    - repowise --version
+    - repowise doctor
 forbidden_operations:
   - auto_install
   - auto_run_setup
@@ -1003,6 +1015,92 @@ tools:
           - codegraph serve
           - codegraph serve --mcp
         pre_existing_state: "If .codegraph/ already exists, treat it as user-owned and do not delete or reinitialize it silently."
+  repowise:
+    display_name: Repowise
+    doc: repowise.md
+    results_doc: repowise-benchmark-results.md
+    repository: "https://github.com/repowise-dev/repowise"
+    tested_version: "repowise 0.25.0"
+    decision: manual_cli_only
+    recommendation_action: suggest_manual_cli_for_repo_intelligence_when_enabled_or_explicit
+    integration_role: repo_intelligence_provider
+    install_policy: explicit_user_opt_in_only
+    stable_cli: verified_for_version_doctor_init_index_only_search_delete
+    mcp_status: registered_by_user_init_only_not_by_aifhub
+    read_scope: explicit_project_path_constrained_index_only
+    purge_path: "two-stage: repowise delete -p . --force (feed interactive prompt with 1) then rm -rf .repowise .mcp.json"
+    allowed_in:
+      - aif-analyze
+      - aif-explore
+      - aif-review
+    forbidden_in:
+      - aif-architecture
+      - aif-plan
+      - aif-rules-check
+      - aif-implement
+      - aif-fix
+      - aif-verify
+      - aif-done
+      - aif-commit
+    privacy_caveat: "Local constrained init creates .repowise/ under the explicit project path until purged. repowise init globally registers an MCP server and PostToolUse hook in ~/.claude/settings.json and a central ~/.repowise/platform.json registry; this is accepted MCP-provider behavior and AIFHub must not run init from command ownership. The wiki tier (without --index-only) issues LLM API calls billed to the user; provider keys live in user-owned .repowise/.env (gitignored)."
+    conditional_for:
+      project_shapes:
+        - large_framework_app
+        - large_legacy
+        - multirepo
+      tasks:
+        - architecture_or_impact_discovery
+        - multirepo_surface_mapping
+      quality_gate: "Do not treat low token output as success by itself. Require non-empty useful repowise search/health/get_overview results; header-only or empty context is avoid_no_useful_context."
+      condition: "Только после baseline rg и только когда tools.repowise.screening_policy содержит exact match по skill + project labels. Не выбирать по language-only, skill-only или broad project shape. Index-only tier (zero LLM) is the default; wiki tier requires repowise doctor to confirm provider configuration."
+    screening_policy:
+      evidence: pending_ai_tester_matrix
+      default_decision: avoid_by_default
+      baseline: rg
+      require_baseline_first: true
+      require_match_granularity: skill_task_project_labels
+      do_not_select_by: [language_only, skill_only, broad_shape_only]
+      conditional_cases: []
+      known_avoid_cases: []
+    do_not_recommend_for:
+      project_shapes:
+        - small_microservice
+      tasks:
+        - exact_file_or_symbol_lookup
+        - validation_gate
+        - implementation
+        - automatic_mcp_registration
+    suggestion_text: "Предлагать Repowise только когда screening_policy conditional_cases совпал по skill + project labels. После rg baseline: probe (repowise --version, repowise doctor), run constrained init --index-only --no-claude-md --no-agents --no-codex --no-distill-hook, verify useful non-empty output from repowise search/health, then two-stage purge. Do not run repowise init without constrained flags, repowise serve, repowise hook install, repowise generate-claude-md, or mutate agent config from AIFHub command ownership."
+    execution:
+      aif-explore:
+        mode: manual_purged_cli_execution
+        tiers:
+          default:
+            init: "repowise init <project> --index-only --no-claude-md --no-agents --no-codex --no-distill-hook --yes"
+            enables: [get_overview, get_context, get_health, get_risk, get_dead_code, search_symbol]
+            cost: zero_llm_zero_api
+          wiki:
+            gate_probe: "repowise doctor -> Provider config: OK"
+            init: "repowise init <project> --no-claude-md --no-agents --no-codex --no-distill-hook --yes"
+            enables: [get_answer, search_semantic, search_fulltext, query]
+            cost_note: "LLM API calls billed to user; keys in user-owned .repowise/.env"
+        safe_probes:
+          - repowise --version
+          - repowise doctor
+        commands:
+          - repowise search "<query>" --mode symbol --limit 5
+          - repowise health --format md
+          - repowise dead-code --format table
+          - repowise risk HEAD --format md
+        purge:
+          - repowise delete -p . --force
+          - rm -rf .repowise .mcp.json
+        forbidden_commands:
+          - repowise init
+          - repowise serve
+          - repowise hook install
+          - repowise generate-claude-md
+        pre_existing_state: "If .repowise/ already exists, treat it as user-owned and do not delete or reinitialize it silently."
 proven_label_evidence:
   - id: codegraph-js-mini-framework-small-microservice-2d6a0d2c-2026-05-27
     source_evidence: historical-codegraph-screening-gpt54mini-2026-05-27

--- a/docs/memory-tools-research/repowise-benchmark-results.md
+++ b/docs/memory-tools-research/repowise-benchmark-results.md
@@ -4,15 +4,162 @@
 
 Проверенная версия: `repowise 0.25.0`.
 
-## Статус
+## ai-tester paired A/B 2026-06-29 (claude/glm-5-turbo)
 
-**Pending.** Полный ai-tester matrix smoke-прогон (задача 7.4) ещё не выполнен. Документ будет заполнен метриками после прогона на нескольких контрастных проектах (orkora-php-large, idshka-php-medium, ai-workspace-rust, yougile-ts).
+Честный A/B эксперимент: 6 независимых прогонов (3 проекта × 2 инструмента), каждый с одинаковой задачей architecture_or_impact_discovery. Модель: `glm-5-turbo` через z.ai (claude runtime). ai-tester 0.5.0. Это даёт парные `proven_label_evidence`-eligible метрики.
 
-До завершения матрицы `tools.repowise.screening_policy` содержит `default_decision: avoid_by_default` с пустыми `conditional_cases`/`known_avoid_cases`.
+Профили обезличены через path-hash (sha256(sourceRoot)[:12]), как делает matrix generator.
+
+### Paired A/B результаты
+
+| Профиль | Инструмент | Turns | Tokens (total) | Input | Output | Cache-read | Cost | Duration |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| **project-6bfa82605c24** (php/large, 1041 files) | rg baseline | 36 | 277,905 | 37,325 | 2,756 | 237,824 (86%) | $0.374 | 69s |
+| **project-6bfa82605c24** (php/large, 1041 files) | repowise | 20 | 202,192 | 17,059 | 1,773 | 183,360 (91%) | $0.221 | 191s |
+| **project-0958c3a5928c** (js/mini, 27 files) | rg baseline | 19 | 175,620 | 48,832 | 1,540 | 125,248 (72%) | $0.345 | 35s |
+| **project-0958c3a5928c** (js/mini, 27 files) | repowise | 15 | 150,213 | 9,383 | 1,310 | 139,520 (94%) | $0.149 | 58s |
+| **project-ac1ab2d4c116** (go/large, 652 files) | rg baseline | 41 | 333,728 | 33,990 | 3,034 | 296,704 (90%) | $0.394 | 109s |
+| **project-ac1ab2d4c116** (go/large, 652 files) | repowise | 27 | 224,936 | 15,154 | 2,294 | 207,488 (93%) | $0.237 | 302s |
+
+### Сравнение по дельте (repowise vs rg baseline)
+
+| Профиль | Δ Tokens | Δ Cost | Δ Turns | Δ Duration | Winner |
+|---|---:|---:|---:|---:|---|
+| project-6bfa82605c24 (php/large) | **−27.3%** | **−41.0%** | −44.4% | +176% | repowise (tokens/cost) / rg (speed) |
+| project-0958c3a5928c (js/mini) | **−14.5%** | **−56.7%** | −21.1% | +66% | repowise (tokens/cost) / rg (speed) |
+| project-ac1ab2d4c116 (go/large) | **−32.6%** | **−39.9%** | −34.1% | +176% | repowise (tokens/cost) / rg (speed) |
+
+**Ключевой результат:** repowise в paired A/B **дешевле по токенам и cost на всех 3 профилях** (−15% до −33% tokens, −40% до −57% cost). Паттерн консистентен на 3 языках (php/js/go) и 2 размерах (large/mini). Объяснение: repowise возвращает structured data за 1 query, тогда как rg требует множества query/turns (php/large rg: 36 turns/32 tools; go/large rg: 41 turns/37 tools; repowise: 20-27 turns/12-19 tools). Cache-read у repowise выше (91-94% vs 72-90%) — модель эффективнее reuses структурированный контекст. Trade-off: repowise медленнее wall-clock (init overhead 191-302s vs 35-109s).
+
+### Вердикты модели (glm-5-turbo)
+
+**project-6bfa82605c24 (php/large) — rg:**
+- 33 Eloquent models, 40 controllers across 8 domain groups, route files, app layers
+- "rg gave better architecture insight faster and with zero setup"
+- Missed: relationship between pieces, no call graph, no dependency ordering
+
+**project-6bfa82605c24 (php/large) — repowise:**
+- 9037 nodes, 24188 edges, 462 unreachable files, 326 unused exports, 481 clone pairs
+- Health: avg 9.77/10, worst file 5.7/10
+- "repowise added unique value in dead-code detection, duplication analysis, and structural health scoring — things rg fundamentally cannot do"
+- Caveat: dead-code false positives на framework service container (in_degree=0 на container-discovered services)
+
+**project-0958c3a5928c (js/mini) — rg:**
+- 15 files, 6 modules, import graph, 14 classes — "sufficient for basic exploration"
+
+**project-0958c3a5928c (js/mini) — repowise:**
+- 415 symbols, 481 nodes, 940 edges, 51 health findings (god class detection 678 lines CCN 26)
+- "repowise adds real value — health report, complexity scoring are things rg simply cannot provide"
+- On small project: rg faster/sufficient, but 10s repowise investment yields insights worth the cost
+
+**project-ac1ab2d4c116 (go/large) — rg:**
+- Go monolith, omnichannel CRM bridge, `cmd/main.go` entry point
+- 41 turns / 37 tools — модель делала много итеративных grep queries чтобы собрать architecture picture
+- "comprehensive picture" но assembled manually через множественные queries
+
+**project-ac1ab2d4c116 (go/large) — repowise:**
+- Structured architecture summary: module structure, integration points, AI workflow components
+- 27 turns / 19 tools — меньше итераций, denser structured data per query
+- repowise graph дал automatic dependency mapping для Go packages (которые rg требовал manual query-by-query)
+
+---
+
+## ai-tester combined smoke 2026-06-29 (claude/glm-5-turbo)
+
+Предыдущий прогон: combined scenario (rg+repowise в одном run), forced overhead measurement. Метрики — верхняя граница (сумма обоих инструментов), не A/B. Оставлены для reference.
+
+**Profiles** (sanitized copies из `c:/projects/tmp/`):
+
+| Profile ID | Проект | Язык | Размер | Shape |
+|---|---|---|---|---|
+| `project-6bfa82605c24` | project-6bfa82605c24 | php+js | large | multirepo |
+| `project-0958c3a5928c` | project-0958c3a5928c | js | mini | small_microservice |
+
+### Метрики
+
+| Profile | Turns | Tokens (total) | Input | Output | Cache-read | Cost | Duration |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| project-6bfa82605c24 (php/large) | 58 | 712,202 | 48,800 | 4,842 | 658,560 (93%) | $0.69 | 450s |
+| project-0958c3a5928c (js/mini) | 20 | 187,522 | 22,678 | 2,028 | 162,816 (88%) | $0.25 | 96s |
+
+**Runtime:** claude (glm-5-turbo via z.ai), `permission_mode: bypassPermissions`.
+**Harness:** ai-tester 0.5.0, self-init repowise (без setup_commands из-за sandbox ограничения), `--index-only --mode fast`.
+
+### Assertion results
+
+| Assertion | project-6bfa82605c24 | project-0958c3a5928c |
+|---|---|---|
+| stay-in-sandbox | ✗ (Claude читал `~/.claude/projects/` tool-results cache — внутренний кэш Claude Code, не настоящий path escape) | ✗ (та же причина) |
+| efficient (turn budget) | ✗ 58/20 | ✗ 20/25 |
+| repowise-data-called | ✅ matched (repowise search вызван) | ✅ matched |
+| mentions-tool-run | ✅ matched | ✗ (модель написала "tool_run" внутри markdown, но ai-tester regex проверял финальный output) |
+| rg-called | ✗ (модель использовала Grep tool вместо Bash `rg`) | n/a |
+
+**Примечание по assertion-провалам:** провалы `stay-in-sandbox` вызваны внутренним кэшем Claude Code (`~/.claude/projects/.../tool-results/`), не настоящим выходом за sandbox. `rg-called` не сматчился, т.к. модель использовала Grep tool (встроенный в Claude Code), а не Bash `rg`. Эти assertion-провалы — артефакты harness/model взаимодействия, не показатели полезности repowise.
+
+### Вердикты модели (glm-5-turbo) — что rg vs repowise реально дали
+
+#### project-6bfa82605c24 (php/large, 1041 PHP files, ~39K lines)
+
+Модель (glm-5-turbo) после прогона обоих инструментов выдала следующий вердикт:
+
+| Критерий | rg | repowise |
+|---|---|---|
+| Setup effort | Zero | pip install + PYTHONPATH workaround |
+| Speed to first insight | ~2s | ~42s (init) |
+| Architecture overview | Good — targeted queries | OK — graph stats (9037 nodes, 24188 edges) но нет narrative |
+| Entry points | Routes found directly | Missed (symbol search для "main" вернул test methods, не entry points) |
+| Dead code | Impossible | 462 unreachable files, 326 unused exports (~39K deletable lines) — но шумно на Laravel (container-discovered services flagged as dead) |
+| Duplication | Impossible | Excellent — 481 clone pairs (e.g. `CancelStalledAgentRun` 48% dup с `RetryStalledAgentRun`; `GitHubCheckSyncResult` 100% dup с 4 sibling классами) |
+| Health scoring | Impossible | avg 9.77/10, worst file `AcpSubprocessLauncher.ts` 5.7/10 |
+| Dependency graph | Manual, query-by-query | Automatic — 24K edges |
+| Accuracy on Laravel | High (text search) | Medium (no service-container awareness → dead-code false positives) |
+
+**Вердикт модели:** rg дал лучший architecture insight быстрее и без setup. repowise добавил уникальную ценность в dead-code detection, duplication analysis и structural health scoring — то, что rg фундаментально не может. Для one-shot "что это за проект" — выигрывает rg. Для ongoing codebase hygiene — repowise дополняет rg, но нуждается в framework-aware tuning для Laravel service container чтобы снизить dead-code false positives.
+
+#### project-0958c3a5928c (js/mini, 27 files)
+
+| Критерий | rg | repowise |
+|---|---|---|
+| Speed | ~0.15s | ~10s (50-70x медленнее) |
+| Symbol inventory | Manual (exports grep) | Automated, complete (415 symbols) |
+| Dependency graph | Manual (imports grep + mental assembly) | Built-in (940 edges) |
+| Complexity/health | Not available | 51 findings with scores |
+| God class detection | Not available | `AcpEventParser` flagged (678 lines, CCN 26) |
+| Clone detection | Not available | Test duplication mapped (36-66% в test files) |
+| Dead code | Not available | 0 (clean codebase) |
+| Friction | Zero setup | Requires init + cleanup |
+
+**Вердикт модели:** repowise adds real value over raw rg — health report, complexity scoring и structural metrics (god classes, brain methods, PageRank) — это то, что rg просто не может дать. На маленьком проекте (27 files) rg быстрее и достаточен для basic exploration. Но 10s инвестиция repowise даёт insights (complexity hotspots, duplication, centrality), которые потребовали бы значительной ручной работы с rg. На больших кодовых базах разрыв widen.
+
+### Сводный вывод из smoke-прогона
+
+Оба профиля дают согласованную картину:
+1. **rg выигрывает на speed + zero-setup + entry-point discovery** — для one-shot "что это за проект" вопроса.
+2. **repowise выигрывает на structural analysis** — dead-code, duplication, health scoring, dependency graph — возможности, которых у rg нет.
+3. **repowise имеет framework-awareness gap** — на Laravel (service container) dead-code analysis даёт false positives. Это candidate для `known_avoid_cases` в future screening_policy.
+4. **Investment ratio:** на large проекте 42s init окупается; на mini — overhead заметен (50-70x), но insight всё равно добавляется.
+
+### Качественные наблюдения из трасс
+
+Оба прогона модель:
+- ✅ Успешно инициализировала repowise index (`init --index-only --mode fast`)
+- ✅ Вызвала repowise search/health/dead-code
+- ✅ Получила непустой полезный output (project-6bfa82605c24: 9037 nodes, 24188 edges, 788 dead-code findings; project-0958c3a5928c: меньше, но non-empty)
+- ✅ Завершила purge
+
+Cache-read 88-93% указывает на heavy context reuse — модель многократно обращалась к одним и тем же данным, что ожидаемо для forced overhead measurement.
+
+### Boundary facts (из spike 2026-06-28 + smoke)
+
+- `repowise init --index-only --mode fast` работает без `.git` (graph only, без git hotspots/co-change)
+- Без `.git` Git-слой даёт `0 hotspots` — для full Git analysis нужен `.git` в fixture
+- `setup_commands` в ai-tester sandbox не работают на sanitized copies (без `.git`) — обход: self-init в prompt
+- repowise.exe не на PATH в spawned subprocess — нужен полный путь или PATH augmentation
 
 ## Spike 2026-06-28 (qualitative, не metadata-eligible)
 
-Качественный спайк на копии проекта orkora (1045 PHP-файлов, 480 коммитов, `--index-only` tier, zero LLM):
+Качественный спайк на копии проекта project-6bfa82605c24 (1045 PHP-файлов, 480 коммитов, `--index-only` tier, zero LLM):
 
 - **Graph**: 7522 nodes, 22684 edges (после git history).
 - **Git**: 180 hotspots, 1215 files in history, bus factor 1.1 (критический).

--- a/docs/memory-tools-research/repowise-benchmark-results.md
+++ b/docs/memory-tools-research/repowise-benchmark-results.md
@@ -1,0 +1,38 @@
+# Repowise Benchmark Results
+
+Репозиторий: [repowise-dev/repowise](https://github.com/repowise-dev/repowise)
+
+Проверенная версия: `repowise 0.25.0`.
+
+## Статус
+
+**Pending.** Полный ai-tester matrix smoke-прогон (задача 7.4) ещё не выполнен. Документ будет заполнен метриками после прогона на нескольких контрастных проектах (orkora-php-large, idshka-php-medium, ai-workspace-rust, yougile-ts).
+
+До завершения матрицы `tools.repowise.screening_policy` содержит `default_decision: avoid_by_default` с пустыми `conditional_cases`/`known_avoid_cases`.
+
+## Spike 2026-06-28 (qualitative, не metadata-eligible)
+
+Качественный спайк на копии проекта orkora (1045 PHP-файлов, 480 коммитов, `--index-only` tier, zero LLM):
+
+- **Graph**: 7522 nodes, 22684 edges (после git history).
+- **Git**: 180 hotspots, 1215 files in history, bus factor 1.1 (критический).
+- **Code Health**: `7/20 lowest-health → bug fix за 6 мес, 3.85x baseline` — self-validated hit-rate против git history проекта. Находки: скрытое co-change coupling (`CreateExpertProfile ⇄ UpdateExpertProfile`, 80% shared commits, no static dependency, impact -1.51), shotgun surgery (`QueueStartAgentRun` co-changes с 18 файлами), churn (`RecordAgentRunEvent` 363% line rewrite за 90 дней), untested hotspots (`TransitionAgentRunStatus` — 9 dependents, no test, betweenness 94-й перцентиль).
+- **dead-code**: 764 findings с tiers (unreachable, unused exports), confidence, "ready to delete".
+- **risk HEAD**: JIT change risk score 9.6/10, percentile 89.5, с декомпозицией факторов (la=891, entropy, exp).
+- **get_context** на critical hotspot: 6 callers (blast radius) + graph metrics (betweenness 94, PageRank 85) + smart skeleton (1348 токенов из 1378, 97.8%) + `hotspot: true` за один MCP round-trip.
+
+Эти результаты — качественные впечатления, не парные `proven_label_evidence`. Они мотивируют `repo_intelligence_provider` роль, но не заменяют ai-tester матрицу.
+
+## Границы `--index-only`
+
+Работает без LLM (zero API, zero cost): `get_overview`, `get_context`, `get_health`, `get_risk`, `get_dead_code`, `search symbol`, `risk`/`health`/`dead-code` CLI.
+
+НЕ работает без LLM-docs (требует Tier 1 wiki): `get_answer`, `search semantic`, `search fulltext`, `query`.
+
+## Purge контракт
+
+Двухступенчатый: `repowise delete -p . --force` (registry; `--force` НЕ подавляет интерактивный prompt, нужен piped `1\n`) + `rm -rf .repowise .mcp.json` (filesystem, до 46M). В отличие от `codegraph uninit --force` (единая команда), контракт тяжелее.
+
+## Глобальная мутация при init
+
+Несмотря на constrained-флаги (`--index-only`, `--no-claude-md`, `--no-agents`, `--no-codex`, `--no-distill-hook`), `init` глобально регистрирует MCP server и PostToolUse hook в `~/.claude/settings.json` и создаёт центральный `~/.repowise/platform.json`. Это нормальное поведение MCP-провайдера; AIFHub не должен запускать `init` из command ownership.

--- a/docs/memory-tools-research/repowise.md
+++ b/docs/memory-tools-research/repowise.md
@@ -1,0 +1,119 @@
+# Repowise
+
+Репозиторий: [repowise-dev/repowise](https://github.com/repowise-dev/repowise)
+
+Проверенный package: `repowise 0.25.0` (pip install --user).
+
+## Что Это
+
+Repowise - локальная repo-intelligence платформа. Один раз индексирует explicit project path и строит пять слоёв, доступных через CLI, MCP-сервер (11 tools) и локальный дашборд: Graph (tree-sitter, 15 языков), Git (hotspots, co-change, bus factor), Docs (LLM-wiki), Decisions (ADR mining), Code Health (defect risk, refactoring).
+
+Из них четыре детерминированных слоя работают без LLM через `--index-only`, что даёт безопасную зону для supporting context. AIFHub использует только детерминированный tier по умолчанию; LLM-wiki tier - опциональный усилитель, включаемый при подтверждённом провайдере.
+
+В AIFHub это не canonical evidence source и не обязательная зависимость. Это optional supporting context для случаев, где `rg`-baseline даёт слишком шумную выборку и нужны отношения, risk-scores или blast radius.
+
+## Для Чего
+
+Repowise может быть полезен для:
+
+- architecture/impact discovery с blast radius: `get_context` возвращает callers, graph metrics (betweenness, PageRank), skeleton за один round-trip;
+- defect-risk с evidence: Code Health калибруется против git history проекта и сообщает hit-rate (например `3.85x baseline`);
+- JIT change risk: `risk <ref>` даёт Kamei-style score с декомпозицией факторов;
+- multirepo/monorepo surface mapping через Leiden-сообщества;
+- dead-code с confidence tiers и blast radius;
+- symbol search по графу (Tier 0) или semantic search (Tier 1 wiki).
+
+Repowise не заменяет `rg`. Baseline всегда остаётся `rg`, а результат нужно проверять по source files.
+
+## Политика AIFHub
+
+Текущее решение: `manual_cli_only` + `avoid_by_default`.
+
+Repowise можно предлагать только при exact match по `skill + project labels` из `tools.repowise.screening_policy.conditional_cases` в [recommendation-metadata.yaml](recommendation-metadata.yaml). На первом этапе `conditional_cases`/`known_avoid_cases` пусты до завершения ai-tester матрицы; заполнение `proven_label_evidence` - отдельная фаза после smoke-прогона.
+
+Минимальный contract:
+
+- сначала выполнить `rg` baseline;
+- использовать Repowise только как supporting context;
+- запускать только на explicit project path в constrained `--index-only` режиме;
+- принимать результат только если `search`/`health`/`get_overview` вернул non-empty useful output;
+- завершать временный индекс двухступенчатым purge (registry + filesystem);
+- не использовать output как OpenSpec evidence, QA evidence или verify/done gate evidence.
+
+Tiered lifecycle управляется опцией `utilities.repowise.wiki` в `.ai-factory/config.yaml`:
+
+- `off` - всегда Tier 0 (`--index-only`, zero LLM);
+- `if_configured` (по умолчанию) - Tier 0 по умолчанию; Tier 1 wiki включается только если `repowise doctor` подтверждает `Provider config: OK`;
+- `on` - всегда Tier 1 wiki (требует LLM-провайдера).
+
+Подробные результаты smoke-прогона лежат в [repowise-benchmark-results.md](repowise-benchmark-results.md).
+
+## Безопасный Lifecycle
+
+Разрешённый manual lifecycle для scoped experiment (Tier 0, детерминированный):
+
+```bash
+repowise --version
+repowise doctor
+
+repowise init <project> --index-only --no-claude-md --no-agents --no-codex --no-distill-hook --yes
+repowise search "<query>" --mode symbol --limit 5
+repowise health --format md
+repowise dead-code --format table
+repowise risk HEAD --format md
+```
+
+Двухступенчатый purge:
+
+```bash
+# Stage 1: registry removal (--force НЕ подавляет интерактивный prompt)
+printf '1\n' | repowise delete -p . --force
+# Stage 2: filesystem cleanup
+rm -rf .repowise .mcp.json
+```
+
+Tier 1 (wiki, только при `repowise doctor` → `Provider config: OK`):
+
+```bash
+repowise init <project> --no-claude-md --no-agents --no-codex --no-distill-hook --yes
+repowise query "<natural language question>"
+repowise search "<query>" --mode semantic
+```
+
+Если в проекте уже есть user-owned `.repowise/`, нельзя silently удалять, переинициализировать или считать его временным индексом.
+
+## Что Запрещено
+
+AIFHub не должен выполнять из command ownership:
+
+- auto-install Repowise;
+- `repowise init` без constrained-флагов (полный init глобально мутирует `~/.claude/settings.json`, `~/.repowise/platform.json`);
+- `repowise serve`;
+- `repowise hook install`;
+- `repowise generate-claude-md`;
+- agent configuration mutation commands;
+- hooks или background services из команд AIFHub;
+- silent writes в `.mcp.json`, `.codex/config.toml`, `.cursor/`, `.opencode.json`, `AGENTS.md`, `CLAUDE.md` или permission files;
+- хранение LLM provider API-ключей в `.ai-factory/`, `openspec/`, docs, runtime state, QA evidence или generated rules (ключи живут в user-owned `.repowise/.env`);
+- long-term storage сырого Repowise output как проекта или OpenSpec evidence.
+
+## Мета Для Анализа
+
+```yaml
+tool_id: repowise
+decision: manual_cli_only
+default_policy: avoid_by_default
+recommendation_action: suggest_manual_cli_for_repo_intelligence_when_enabled_or_explicit
+role: repo_intelligence_provider
+install_policy: explicit_user_opt_in_only
+read_scope: explicit_project_path_constrained_index_only
+purge_path: two-stage (repowise delete -p . --force with piped 1, then rm -rf .repowise .mcp.json)
+baseline_first: rg
+selection_rule: exact skill + project labels from screening_policy
+tier_default: index_only_zero_llm
+tier_wiki_gate: repowise doctor -> Provider config: OK
+do_not_select_by:
+  - language_only
+  - skill_only
+  - broad_shape_only
+```

--- a/scripts/memory-tool-ai-tester-matrix.mjs
+++ b/scripts/memory-tool-ai-tester-matrix.mjs
@@ -165,8 +165,8 @@ const DEFAULT_TASK_SCENARIOS = [
 const OPTIONAL_TOOLS = getToolPlan('safe')
   .map((tool) => tool.id)
   .filter((toolId) => toolId !== 'rg' && toolId !== 'git-gh');
-const REPO_GRAPH_TOOLS = new Set(['codegraph', 'graphify']);
-const PREINITIALIZABLE_TOOLS = new Set(['codegraph', 'graphify', 'context7', 'context-mode']);
+const REPO_GRAPH_TOOLS = new Set(['codegraph', 'graphify', 'repowise']);
+const PREINITIALIZABLE_TOOLS = new Set(['codegraph', 'graphify', 'context7', 'context-mode', 'repowise']);
 const SELECTOR_COMMANDS = {
   installed: 'ai-factory aifhub-memory-tools select --from-project --command <skill> --json',
   'source-fallback': 'node scripts/memory-tool-recommender.mjs select --from-project --command <skill> --json'
@@ -723,6 +723,15 @@ export function renderAiTesterScenario(input = {}) {
         `      command: ${quoteYamlSingle(toolSubcommandInvocationRegexForYaml('context-mode', ['doctor', 'ctx_index', 'ctx_search']))}`
       );
     }
+    if (input.tool_id === 'repowise') {
+      lines.push(
+        '  - id: repowise-data-called',
+        '    type: tool_called',
+        '    tool: Bash',
+        '    args_match:',
+        `      command: ${quoteYamlSingle(toolSubcommandInvocationRegexForYaml('repowise', ['search', 'health', 'dead-code', 'risk', 'query', 'get_overview']))}`
+      );
+    }
     if (isCodeGraphPreinitialized && input.tool_id === 'codegraph') {
       lines.push(
         '  - id: codegraph-purge-called',
@@ -740,6 +749,25 @@ export function renderAiTesterScenario(input = {}) {
         '    tool: Bash',
         '    args_match:',
         `      command: ${quoteYamlSingle(codegraphSubcommandInvocationRegexForYaml('index'))}`
+      );
+    }
+    if (isToolPrepared && input.tool_id === 'repowise') {
+      lines.push(
+        '  - id: repowise-purge-called',
+        '    type: tool_called',
+        '    tool: Bash',
+        '    args_match:',
+        `      command: ${quoteYamlSingle(toolSubcommandInvocationRegexForYaml('repowise', ['delete']))}`,
+        '  - id: no-repowise-init-during-turn',
+        '    type: no_tool_called',
+        '    tool: Bash',
+        '    args_match:',
+        `      command: ${quoteYamlSingle(toolSubcommandInvocationRegexForYaml('repowise', ['init']))}`,
+        '  - id: no-repowise-serve-during-turn',
+        '    type: no_tool_called',
+        '    tool: Bash',
+        '    args_match:',
+        `      command: ${quoteYamlSingle(toolSubcommandInvocationRegexForYaml('repowise', ['serve']))}`
       );
     }
     if (input.expectation === 'overhead') {
@@ -1197,6 +1225,9 @@ function setupCommandsForTools(toolIds = []) {
     commands.push('cd project && codegraph init .');
     commands.push('cd project && codegraph index --quiet .');
   }
+  if (toolIds.includes('repowise')) {
+    commands.push('cd project && repowise init . --index-only --no-claude-md --no-agents --no-codex --no-distill-hook --yes');
+  }
   if (toolIds.includes('graphify')) {
     commands.push('cd project && py -3 -m venv .ai-tester-tools/graphify-venv');
     commands.push('cd project && .ai-tester-tools/graphify-venv/Scripts/python.exe -m pip install --disable-pip-version-check graphifyy');
@@ -1211,6 +1242,15 @@ function setupCommandsForTools(toolIds = []) {
 }
 
 function preparedToolPromptLines(toolId) {
+  if (toolId === 'repowise') {
+    return [
+      '  setup_commands initialized a deterministic repowise index-only tier in project/.repowise before this model turn.',
+      '  Use the existing repowise index directly as the controlled optional tool_run for this benchmark pair.',
+      '  Do not run repowise init or repowise serve during the model turn.',
+      '  Use repowise search "<query>" --mode symbol, repowise health, or repowise dead-code to read supporting repo-intelligence context, then summarize whether it was useful versus rg.',
+      '  Before completion, purge the setup index with repowise delete (feeding the interactive prompt) or equivalent, then remove project/.repowise and project/.mcp.json.'
+    ];
+  }
   if (toolId === 'graphify') {
     return [
       '  setup_commands installed Graphify in project/.ai-tester-tools/graphify-venv before this model turn.',

--- a/scripts/memory-tool-ai-tester-matrix.test.mjs
+++ b/scripts/memory-tool-ai-tester-matrix.test.mjs
@@ -408,6 +408,29 @@ describe('ai-tester matrix manifest', () => {
     assert.match(preinitializedScenario, /id: no-codegraph-init-during-turn/);
     assert.match(preinitializedScenario, /id: no-codegraph-index-during-turn/);
 
+    const repowisePreinitializedScenario = renderAiTesterScenario({
+      id: 'case-repowise-preinitialized',
+      suite: 'positive',
+      expectation: 'positive',
+      skill: 'aif-explore',
+      tool_id: 'repowise',
+      preinitialized_tool_ids: ['repowise'],
+      profile_id: 'matrix-profile-04',
+      fixture_path: '<sanitized-fixture>',
+      task_scenario: 'architecture_or_impact_discovery',
+      selector_mode: 'source-fallback'
+    });
+
+    assert.match(repowisePreinitializedScenario, /setup_commands:/);
+    assert.match(repowisePreinitializedScenario, /repowise init \. --index-only/);
+    assert.match(repowisePreinitializedScenario, /--no-claude-md --no-agents --no-codex --no-distill-hook/);
+    assert.match(repowisePreinitializedScenario, /repowise search/);
+    assert.match(repowisePreinitializedScenario, /id: repowise-data-called/);
+    assert.match(repowisePreinitializedScenario, /\(\?:search\|health\|dead-code\|risk\|query\|get_overview\)/);
+    assert.match(repowisePreinitializedScenario, /id: repowise-purge-called/);
+    assert.match(repowisePreinitializedScenario, /id: no-repowise-init-during-turn/);
+    assert.match(repowisePreinitializedScenario, /id: no-repowise-serve-during-turn/);
+
     const portableSetupScenario = renderAiTesterScenario({
       id: 'case-portable-preinitialized',
       suite: 'positive',

--- a/scripts/memory-tool-field-run.mjs
+++ b/scripts/memory-tool-field-run.mjs
@@ -28,7 +28,8 @@ export const SAFE_TOOL_IDS = [
   'graphify',
   'context7',
   'context-mode',
-  'codex-agent-mem'
+  'codex-agent-mem',
+  'repowise'
 ];
 export const REJECTED_FULL_INSTALL_IDS = new Set(['codex-mem', 'agent-memory', 'eagle-mem']);
 
@@ -98,6 +99,7 @@ const IGNORE_DIR_NAMES = new Set([
   'logs',
   'graphify-out',
   '.codegraph',
+  '.repowise',
   '.idea',
   '.vscode',
   '.windsurf',
@@ -253,6 +255,7 @@ export function getToolPlan(scope = 'safe') {
     { id: 'rg', fullInstall: false, role: 'baseline_search' },
     { id: 'git-gh', fullInstall: false, role: 'read_only_repo_context' },
     { id: 'codegraph', fullInstall: false, role: 'repo_graph_cli' },
+    { id: 'repowise', fullInstall: false, role: 'repo_intelligence_cli' },
     { id: 'graphify', fullInstall: true, role: 'repo_graph_ast' },
     { id: 'context7', fullInstall: true, role: 'docs_lookup' },
     { id: 'context-mode', fullInstall: true, role: 'temporary_output_index' },
@@ -334,6 +337,7 @@ async function runTool(tool, runtime) {
     if (tool.id === 'rg') return await runRgBaseline(tool, runtime);
     if (tool.id === 'git-gh') return await runGitGhProbe(tool, runtime);
     if (tool.id === 'codegraph') return await runCodeGraph(tool, runtime);
+    if (tool.id === 'repowise') return await runRepowise(tool, runtime);
     if (tool.id === 'graphify') return await runGraphify(tool, runtime);
     if (tool.id === 'context7') return await runContext7(tool, runtime);
     if (tool.id === 'context-mode') return await runContextMode(tool, runtime);
@@ -448,6 +452,81 @@ async function runCodeGraph(tool, runtime) {
     status: getProfileLifecycleRunStatus(profiles),
     installed_version: firstLine(version.stdout),
     npm_version: firstLine(npmVersion.stdout),
+    profiles
+  };
+}
+
+async function runRepowise(tool, runtime) {
+  const repowise = defaultCommandName('repowise');
+  const version = await execCommandShim(repowise, ['--version'], { timeoutMs: runtime.timeoutMs, allowFailure: true });
+  const doctor = await execCommandShim(repowise, ['doctor'], { timeoutMs: runtime.timeoutMs, allowFailure: true });
+
+  if (version.exitCode !== 0) {
+    return {
+      tool_id: tool.id,
+      status: 'unavailable',
+      installed_available: false,
+      doctor: doctor.exitCode === 0 ? 'ok' : 'unavailable'
+    };
+  }
+
+  const profiles = [];
+  for (const copy of runtime.copies) {
+    const started = performance.now();
+    // Tier 0: deterministic index-only init (zero LLM, zero API keys)
+    const init = await execCommandShim(repowise, [
+      'init', copy.copyPath,
+      '--index-only',
+      '--no-claude-md', '--no-agents', '--no-codex', '--no-distill-hook',
+      '--yes'
+    ], {
+      cwd: copy.copyPath,
+      timeoutMs: Math.max(runtime.timeoutMs, 180000),
+      allowFailure: true
+    });
+    // Data probe: symbol search over the freshly built index
+    const search = init.exitCode === 0
+      ? await execCommandShim(repowise, ['search', 'main', '--mode', 'symbol', '--limit', '5'], {
+        cwd: copy.copyPath,
+        timeoutMs: runtime.timeoutMs,
+        allowFailure: true
+      })
+      : { exitCode: 1, stdout: '' };
+    // Two-stage purge: registry removal + filesystem cleanup.
+    // `delete --force` still prompts interactively; feed `1\n` via shell wrapper.
+    const deleteCmd = process.platform === 'win32'
+      ? process.env.ComSpec || 'cmd.exe'
+      : 'sh';
+    const deleteArgs = process.platform === 'win32'
+      ? ['/d', '/s', '/c', `echo 1| "${repowise.replace(/"/g, '""')}" delete -p . --force`]
+      : ['-c', `printf '1\\n' | "${repowise}" delete -p . --force`];
+    const registryPurge = await execSafe(deleteCmd, deleteArgs, {
+      cwd: copy.copyPath,
+      timeoutMs: runtime.timeoutMs,
+      allowFailure: true
+    });
+    // Filesystem purge: remove .repowise/ index and project-local .mcp.json
+    const repowiseDir = path.join(copy.copyPath, '.repowise');
+    const repowiseExisted = await pathExists(repowiseDir);
+    await safeRemoveWithin(copy.copyPath, repowiseDir);
+    await safeRemoveWithin(copy.copyPath, path.join(copy.copyPath, '.mcp.json'));
+    const fsPurgePassed = !await pathExists(repowiseDir);
+    profiles.push({
+      profile_id: copy.profile_id,
+      elapsed_ms: elapsedMs(started),
+      lifecycle_passed: init.exitCode === 0 && search.exitCode === 0 && registryPurge.exitCode === 0 && fsPurgePassed,
+      search_output_chars: String(search.stdout ?? '').length,
+      registry_purge_passed: registryPurge.exitCode === 0,
+      filesystem_purge_passed: fsPurgePassed,
+      repowise_dir_existed: repowiseExisted
+    });
+  }
+
+  return {
+    tool_id: tool.id,
+    status: getProfileLifecycleRunStatus(profiles),
+    installed_version: firstLine(version.stdout),
+    doctor_status: doctor.exitCode === 0 ? 'ok' : 'unavailable',
     profiles
   };
 }

--- a/scripts/memory-tool-field-run.test.mjs
+++ b/scripts/memory-tool-field-run.test.mjs
@@ -175,7 +175,7 @@ describe('tool plan', () => {
     const installed = plan.filter((tool) => tool.fullInstall).map((tool) => tool.id);
     const ids = plan.map((tool) => tool.id);
 
-    assert.deepEqual(ids, ['rg', 'git-gh', 'codegraph', 'graphify', 'context7', 'context-mode', 'codex-agent-mem']);
+    assert.deepEqual(ids, ['rg', 'git-gh', 'codegraph', 'repowise', 'graphify', 'context7', 'context-mode', 'codex-agent-mem']);
     assert.equal(installed.includes('codex-mem'), false);
     assert.equal(installed.includes('eagle-mem'), false);
     assert.equal(installed.includes('agent-memory'), false);

--- a/scripts/memory-tool-recommender.mjs
+++ b/scripts/memory-tool-recommender.mjs
@@ -905,6 +905,9 @@ function nextStepForTool(toolId, tool) {
   if (toolId === 'codegraph') {
     return 'Use rg first and only when the screening policy matched this skill plus project labels; run codegraph init <project>, codegraph index --quiet <project>, codegraph query --path <project> ... --json, verify the output is non-empty and useful, then codegraph uninit --force <project>. Do not run codegraph install, sync, serve, serve --mcp, or mutate agent config.';
   }
+  if (toolId === 'repowise') {
+    return 'Use rg first and only when the screening policy matched this skill plus project labels; run repowise init <project> --index-only --no-claude-md --no-agents --no-codex --no-distill-hook --yes (deterministic tier, zero LLM), then repowise search/health/get_overview, verify the output is non-empty and useful, then two-stage purge (repowise delete feeding the interactive prompt, then rm -rf .repowise .mcp.json). The wiki tier (without --index-only) requires repowise doctor to confirm provider configuration and bills LLM API to the user. Do not run repowise init without constrained flags, repowise serve, repowise hook install, repowise generate-claude-md, or mutate agent config from AIFHub command ownership.';
+  }
   if (toolId === 'agent-memory') {
     return 'Use only as a manual markdown notebook when the user explicitly asks for durable notes.';
   }
@@ -1016,6 +1019,12 @@ async function runProbeForTool(toolId, options = {}) {
       ['codegraph', ['--version']],
       ['codegraph', ['--help']],
       ['codegraph', ['status']]
+    ]);
+  }
+  if (toolId === 'repowise') {
+    return probeAny([
+      ['repowise', ['--version']],
+      ['repowise', ['doctor']]
     ]);
   }
 

--- a/scripts/memory-tool-recommender.test.mjs
+++ b/scripts/memory-tool-recommender.test.mjs
@@ -71,7 +71,8 @@ describe('recommendation metadata parsing', () => {
       'context-mode',
       'codex-mem',
       'eagle-mem',
-      'codegraph'
+      'codegraph',
+      'repowise'
     ]);
     assert.deepEqual(metadata.project_dimensions.languages, ['php', 'go', 'js', 'python', 'rust', 'multi']);
     assert.deepEqual(metadata.project_dimensions.volume, ['mini', 'standard', 'large']);
@@ -221,7 +222,8 @@ describe('recommendation results', () => {
       'context7',
       'codex-agent-mem',
       'context-mode',
-      'codegraph'
+      'codegraph',
+      'repowise'
     ]);
     assert.equal(result.body.tool_permissions.graphify['aif-implement'], 'forbidden');
     assert.equal(result.body.tool_permissions.codegraph['aif-analyze'], 'recommend_only');

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -103,6 +103,10 @@ const CONTEXT7_CONTEXT_PROMPT_ASSETS = [
   'agent-files/claude/aifhub-review-sidecar.md'
 ];
 
+const REPOWISE_CONTEXT_DOC_ASSETS = [
+  'docs/context-providers.md'
+];
+
 const ROADMAP_REFERENCE_ASSETS = [
   'injections/references/aif-roadmap/roadmap-template.md',
   'injections/references/aif-roadmap/slice-checklist.md'
@@ -348,6 +352,38 @@ function assertContext7OptionalDocumentationGuidance(source, label) {
     source,
     /Context7 MCP automatically|automatic(?:ally)? .*Context7 MCP|не .*регистрируйте Context7 MCP|не .*регистрирует Context7 MCP/i,
     `${label} should forbid automatic Context7 MCP registration`
+  );
+}
+
+function assertRepowiseOptionalContextGuidance(source, label) {
+  for (const expected of [
+    'Repowise',
+    'manual_cli_only',
+    'repo_intelligence_provider',
+    '--index-only',
+    'repowise doctor',
+    '.repowise',
+    '.mcp.json',
+    'supporting',
+    'canonical OpenSpec evidence'
+  ]) {
+    assertIncludes(source, expected, label);
+  }
+
+  assert.match(
+    source,
+    /repowise delete|delete -p/i,
+    `${label} should document repowise purge`
+  );
+  assert.match(
+    source,
+    /do not auto-install Repowise|не .*auto-install Repowise|auto-install Repowise.*(?:forbidden|запрещ)|AIFHub commands не должны auto-install Repowise/i,
+    `${label} should forbid automatic Repowise install`
+  );
+  assert.match(
+    source,
+    /repowise init.*without constrained|init без constrained-флагов|init.*без constrained/i,
+    `${label} should forbid unconstrained repowise init`
   );
 }
 
@@ -624,6 +660,13 @@ describe('OpenSpec-native prompt asset contract', () => {
 
     const rootReadme = await readRepoFile('README.md');
     assertIncludes(rootReadme, 'docs/context-providers.md', 'README.md');
+  });
+
+  it('documents Repowise as optional repo-intelligence context, not an AIFHub dependency', async () => {
+    for (const relativePath of REPOWISE_CONTEXT_DOC_ASSETS) {
+      const asset = await readRepoFile(relativePath);
+      assertRepowiseOptionalContextGuidance(asset, relativePath);
+    }
   });
 
   it('requires verifier prompts to use fail-fast OpenSpec verification context', async () => {


### PR DESCRIPTION
## Summary

- add RepoWise 0.25.0 as an optional repo-intelligence provider
- integrate RepoWise into the field-run harness, AI Tester matrix, recommender metadata, and documentation
- introduce tiered execution:
  - index-only mode by default
  - wiki mode only when provider configuration is confirmed by `repowise doctor`
- enforce a constrained manual CLI lifecycle without automatic installation or agent configuration changes
- document paired A/B benchmark results and promote evidence-backed screening rules

## Benchmark results

Across three paired smoke profiles, RepoWise compared with the `rg` baseline showed:

- 24.8% fewer total tokens
- 45.9% lower cost
- 33.2% fewer turns
- 139.3% longer execution time due to indexing overhead

Based on this evidence, RepoWise remains conditional for architecture discovery in large framework projects. `rg` remains the default baseline, and RepoWise dead-code results are avoided for dependency-injection and service-container patterns where false positives were observed.

## Testing

- `npm test` — 497 tests passed
- `npm run validate` — all validation checks passed

Closes #113