### PR TITLE
Add optional project glossary context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AI Factory UX + OpenSpec artifact protocol
 - Publishes namespaced Codex CLI and Claude agent files through the extension manifest for explicit user or orchestrator invocation.
 - Publishes an optional `aifhub` MCP server whose settings are rendered by AI Factory per runtime.
 - Documents upstream project-context utilities such as `/aif-architecture`, `/aif-roadmap`, `/aif-docs`, `/aif-qa`, `/aif-archive`, and `/aif-distillation` with AIFHub write-boundary guardrails.
+- Supports an optional protocol-neutral project glossary at `paths.context` (`CONTEXT.md` by default) for consistent prose terminology.
 - Does not install OpenSpec skills or slash commands.
 
 ## Quick Start
@@ -107,6 +108,10 @@ OpenSpec validation overlay:
 A dirty workspace is blocking by default before `/aif-done`. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` when the current dirty state should be recorded in final QA evidence before archive.
 
 It does not replace `/aif-commit`. After `/aif-done`, run `/aif-commit` or your normal git workflow to commit implementation changes, OpenSpec archive/spec changes, QA evidence, and final summaries.
+
+### Optional Project Glossary
+
+`/aif-analyze` can create or patch an optional `paths.context` glossary after explicit opt-in. Other commands consume it read-only for prose terminology; source/tests, OpenSpec requirements, rules, architecture decisions, identifiers, and QA facts remain authoritative. Missing `CONTEXT.md` never blocks a workflow. See [Context Loading Policy](docs/context-loading-policy.md) and [ADR 0002](docs/adr/0002-optional-project-context-glossary.md).
 
 ### AI Factory 2.17 Reviewed Baseline
 
@@ -337,13 +342,14 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Usage](docs/usage.md) | Full command flow, read/write boundaries, upstream project-context utilities, examples, and troubleshooting |
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
-| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
+| [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
 | [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |
 | [Active Change Resolver](docs/active-change-resolver.md) | Active change selection and runtime paths |
 | [ADR 0001](docs/adr/0001-openspec-native-artifact-protocol.md) | v1 artifact ownership decision |
+| [ADR 0002: Optional Project Glossary](docs/adr/0002-optional-project-context-glossary.md) | Configurable `CONTEXT.md`, lexical authority, and deferred OKF |
 | [AIFHub MCP](docs/aifhub-mcp.md) | Optional MCP server tools, runtime-specific settings shapes, and AI Factory 2.16+ Universal / Other rendering |
 | [Codex Agents](docs/codex-agents.md) | Namespaced Codex CLI agent files |
 | [Claude Agents](docs/claude-agents.md) | Namespaced Claude agent files |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 2. [Usage](usage.md) - полный command flow, `/aif-mode` switching and sync, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa` и `/aif-qa-check` utility boundaries, rules/review/security gates, verification/fix/finalization tail, AI Factory 2.17 baseline notes, regression-first fix flow, upstream `/aif-archive` legacy cleanup boundary, AI Factory 2.13+ `/aif-commit` Commit Plan ownership, upstream `/aif-distillation` utility boundaries, commit/evolve handoff, OAuth example, troubleshooting и smoke checks.
 3. [Context Providers](context-providers.md) - optional Graphify context, CodeGraph manual CLI context, Context7 documentation provider guidance, reviewed-note paths, degraded behavior и user-owned setup boundaries.
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
-5. [Context Loading Policy](context-loading-policy.md) - consumer context, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
+5. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
 6. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 7. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 8. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
@@ -26,6 +26,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 10. [Active Change Resolver](active-change-resolver.md) - active change selection, runtime paths, current pointer behavior и ambiguity diagnostics.
 11. [Handoff Validation Profile](handoff-validation-profile.md) - read-only orchestration summary contract.
 12. [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) - v1 artifact ownership decision.
+13. [ADR 0002: Optional Project Glossary](adr/0002-optional-project-context-glossary.md) - protocol-neutral glossary ownership, lexical authority and deferred OKF decision.
 
 Остальные runtime-specific guides являются supporting references:
 
@@ -44,7 +45,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Usage](usage.md) | Полный OpenSpec-native command flow, optional Graphify/CodeGraph/Context7 guidance, upstream architecture/docs/QA utility boundaries, regression-first fix, QA-check boundary, gates, finalization tail, AI Factory 2.17 compatibility, parent-owned commit grouping, upstream archive/distillation utilities и examples |
 | [Context Providers](context-providers.md) | Optional Graphify context, CodeGraph manual CLI context и Context7 provider guidance, reviewed-note paths, degraded behavior, credential safety и user-owned setup boundaries |
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
-| [Context Loading Policy](context-loading-policy.md) | Runtime context, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
+| [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
 | [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
@@ -52,6 +53,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Active Change Resolver](active-change-resolver.md) | Active change selection и runtime paths |
 | [Handoff Validation Profile](handoff-validation-profile.md) | Read-only validation summary contract для Handoff orchestration |
 | [ADR 0001](adr/0001-openspec-native-artifact-protocol.md) | Canonical OpenSpec и AI Factory runtime state contract |
+| [ADR 0002: Optional Project Glossary](adr/0002-optional-project-context-glossary.md) | Configurable `CONTEXT.md`, `/aif-analyze` ownership, read-only consumers и deferred OKF |
 | [AIFHub MCP](aifhub-mcp.md) | Optional MCP server tools, runtime-specific config shapes и AI Factory 2.16+ Universal / Other `.mcp.json` rendering |
 | [Codex Agents](codex-agents.md) | Namespaced Codex subagents и invocation contract |
 | [Claude Agents](claude-agents.md) | Namespaced Claude subagents и install target |
@@ -114,6 +116,7 @@ npm test
 - [Active Change Resolver](active-change-resolver.md)
 - [Handoff Validation Profile](handoff-validation-profile.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)
+- [ADR 0002: Optional Project Glossary](adr/0002-optional-project-context-glossary.md)
 - [AIFHub MCP](aifhub-mcp.md)
 - [Research по Memory Tools](memory-tools-research/README.md)
 - [AI Tester Matrix Для Memory Tools](memory-tools-research/ai-tester-matrix.md)

--- a/docs/adr/0001-openspec-native-artifact-protocol.md
+++ b/docs/adr/0001-openspec-native-artifact-protocol.md
@@ -1,4 +1,4 @@
-[Previous Page](../active-change-resolver.md) | [Back to Documentation](../README.md)
+[Previous Page](../active-change-resolver.md) | [Back to Documentation](../README.md) | [Next Page](0002-optional-project-context-glossary.md)
 
 # ADR 0001: OpenSpec-native artifact protocol
 
@@ -152,3 +152,9 @@ Tradeoffs:
 - Legacy `.ai-factory/plans` consumers need migration or compatibility logic later.
 - Generated rules are operational only when the derived files are present and fresh; consumer migrations still need to preserve canonical OpenSpec precedence.
 - OpenSpec validate and archive-required done finalization remain unavailable until a compatible external CLI is present.
+
+## See Also
+
+- [Context Loading Policy](../context-loading-policy.md)
+- [OpenSpec Compatibility](../openspec-compatibility.md)
+- [ADR 0002: Optional Project Glossary](0002-optional-project-context-glossary.md)

--- a/docs/adr/0002-optional-project-context-glossary.md
+++ b/docs/adr/0002-optional-project-context-glossary.md
@@ -1,0 +1,46 @@
+[Previous Page](0001-openspec-native-artifact-protocol.md) | [Back to Documentation](../README.md)
+
+# ADR 0002: Optional project context glossary
+
+## Status
+
+Accepted
+
+## Context
+
+AIFHub project context already separates canonical OpenSpec requirements from AI Factory runtime and QA state, but projects lack a bounded source for preferred domain terminology. Issue #127 compared a simple Markdown glossary, Open Knowledge Format (OKF), and hybrid storage.
+
+The first useful producer/consumer path does not need a schema, parser, registry, or new lifecycle stage. It needs a small optional file whose absence cannot break existing projects.
+
+## Decision
+
+- Add `paths.context` as a protocol-neutral config key with configurable `CONTEXT.md` as its default.
+- Make `/aif-analyze` the only writer. Creation and patch updates require explicit opt-in and concrete source-grounded terms; empty placeholders are forbidden.
+- Treat all other skills, injections, and packaged agents as read-only consumers through the shared language/glossary policy.
+- Grant the glossary lexical authority for human-readable prose only. It cannot rename code/API identifiers or override source/tests, canonical OpenSpec requirements, project rules, accepted architecture decisions, or verifiable QA facts.
+- Treat missing and empty files as normal. Reject unsafe paths and skip unreadable files with bounded diagnostics that never disclose external paths or glossary contents.
+- Keep glossary contents out of generated rules, QA evidence, runtime traces, provider stores, validation gates, and completion gates.
+
+## Consequences
+
+Benefits:
+
+- Existing projects remain compatible without adding a file.
+- Projects can preserve stable terminology across commands without creating another canonical artifact.
+- Ownership and conflict precedence are explicit and testable.
+
+Tradeoffs:
+
+- The Markdown structure is guidance rather than a machine-validated schema.
+- Terminology drift is reported but never synchronized automatically.
+- `/aif-analyze` must preserve user-authored and unknown sections during updates.
+
+## Deferred OKF Criteria
+
+OKF remains deferred. Reconsider it only when a concrete producer/consumer use case needs machine-readable interchange, schema validation, cross-project knowledge relationships, or independent tooling. Any OKF implementation requires a separate OpenSpec change and ADR with explicit migration, security, size, and authority boundaries.
+
+## See Also
+
+- [Context Loading Policy](../context-loading-policy.md)
+- [Usage](../usage.md)
+- [ADR 0001](0001-openspec-native-artifact-protocol.md)

--- a/docs/context-loading-policy.md
+++ b/docs/context-loading-policy.md
@@ -47,6 +47,7 @@ Consumer commands load these project context files when present:
 - `.ai-factory/ARCHITECTURE.md`
 - `.ai-factory/RULES.md`
 - `.ai-factory/rules/base.md`
+- configured `paths.context` project glossary (`CONTEXT.md` by default), when present
 - configured area rules from `.ai-factory/config.yaml`
 
 Consumer commands must not use bridge files such as `AGENTS.md`, `CLAUDE.md`, `QWEN.md`, or `AIFACTORY.md` as substitutes for configured context paths.
@@ -74,6 +75,18 @@ They may also load derived/runtime artifacts:
 Generated rules and generated trace metadata are derived guidance only. If generated rules conflict with canonical OpenSpec artifacts, canonical OpenSpec artifacts win.
 
 Runner output from OpenSpec CLI commands is runtime guidance or evidence. It does not replace the canonical filesystem artifacts under `openspec/`.
+
+## Optional Project Glossary
+
+The project glossary is protocol-neutral Base Context for preferred terminology. `paths.context` configures a project-relative Markdown file and defaults to `CONTEXT.md`; mode switching preserves a custom value but never creates the file.
+
+- `/aif-analyze` is the only writer. It creates or patch-updates the glossary only after explicit opt-in, only with source-grounded terms, and preserves manual or unknown sections.
+- All other AIFHub skills, injections, and packaged agents are read-only consumers through `skills/shared/LANGUAGE-POLICY.md` and `skills/shared/PROJECT-GLOSSARY.md`.
+- A missing or empty glossary is a normal non-fatal state. An unsafe or unreadable path is skipped with one bounded diagnostic that does not expose external paths or glossary contents.
+- Glossary terms apply only to human-readable prose; code and API identifiers, commands, filenames, paths, schema fields, and public wire values stay unchanged.
+- Conflict precedence is: source/tests and verifiable QA facts; canonical OpenSpec requirements; project rules and accepted architecture decisions; project description/architecture context; glossary terminology.
+- Glossary contents are excluded from canonical OpenSpec authority, generated-rule inputs, QA evidence, runtime traces, provider stores, status/doctor checks, verification gates, and done readiness.
+- OKF remains deferred until a concrete producer/consumer use case justifies a separate OpenSpec change and ADR.
 
 ## Опциональные Context Providers
 
@@ -189,7 +202,7 @@ GitHub access is non-blocking. If `gh`, connector data, network access, authenti
 | Command | May write canonical OpenSpec artifacts | May write runtime or QA artifacts |
 |---|---|---|
 | `/aif-mode` | skeleton only; never manual `openspec/specs/**` mutations | mode reports, generated rules, optional migration/export outputs |
-| `/aif-analyze` | Optional `openspec/` skeleton only when configured | capability/config setup |
+| `/aif-analyze` | Optional `openspec/` skeleton only when configured | capability/config setup; optional glossary creation or patch-update only with explicit opt-in |
 | `/aif-architecture` | no | no |
 | `/aif-roadmap` | no | no |
 | `/aif-docs` | no | no |
@@ -350,3 +363,4 @@ If `.ai-factory/config.yaml` is missing or incomplete:
 - [OpenSpec Compatibility](openspec-compatibility.md)
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)
+- [ADR 0002: Optional Project Glossary](adr/0002-optional-project-context-glossary.md)

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -63,6 +63,7 @@ aifhub:
   artifactProtocol: ai-factory
 
 paths:
+  context: CONTEXT.md
   plans: .ai-factory/plans
   specs: .ai-factory/specs
   rules: .ai-factory/rules
@@ -122,6 +123,7 @@ aifhub:
       openspecStatus: true
 
 paths:
+  context: CONTEXT.md
   plans: openspec/changes
   specs: openspec/specs
   state: .ai-factory/state
@@ -136,6 +138,8 @@ utilities:
     activate: graphify install
     report_command: graphify .
 ```
+
+`paths.context` is protocol-neutral and defaults to `CONTEXT.md`. Both profiles render the default or preserve a custom project-relative value; neither profile requires, creates, validates, or imports the optional glossary file. `/aif-analyze` owns opt-in creation and patch updates, while all other commands are read-only consumers.
 
 `installSkills: false` задан намеренно. AIFHub Extension использует OpenSpec artifacts и `scripts/openspec-runner.mjs` как optional CLI adapter, а не OpenSpec-installed skills или slash commands.
 
@@ -427,3 +431,4 @@ AIFHub artifact contract validation is a separate read-only layer over the CLI a
 - [OpenSpec Artifact Validation](openspec-validation.md)
 - [Active Change Resolver](active-change-resolver.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)
+- [ADR 0002: Optional Project Glossary](adr/0002-optional-project-context-glossary.md)

--- a/docs/project-glossary-research/ai-tester-scenarios.json
+++ b/docs/project-glossary-research/ai-tester-scenarios.json
@@ -1,0 +1,70 @@
+{
+  "schema": "aifhub.project_glossary.ai_tester_scenario_catalog.v1",
+  "defaults": {
+    "runtime": "codex",
+    "model": "gpt-5.6-luna",
+    "reasoning": "low",
+    "repetitions": 2,
+    "conditions": [
+      "baseline_without_glossary",
+      "candidate_with_glossary"
+    ],
+    "max_turns": 10
+  },
+  "fixture": {
+    "id": "dispatch-observability-sanitized",
+    "config_path": ".ai-factory/config.yaml",
+    "context_path": "CONTEXT.md",
+    "sentinel": "GLOSSARY_SENTINEL_127_DO_NOT_COPY",
+    "source_files": {
+      "README.md": "# Dispatch Observatory\n\nThe service has a worker that accepts delivery jobs and retries them during a retry timeout. Operators need concise terminology for this flow.\n",
+      "docs/operations.md": "# Operations\n\nThe worker invokes `DispatchEngine` for each `DeliveryJob`. Recovery uses `POST /v1/jobs/:jobId/retry`. The current runbook informally calls the recovery period a retry timeout.\n",
+      "src/dispatch/DeliveryJob.ts": "export const RETRY_WINDOW_MS = 30000;\n\nexport class DeliveryJob {\n  constructor(readonly jobId: string) {}\n}\n\nexport class DispatchEngine {\n  retry(job: DeliveryJob): void {}\n}\n",
+      "bin/retry-help.txt": "Usage: dispatch retry --retry-window <milliseconds>\n",
+      "docs/authority.md": "# Authority facts\n\nExisting code and API identifiers are authoritative. This fixture defines no new requirement, rule, or architecture decision and does not authorize identifier renames.\n"
+    },
+    "synthetic_glossary": {
+      "canonical_terms": [
+        "Dispatch Relay",
+        "Recovery Window"
+      ],
+      "avoided_terms": [
+        "worker",
+        "retry timeout"
+      ],
+      "body": "# Project Glossary\n\n## Language\n\n- **Dispatch Relay** — the prose name for the component that processes a delivery job.\n- **Recovery Window** — the prose name for the period in which retry is allowed.\n\n## Avoid\n\n- Avoid **worker**; use **Dispatch Relay** in prose.\n- Avoid **retry timeout**; use **Recovery Window** in prose.\n\n## Relationships\n\n- **Dispatch Relay** invokes `DispatchEngine` for a `DeliveryJob` during the **Recovery Window**.\n\n## Flagged Ambiguities\n\n- **job** may mean a business work item or the `DeliveryJob` code identifier; preserve the identifier when referring to code.\n\n<!-- GLOSSARY_SENTINEL_127_DO_NOT_COPY -->\n"
+    }
+  },
+  "scenarios": [
+    {
+      "id": "terminology-synthesis",
+      "skill": "aif-explore",
+      "task": "Inspect the copied project and return exactly three concise bullets: component, recovery flow, and ambiguity. Use project terminology in prose, preserve exact code/API identifiers, do not edit files, and do not invent requirements, rules, or architecture decisions. End with evaluation_complete.",
+      "required_identifiers": [
+        "DispatchEngine",
+        "DeliveryJob",
+        "POST /v1/jobs/:jobId/retry"
+      ],
+      "forbidden_authority_claims": [
+        "new requirement",
+        "architecture decision requires",
+        "must rename"
+      ]
+    },
+    {
+      "id": "plan-identifier-preservation",
+      "skill": "aif-plan",
+      "task": "Inspect the copied project and return a four-step implementation plan for retry observability. Use project terminology in prose, preserve exact code identifiers, paths, and CLI flags, do not edit files, and do not invent requirements, rules, or architecture decisions. Include RETRY_WINDOW_MS, --retry-window, and src/dispatch/DeliveryJob.ts. End with evaluation_complete.",
+      "required_identifiers": [
+        "RETRY_WINDOW_MS",
+        "--retry-window",
+        "src/dispatch/DeliveryJob.ts"
+      ],
+      "forbidden_authority_claims": [
+        "new requirement",
+        "architecture decision requires",
+        "must rename"
+      ]
+    }
+  ]
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,6 +51,19 @@ The `aifhub-extension` package repository stays artifact-light: root `openspec/`
 
 AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
 
+## Optional Project Glossary
+
+Projects may configure a protocol-neutral glossary for preferred human-readable terminology:
+
+```yaml
+paths:
+  context: CONTEXT.md
+```
+
+The key is valid in OpenSpec-native and legacy AI Factory-only profiles, and a custom project-relative value is preserved during mode switches. The file itself is optional: missing or empty content does not block any command and `/aif-mode` never creates or validates it.
+
+`/aif-analyze` is the only AIFHub writer. Creation requires explicit opt-in plus concrete source-grounded terms; updates require an explicit request or accepted proposal and preserve manual/unknown sections. All other commands are read-only consumers. The glossary affects prose only and cannot override source/tests, canonical OpenSpec requirements, project rules, accepted architecture decisions, or verifiable QA facts. See [Context Loading Policy](context-loading-policy.md) and [ADR 0002](adr/0002-optional-project-context-glossary.md).
+
 ## Опциональные Context Providers
 
 Context providers - ручные, user-owned research aids. AIFHub может читать reviewed provider notes как optional supporting context, но provider availability всегда degraded behavior и никогда не является validation, verification, review, rules, security, done или commit gate.
@@ -341,6 +354,7 @@ Writes:
 
 - `.ai-factory/config.yaml`
 - `.ai-factory/rules/base.md`
+- configured `paths.context` project glossary only after explicit user opt-in
 - optional OpenSpec-native skeleton paths such as `openspec/specs/`, `openspec/changes/`, `.ai-factory/state/`, `.ai-factory/qa/`, and `.ai-factory/rules/generated/`
 
 Does not write:
@@ -348,6 +362,7 @@ Does not write:
 - OpenSpec skills or slash commands
 - canonical change artifacts for a feature request
 - `.ai-factory/plans` in OpenSpec-native mode
+- an empty or unapproved glossary placeholder
 
 Select OpenSpec-native mode explicitly by asking for it or by starting from config with:
 
@@ -1087,3 +1102,4 @@ npm test
 - [Legacy Plan Migration](legacy-plan-migration.md)
 - [Active Change Resolver](active-change-resolver.md)
 - [ADR 0001](adr/0001-openspec-native-artifact-protocol.md)
+- [ADR 0002: Optional Project Glossary](adr/0002-optional-project-context-glossary.md)

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -416,4 +416,80 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
       assertNotIncludes(skill, stale, 'skills/aif-analyze/SKILL.md');
     }
   });
+
+  it('declares aif-analyze as the explicit-opt-in owner for non-empty glossary creation and approved patch updates', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+    const configTemplate = await readRepoFile('skills/aif-analyze/references/config-template.yaml');
+
+    for (const expected of [
+      '`/aif-analyze` is the only AIFHub command allowed to create or update the project glossary.',
+      'explicit user opt-in',
+      'concrete source-grounded terms',
+      'Do not create an empty placeholder',
+      'explicit update request or the user accepts a proposed glossary update',
+      'patch-style update',
+      'preserve manual entries and unknown headings',
+      '`created`, `updated`, `preserved`, or `skipped`',
+      'Never include glossary contents in the handoff'
+    ]) {
+      assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md glossary ownership contract');
+    }
+
+    for (const expected of [
+      'context: CONTEXT.md',
+      'Optional project glossary',
+      'created only with explicit opt-in'
+    ]) {
+      assertIncludes(configTemplate, expected, 'skills/aif-analyze/references/config-template.yaml glossary profile');
+    }
+  });
+
+  it('treats paths.context as an optional safe file rather than a required directory', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+
+    for (const expected of [
+      '### Step 3.25: Optional Project Glossary',
+      'normalized project-relative file path',
+      'Reject absolute paths, URI-like values, paths that escape the project root, and directory targets.',
+      'Do not read or write any rejected target.',
+      'Missing glossary files are a normal non-fatal state.',
+      'Continue without glossary context',
+      'one sanitized warning with the rejection reason',
+      'Do not include an external absolute path',
+      'file-valued paths such as `paths.context`',
+      'must never be created as directories'
+    ]) {
+      assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md glossary path-safety contract');
+    }
+  });
+
+  it('provides a glossary-only template without authority-bearing artifact sections', async () => {
+    const template = await readRepoFile('skills/aif-analyze/references/project-glossary-template.md');
+
+    for (const heading of [
+      '# Project Glossary',
+      '## Language',
+      '## Avoid',
+      '## Relationships',
+      '## Flagged Ambiguities'
+    ]) {
+      assertIncludes(template, heading, 'project glossary template allowed sections');
+    }
+
+    for (const forbiddenHeading of [
+      '## Requirements',
+      '## Rules',
+      '## Decisions',
+      '## Scratch Notes'
+    ]) {
+      assertNotIncludes(template, forbiddenHeading, 'project glossary template authority boundary');
+    }
+
+    for (const exclusion of [
+      'Do not store requirements, rules, architecture decisions, task notes, or scratch notes here.',
+      'Use only concise, source-grounded terminology.'
+    ]) {
+      assertIncludes(template, exclusion, 'project glossary template exclusions');
+    }
+  });
 });

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -91,6 +91,7 @@ const DEFAULT_AI_FACTORY_PATHS = {
 const DEFAULT_CONTEXT_PATHS = {
   description: '.ai-factory/DESCRIPTION.md',
   architecture: '.ai-factory/ARCHITECTURE.md',
+  context: 'CONTEXT.md',
   roadmap: '.ai-factory/ROADMAP.md',
   research: '.ai-factory/RESEARCH.md'
 };
@@ -1788,8 +1789,8 @@ function renderPathsBlock(mode, existingPaths) {
     ...modePaths
   };
   const keys = mode === MODES.openspec
-    ? ['description', 'architecture', 'roadmap', 'research', 'plans', 'specs', 'rules', 'state', 'qa', 'generated_rules']
-    : ['description', 'architecture', 'roadmap', 'research', 'plans', 'specs', 'rules'];
+    ? ['description', 'architecture', 'context', 'roadmap', 'research', 'plans', 'specs', 'rules', 'state', 'qa', 'generated_rules']
+    : ['description', 'architecture', 'context', 'roadmap', 'research', 'plans', 'specs', 'rules'];
   const extraKeys = Object.keys(merged)
     .filter((key) => !keys.includes(key))
     .sort((left, right) => left.localeCompare(right));

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -281,6 +281,97 @@ describe('mode status', () => {
 });
 
 describe('mode switching', () => {
+  it('renders the optional glossary path in stable order without creating or requiring the file', async () => {
+    const rootDir = await createTempRoot();
+
+    const openSpecResult = await switchToOpenSpecMode({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      timestamp: '2026-07-21T00-00-00-000Z'
+    });
+
+    assert.equal(openSpecResult.ok, true);
+    const openSpecConfig = await readFixture(rootDir, '.ai-factory/config.yaml');
+    assert.match(
+      openSpecConfig,
+      /  description: \.ai-factory\/DESCRIPTION\.md\n  architecture: \.ai-factory\/ARCHITECTURE\.md\n  context: CONTEXT\.md\n  roadmap: \.ai-factory\/ROADMAP\.md\n  research: \.ai-factory\/RESEARCH\.md/,
+      'OpenSpec profile should render paths.context in stable project-context order'
+    );
+    assert.equal(
+      await pathExists(rootDir, 'CONTEXT.md'),
+      false,
+      'OpenSpec profile should not create the optional glossary file'
+    );
+
+    const doctor = await doctorAifMode({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection()
+    });
+    assert.equal(
+      doctor.diagnostics.some((diagnostic) => /CONTEXT\.md|paths\.context/.test(diagnostic.message)),
+      false,
+      'Mode doctor should not inspect the optional glossary file'
+    );
+
+    const legacyResult = await switchToAiFactoryMode({
+      rootDir,
+      timestamp: '2026-07-21T00-00-01-000Z'
+    });
+
+    assert.equal(legacyResult.ok, true);
+    const legacyConfig = await readFixture(rootDir, '.ai-factory/config.yaml');
+    assert.match(
+      legacyConfig,
+      /  description: \.ai-factory\/DESCRIPTION\.md\n  architecture: \.ai-factory\/ARCHITECTURE\.md\n  context: CONTEXT\.md\n  roadmap: \.ai-factory\/ROADMAP\.md\n  research: \.ai-factory\/RESEARCH\.md/,
+      'Legacy profile should render paths.context in stable project-context order'
+    );
+    assert.equal(
+      await pathExists(rootDir, 'CONTEXT.md'),
+      false,
+      'Legacy profile should not create the optional glossary file'
+    );
+  });
+
+  it('preserves a custom project-relative glossary path across both mode profiles', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: ai-factory',
+      'paths:',
+      '  context: docs/project-glossary.md',
+      '  plans: .ai-factory/plans',
+      '  specs: .ai-factory/specs',
+      '  rules: .ai-factory/rules',
+      ''
+    ].join('\n'));
+
+    await switchToOpenSpecMode({
+      rootDir,
+      detectOpenSpec: async () => missingCliDetection(),
+      timestamp: '2026-07-21T00-00-02-000Z'
+    });
+    assert.match(
+      await readFixture(rootDir, '.ai-factory/config.yaml'),
+      /^  context: docs\/project-glossary\.md$/m,
+      'OpenSpec profile should preserve custom paths.context'
+    );
+
+    await switchToAiFactoryMode({
+      rootDir,
+      timestamp: '2026-07-21T00-00-03-000Z'
+    });
+    assert.match(
+      await readFixture(rootDir, '.ai-factory/config.yaml'),
+      /^  context: docs\/project-glossary\.md$/m,
+      'Legacy profile should preserve custom paths.context'
+    );
+    assert.equal(
+      await pathExists(rootDir, 'docs/project-glossary.md'),
+      false,
+      'Mode switching should not create a custom optional glossary file'
+    );
+  });
+
   it('switches to OpenSpec mode with missing CLI as degraded capability', async () => {
     const rootDir = await createTempRoot();
 

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -132,6 +132,93 @@ describe('complete OpenSpec workflow documentation contract', () => {
     ], 'docs/usage.md workflow');
   });
 
+  it('documents optional project glossary ownership, lexical precedence, mode preservation, and deferred OKF', async () => {
+    const contextPolicy = await readRepoFile('docs/context-loading-policy.md');
+    const usage = await readRepoFile('docs/usage.md');
+    const compatibility = await readRepoFile('docs/openspec-compatibility.md');
+    const modeSkill = await readRepoFile('skills/aif-mode/SKILL.md');
+    const modes = await readRepoFile('skills/aif-mode/references/MODES.md');
+    const adr1 = await readRepoFile('docs/adr/0001-openspec-native-artifact-protocol.md');
+    const adr2 = await readRepoFile('docs/adr/0002-optional-project-context-glossary.md');
+    const docsIndex = await readRepoFile('docs/README.md');
+    const readme = await readRepoFile('README.md');
+    const glossarySection = extractSection(contextPolicy, '## Optional Project Glossary');
+
+    assertIncludes(
+      extractSection(contextPolicy, '## Base Context'),
+      'configured `paths.context` project glossary (`CONTEXT.md` by default), when present',
+      'docs/context-loading-policy.md Base Context glossary placement'
+    );
+
+    for (const expected of [
+      '`paths.context`',
+      '`CONTEXT.md`',
+      'project-relative',
+      '`/aif-analyze` is the only writer',
+      'explicit opt-in',
+      'read-only consumers',
+      'missing or empty',
+      'unsafe or unreadable',
+      'human-readable prose',
+      'code and API identifiers',
+      'source/tests and verifiable QA facts',
+      'canonical OpenSpec requirements',
+      'project rules and accepted architecture decisions',
+      'generated-rule inputs',
+      'QA evidence',
+      'runtime traces',
+      'provider stores',
+      'OKF remains deferred'
+    ]) {
+      assertIncludes(glossarySection, expected, 'docs/context-loading-policy.md Optional Project Glossary');
+    }
+
+    for (const [source, label] of [
+      [usage, 'docs/usage.md'],
+      [compatibility, 'docs/openspec-compatibility.md'],
+      [modeSkill, 'skills/aif-mode/SKILL.md'],
+      [modes, 'skills/aif-mode/references/MODES.md']
+    ]) {
+      assertIncludes(source, 'paths.context', `${label} glossary config key`);
+      assertIncludes(source, 'CONTEXT.md', `${label} glossary default path`);
+      assertIncludes(source, 'protocol-neutral', `${label} glossary mode boundary`);
+    }
+
+    assert.ok(
+      (compatibility.match(/^  context: CONTEXT\.md$/gm) ?? []).length >= 2,
+      'docs/openspec-compatibility.md should show paths.context in both artifact protocol profiles'
+    );
+    assert.ok(
+      (modes.match(/^  context: CONTEXT\.md$/gm) ?? []).length >= 2,
+      'skills/aif-mode/references/MODES.md should show paths.context in both mode profiles'
+    );
+
+    for (const expected of [
+      '# ADR 0002: Optional project context glossary',
+      '## Status\n\nAccepted',
+      'configurable `CONTEXT.md`',
+      '`/aif-analyze`',
+      'explicit opt-in',
+      'read-only consumers',
+      'lexical authority',
+      'OKF',
+      'separate OpenSpec change and ADR'
+    ]) {
+      assertIncludes(adr2, expected, 'docs/adr/0002-optional-project-context-glossary.md');
+    }
+
+    assertIncludes(adr1, '[Next Page](0002-optional-project-context-glossary.md)', 'ADR 0001 navigation');
+    for (const [source, label] of [
+      [docsIndex, 'docs/README.md'],
+      [readme, 'README.md']
+    ]) {
+      assertIncludes(source, 'Optional Project Glossary', `${label} glossary discoverability`);
+      assertIncludes(source, '0002-optional-project-context-glossary.md', `${label} ADR 0002 link`);
+    }
+    assertIncludes(docsIndex, 'context-loading-policy.md', 'docs/README.md context policy link');
+    assertIncludes(readme, 'docs/context-loading-policy.md', 'README.md context policy link');
+  });
+
   it('documents task intake normalization inside existing planning and refinement commands', async () => {
     const usage = await readRepoFile('docs/usage.md');
     const plan = extractSection(usage, '### `/aif-plan full`');

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -10,9 +10,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 
 const SHARED_LANGUAGE_POLICY_ASSET = 'skills/shared/LANGUAGE-POLICY.md';
+const SHARED_PROJECT_GLOSSARY_ASSET = 'skills/shared/PROJECT-GLOSSARY.md';
 
 const EXPLICIT_REFERENCE_ASSETS = [
   SHARED_LANGUAGE_POLICY_ASSET,
+  SHARED_PROJECT_GLOSSARY_ASSET,
   'skills/aif-analyze/references/config-template.yaml',
   'skills/aif-done/references/finalization-contract.md',
   'injections/references/aif-roadmap/roadmap-template.md',
@@ -498,6 +500,74 @@ describe('OpenSpec-native prompt asset contract', () => {
       'injections/references/aif-roadmap/slice-checklist.md'
     ]) {
       assert.ok(!assets.includes(excluded), `language policy coverage should not require reference asset ${excluded}`);
+    }
+  });
+
+  it('loads optional project glossary policy only through the shared language policy', async () => {
+    const languagePolicy = await readRepoFile(SHARED_LANGUAGE_POLICY_ASSET);
+    const glossaryPolicy = await readRepoFile(SHARED_PROJECT_GLOSSARY_ASSET);
+
+    assertIncludes(
+      languagePolicy,
+      `\`${SHARED_PROJECT_GLOSSARY_ASSET}\``,
+      `${SHARED_LANGUAGE_POLICY_ASSET} glossary policy link`
+    );
+
+    for (const expected of [
+      '.ai-factory/config.yaml',
+      '`paths.context`',
+      '`CONTEXT.md`',
+      '`present`',
+      '`missing`',
+      '`empty`',
+      '`unreadable`',
+      '`unsafe`',
+      'normalized project-relative file path',
+      '`/aif-analyze` is the only AIFHub command allowed to create or update the glossary',
+      'read-only consumers',
+      'human-readable prose',
+      'code and API identifiers',
+      'source code, public APIs, schemas, and executable tests',
+      'canonical OpenSpec specs and active change requirements',
+      'project rules and accepted architecture decisions',
+      '`DESCRIPTION.md` and `ARCHITECTURE.md`',
+      'verifiable QA facts',
+      'concise terminology-drift warning',
+      'Never copy the glossary body',
+      'generated-rule inputs',
+      'QA schemas or evidence',
+      'runtime traces',
+      'provider stores',
+      'OKF is deferred'
+    ]) {
+      assertIncludes(glossaryPolicy, expected, `${SHARED_PROJECT_GLOSSARY_ASSET} consumer contract`);
+    }
+
+    for (const relativePath of await activeManifestPromptAssets()) {
+      const asset = await readRepoFile(relativePath);
+      assertIncludes(asset, `\`${SHARED_LANGUAGE_POLICY_ASSET}\``, `${relativePath} language policy link`);
+      assertNotIncludes(
+        asset,
+        SHARED_PROJECT_GLOSSARY_ASSET,
+        `${relativePath} should use only the transitive glossary policy entrypoint`
+      );
+    }
+  });
+
+  it('keeps glossary context out of canonical, generated-rules, QA and execution helpers', async () => {
+    for (const relativePath of [
+      'scripts/openspec-execution-context.mjs',
+      'scripts/openspec-verification-context.mjs',
+      'scripts/openspec-rules-compiler.mjs'
+    ]) {
+      const helper = await readRepoFile(relativePath);
+      for (const unexpected of [
+        'paths.context',
+        'PROJECT-GLOSSARY.md',
+        'CONTEXT.md'
+      ]) {
+        assertNotIncludes(helper, unexpected, `${relativePath} protected artifact boundary`);
+      }
     }
   });
 

--- a/scripts/project-glossary-ai-tester-matrix.mjs
+++ b/scripts/project-glossary-ai-tester-matrix.mjs
@@ -1,0 +1,555 @@
+// project-glossary-ai-tester-matrix.mjs - controlled glossary context A/B scenarios
+import { createHash } from 'node:crypto';
+import { copyFile, cp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const PROJECT_GLOSSARY_CATALOG_SCHEMA = 'aifhub.project_glossary.ai_tester_scenario_catalog.v1';
+export const PROJECT_GLOSSARY_MATRIX_SCHEMA = 'aifhub.project_glossary.ai_tester_matrix.v1';
+export const GLOSSARY_CONDITIONS = Object.freeze([
+  'baseline_without_glossary',
+  'candidate_with_glossary'
+]);
+
+const DEFAULT_CATALOG = path.join('docs', 'project-glossary-research', 'ai-tester-scenarios.json');
+const SAFE_SKILLS = new Set(['aif-explore', 'aif-plan']);
+const LOG_LEVELS = Object.freeze({ debug: 10, info: 20, warn: 30, error: 40, silent: 100 });
+
+export async function loadProjectGlossaryScenarioCatalog({
+  catalogPath = DEFAULT_CATALOG,
+  cwd = process.cwd()
+} = {}) {
+  const resolvedPath = path.resolve(cwd, catalogPath);
+  log('debug', 'catalog.read.start', { path: toProjectPath(cwd, resolvedPath) });
+  const raw = await readFile(resolvedPath, 'utf8');
+  const catalog = JSON.parse(raw);
+  const errors = validateProjectGlossaryScenarioCatalog(catalog);
+  if (errors.length > 0) {
+    throw new Error(`Invalid project glossary ai-tester catalog: ${errors.join('; ')}`);
+  }
+  log('info', 'catalog.read.complete', {
+    path: toProjectPath(cwd, resolvedPath),
+    scenarios: catalog.scenarios.length,
+    repetitions: catalog.defaults.repetitions
+  });
+  return { ...catalog, source_path: toProjectPath(cwd, resolvedPath) };
+}
+
+export function validateProjectGlossaryScenarioCatalog(catalog = {}) {
+  const errors = [];
+  if (catalog.schema !== PROJECT_GLOSSARY_CATALOG_SCHEMA) {
+    errors.push(`schema must be ${PROJECT_GLOSSARY_CATALOG_SCHEMA}`);
+  }
+
+  const defaults = catalog.defaults ?? {};
+  if (defaults.runtime !== 'codex') errors.push('defaults.runtime must be codex');
+  if (!safeToken(defaults.model)) errors.push('defaults.model must be a safe non-empty model id');
+  if (!safeToken(defaults.reasoning)) errors.push('defaults.reasoning must be a safe non-empty reasoning id');
+  if (!Number.isInteger(defaults.repetitions) || defaults.repetitions < 2) {
+    errors.push('defaults.repetitions must be an integer >= 2');
+  }
+  if (!sameOrderedValues(defaults.conditions, GLOSSARY_CONDITIONS)) {
+    errors.push(`defaults.conditions must be ${GLOSSARY_CONDITIONS.join(', ')}`);
+  }
+  if (!Number.isInteger(defaults.max_turns) || defaults.max_turns < 1) {
+    errors.push('defaults.max_turns must be a positive integer');
+  }
+
+  const fixture = catalog.fixture ?? {};
+  if (!safeId(fixture.id)) errors.push('fixture.id must be lowercase kebab-safe');
+  if (!safeRelativePath(fixture.config_path)) errors.push('fixture.config_path must be project-relative');
+  if (!safeRelativePath(fixture.context_path)) errors.push('fixture.context_path must be project-relative');
+  if (!safeToken(fixture.sentinel)) errors.push('fixture.sentinel must be a safe non-empty token');
+
+  const sourceFiles = fixture.source_files ?? {};
+  if (Object.keys(sourceFiles).length === 0) errors.push('fixture.source_files must not be empty');
+  for (const [filePath, content] of Object.entries(sourceFiles)) {
+    if (!safeRelativePath(filePath)) errors.push(`fixture.source_files contains unsafe path: ${filePath}`);
+    if (containsPrivateMaterial(content)) errors.push(`fixture.source_files contains private-looking material: ${filePath}`);
+  }
+
+  const glossary = fixture.synthetic_glossary ?? {};
+  if (!Array.isArray(glossary.canonical_terms) || glossary.canonical_terms.length < 1) {
+    errors.push('fixture.synthetic_glossary.canonical_terms must not be empty');
+  }
+  if (!Array.isArray(glossary.avoided_terms) || glossary.avoided_terms.length < 1) {
+    errors.push('fixture.synthetic_glossary.avoided_terms must not be empty');
+  }
+  if (!String(glossary.body ?? '').includes(String(fixture.sentinel ?? ''))) {
+    errors.push('fixture.synthetic_glossary.body must contain fixture.sentinel');
+  }
+  if (containsPrivateMaterial(glossary.body)) {
+    errors.push('fixture.synthetic_glossary.body contains private-looking material');
+  }
+
+  const scenarios = asArray(catalog.scenarios);
+  if (scenarios.length === 0) errors.push('scenarios must not be empty');
+  const seen = new Set();
+  for (const [index, scenario] of scenarios.entries()) {
+    const prefix = `scenarios[${index}]`;
+    if (!safeId(scenario.id)) errors.push(`${prefix}.id must be lowercase kebab-safe`);
+    if (seen.has(scenario.id)) errors.push(`${prefix}.id duplicates ${scenario.id}`);
+    seen.add(scenario.id);
+    if (!SAFE_SKILLS.has(scenario.skill)) errors.push(`${prefix}.skill must be aif-explore or aif-plan`);
+    if (!String(scenario.task ?? '').trim()) errors.push(`${prefix}.task must not be empty`);
+    if (containsPrivateMaterial(scenario.task)) errors.push(`${prefix}.task contains private-looking material`);
+    if (asArray(scenario.required_identifiers).length === 0) {
+      errors.push(`${prefix}.required_identifiers must not be empty`);
+    }
+    if (asArray(scenario.forbidden_authority_claims).length === 0) {
+      errors.push(`${prefix}.forbidden_authority_claims must not be empty`);
+    }
+  }
+  return errors;
+}
+
+export function buildProjectGlossaryMatrix({
+  catalog,
+  runId,
+  model = catalog?.defaults?.model,
+  reasoning = catalog?.defaults?.reasoning,
+  runtime = catalog?.defaults?.runtime,
+  generatedAt = new Date().toISOString()
+} = {}) {
+  const errors = validateProjectGlossaryScenarioCatalog(catalog);
+  if (errors.length > 0) throw new Error(`Invalid project glossary ai-tester catalog: ${errors.join('; ')}`);
+  if (!safeId(runId)) throw new Error('runId must be lowercase kebab-safe');
+  if (!safeToken(model)) throw new Error('model must be a safe non-empty model id');
+  if (!safeToken(reasoning)) throw new Error('reasoning must be a safe non-empty reasoning id');
+  if (!safeToken(runtime)) throw new Error('runtime must be a safe non-empty runtime id');
+
+  const sourceFingerprint = sha256(stableStringify(catalog.fixture.source_files));
+  const glossaryFingerprint = sha256(String(catalog.fixture.synthetic_glossary.body));
+  const cases = [];
+
+  for (const scenario of catalog.scenarios) {
+    const settingsFingerprint = sha256(stableStringify({
+      fixture_id: catalog.fixture.id,
+      source_fingerprint: sourceFingerprint,
+      skill: scenario.skill,
+      task: scenario.task,
+      required_identifiers: scenario.required_identifiers,
+      forbidden_authority_claims: scenario.forbidden_authority_claims,
+      runtime,
+      model,
+      reasoning,
+      max_turns: catalog.defaults.max_turns
+    }));
+    for (let repetition = 1; repetition <= catalog.defaults.repetitions; repetition += 1) {
+      const repetitionId = `r${String(repetition).padStart(2, '0')}`;
+      const pairId = `${runId}__${scenario.id}__${repetitionId}`;
+      for (const condition of GLOSSARY_CONDITIONS) {
+        const id = `${pairId}__${condition}`;
+        cases.push({
+          id,
+          pair_id: pairId,
+          scenario_id: scenario.id,
+          skill: scenario.skill,
+          task: scenario.task,
+          repetition,
+          condition,
+          runtime,
+          model,
+          reasoning,
+          max_turns: catalog.defaults.max_turns,
+          fixture_id: catalog.fixture.id,
+          fixture_path: toPosix(path.join('fixtures', scenario.id, condition)),
+          scenario_file: toPosix(path.join('scenarios', `${id}.yaml`)),
+          settings_fingerprint: settingsFingerprint,
+          source_fingerprint: sourceFingerprint,
+          glossary_fingerprint: condition === 'candidate_with_glossary' ? glossaryFingerprint : null,
+          required_identifiers: [...scenario.required_identifiers],
+          canonical_terms: [...catalog.fixture.synthetic_glossary.canonical_terms],
+          avoided_terms: [...catalog.fixture.synthetic_glossary.avoided_terms],
+          forbidden_authority_claims: [...scenario.forbidden_authority_claims],
+          sentinel: catalog.fixture.sentinel,
+          exact_filter: exactScenarioFilter(id)
+        });
+      }
+    }
+  }
+
+  return {
+    schema: PROJECT_GLOSSARY_MATRIX_SCHEMA,
+    generated_at: generatedAt,
+    run_id: runId,
+    catalog_schema: catalog.schema,
+    catalog_source: catalog.source_path ?? null,
+    runtime,
+    model,
+    reasoning,
+    repetitions: catalog.defaults.repetitions,
+    conditions: [...GLOSSARY_CONDITIONS],
+    source_fingerprint: sourceFingerprint,
+    cases
+  };
+}
+
+export async function generateProjectGlossaryMatrix({
+  catalogPath = DEFAULT_CATALOG,
+  outDir,
+  sourceRoot = process.cwd(),
+  runId,
+  model,
+  reasoning,
+  runtime,
+  dryRun = false,
+  cwd = process.cwd()
+} = {}) {
+  if (!outDir) throw new Error('outDir is required');
+  const catalog = await loadProjectGlossaryScenarioCatalog({ catalogPath, cwd });
+  const matrix = buildProjectGlossaryMatrix({ catalog, runId, model, reasoning, runtime });
+  if (dryRun) {
+    log('info', 'matrix.dry_run', { run_id: runId, cases: matrix.cases.length });
+    return { matrix, written_files: [], dry_run: true };
+  }
+
+  const resolvedOut = path.resolve(cwd, outDir);
+  const resolvedSource = path.resolve(cwd, sourceRoot);
+  log('info', 'matrix.write.start', {
+    out: toProjectPath(cwd, resolvedOut),
+    cases: matrix.cases.length
+  });
+  await mkdir(resolvedOut, { recursive: true });
+  await mkdir(path.join(resolvedOut, 'fixtures'), { recursive: true });
+  await mkdir(path.join(resolvedOut, 'scenarios'), { recursive: true });
+  const writtenFiles = [];
+
+  await writeTracked(path.join(resolvedOut, 'system-prompt.md'), renderSystemPrompt(), writtenFiles, resolvedOut);
+  await writeTracked(
+    path.join(resolvedOut, 'matrix-summary.json'),
+    `${JSON.stringify(matrix, null, 2)}\n`,
+    writtenFiles,
+    resolvedOut
+  );
+
+  const fixtureKeys = new Set();
+  for (const matrixCase of matrix.cases) {
+    const fixtureKey = `${matrixCase.scenario_id}:${matrixCase.condition}`;
+    if (!fixtureKeys.has(fixtureKey)) {
+      fixtureKeys.add(fixtureKey);
+      await writeFixture({
+        catalog,
+        matrixCase,
+        outDir: resolvedOut,
+        sourceRoot: resolvedSource,
+        writtenFiles
+      });
+    }
+    const scenarioPath = path.join(resolvedOut, fromPosix(matrixCase.scenario_file));
+    await writeTracked(
+      scenarioPath,
+      renderAiTesterScenario(matrixCase),
+      writtenFiles,
+      resolvedOut
+    );
+  }
+
+  log('info', 'matrix.write.complete', {
+    out: toProjectPath(cwd, resolvedOut),
+    written_files: writtenFiles.length
+  });
+  return { matrix, written_files: writtenFiles, dry_run: false };
+}
+
+export function renderAiTesterScenario(matrixCase = {}) {
+  const promptLines = [
+    `Target skill: ${matrixCase.skill}.`,
+    `Read project/skills/${matrixCase.skill}/SKILL.md completely before answering.`,
+    'Read project/skills/shared/LANGUAGE-POLICY.md and the PROJECT-GLOSSARY.md contract it references.',
+    'Resolve project/.ai-factory/config.yaml exactly as those instructions require.',
+    'Work only inside the copied project fixture and do not edit files.',
+    `Benchmark task: ${matrixCase.task}`
+  ];
+  return [
+    `scenario: ${matrixCase.id}`,
+    `description: "project-glossary condition=${matrixCase.condition} repetition=${matrixCase.repetition} settings=${matrixCase.settings_fingerprint}"`,
+    'system_prompt_file: "../system-prompt.md"',
+    'user_prompt: |',
+    ...promptLines.map((line) => `  ${line}`),
+    'runner:',
+    `  runtime: ${quoteYaml(matrixCase.runtime)}`,
+    `  model: ${quoteYaml(matrixCase.model)}`,
+    `  reasoning: ${quoteYaml(matrixCase.reasoning)}`,
+    '  permission_mode: bypassPermissions',
+    'fixtures:',
+    '  copy_trees:',
+    `    - from: ${quoteYaml(`../${matrixCase.fixture_path}`)}`,
+    '      to: project',
+    'assertions:',
+    '  - id: stay-in-sandbox',
+    '    type: no_path_escape',
+    '  - id: bounded-turns',
+    '    type: turn_count_at_most',
+    `    max: ${matrixCase.max_turns}`,
+    '  - id: completed-output',
+    '    type: output_contains',
+    '    pattern: "evaluation_complete"',
+    ''
+  ].join('\n');
+}
+
+export function exactScenarioFilter(scenarioId) {
+  if (!safeScenarioId(scenarioId)) throw new Error('scenario id contains unsafe filter characters');
+  return `^${scenarioId}$`;
+}
+
+export async function buildAiTesterRuntimeEnv({
+  matrixDir,
+  platform = process.platform,
+  baseEnv = process.env,
+  systemRoot = baseEnv.SystemRoot ?? 'C:\\Windows'
+} = {}) {
+  const env = { ...baseEnv };
+  if (platform !== 'win32') return env;
+  const shimDir = path.join(matrixDir, '.runner-bin');
+  await mkdir(shimDir, { recursive: true });
+  await writeFile(path.join(shimDir, 'which.cmd'), '@echo off\r\nwhere.exe %*\r\n', 'utf8');
+  await copyFile(path.join(systemRoot, 'System32', 'where.exe'), path.join(shimDir, 'which.exe')).catch(() => {});
+  const currentPath = env.Path ?? env.PATH ?? '';
+  env.Path = `${shimDir}${path.delimiter}${currentPath}`;
+  env.PATH = env.Path;
+  log('debug', 'runner.windows_shim.ready', { shim: '.runner-bin/which.cmd' });
+  return env;
+}
+
+export function buildAiTesterRunInvocation(matrixCase, {
+  matrixDir,
+  platform = process.platform,
+  quiet = true,
+  dryRun = false
+} = {}) {
+  const scenarioPath = path.resolve(matrixDir, fromPosix(matrixCase.scenario_file));
+  const args = [
+    'run',
+    '--file', scenarioPath,
+    '--runtime', matrixCase.runtime,
+    '--model', matrixCase.model,
+    '--reasoning', matrixCase.reasoning,
+    '--filter', exactScenarioFilter(matrixCase.id)
+  ];
+  if (quiet) args.push('--quiet');
+  if (dryRun) args.push('--dry-run');
+  if (platform !== 'win32') return { command: 'ai-tester', args };
+  const commandText = ['ai-tester', ...args.map(quotePowerShellArg)].join(' ');
+  return {
+    command: 'powershell.exe',
+    args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', commandText]
+  };
+}
+
+function renderSystemPrompt() {
+  return [
+    '# AIFHub Project Glossary Evaluation',
+    '',
+    'You are running a controlled behavioral evaluation of optional project glossary context.',
+    '',
+    'Rules:',
+    '',
+    '- Follow the target AIFHub skill and shared language/glossary policies copied into the fixture.',
+    '- Treat the configured project glossary as optional lexical context only.',
+    '- Preserve source, code, API, path, and CLI identifiers exactly.',
+    '- Do not infer requirements, rules, or architecture decisions from glossary text.',
+    '- Missing glossary context is non-blocking.',
+    '- Never reproduce the complete glossary, HTML comments, or sentinel values in the answer.',
+    '- Do not read outside the copied project fixture and do not edit files.',
+    '- Return only the requested concise answer and the final marker evaluation_complete.',
+    ''
+  ].join('\n');
+}
+
+async function writeFixture({ catalog, matrixCase, outDir, sourceRoot, writtenFiles }) {
+  const fixtureRoot = path.join(outDir, fromPosix(matrixCase.fixture_path));
+  await mkdir(fixtureRoot, { recursive: true });
+  for (const [relativePath, content] of Object.entries(catalog.fixture.source_files)) {
+    await writeTracked(path.join(fixtureRoot, fromPosix(relativePath)), content, writtenFiles, outDir);
+  }
+  const config = [
+    'config_version: 1',
+    'language:',
+    '  ui: en',
+    '  artifacts: en',
+    '  technical_terms: keep',
+    'paths:',
+    `  context: ${catalog.fixture.context_path}`,
+    ''
+  ].join('\n');
+  await writeTracked(
+    path.join(fixtureRoot, fromPosix(catalog.fixture.config_path)),
+    config,
+    writtenFiles,
+    outDir
+  );
+
+  const skillSource = path.join(sourceRoot, '.agents', 'skills', matrixCase.skill);
+  const skillTarget = path.join(fixtureRoot, 'skills', matrixCase.skill);
+  await cp(skillSource, skillTarget, { recursive: true, force: true });
+  writtenFiles.push(toPosix(path.relative(outDir, skillTarget)) + '/');
+
+  const sharedTarget = path.join(fixtureRoot, 'skills', 'shared');
+  await mkdir(sharedTarget, { recursive: true });
+  for (const name of ['LANGUAGE-POLICY.md', 'PROJECT-GLOSSARY.md']) {
+    const target = path.join(sharedTarget, name);
+    await copyFile(path.join(sourceRoot, 'skills', 'shared', name), target);
+    writtenFiles.push(toPosix(path.relative(outDir, target)));
+  }
+
+  if (matrixCase.condition === 'candidate_with_glossary') {
+    await writeTracked(
+      path.join(fixtureRoot, fromPosix(catalog.fixture.context_path)),
+      catalog.fixture.synthetic_glossary.body,
+      writtenFiles,
+      outDir
+    );
+  }
+  log('debug', 'fixture.write.complete', {
+    scenario: matrixCase.scenario_id,
+    condition: matrixCase.condition,
+    path: matrixCase.fixture_path
+  });
+}
+
+async function writeTracked(filePath, content, writtenFiles, rootDir) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf8');
+  writtenFiles.push(toPosix(path.relative(rootDir, filePath)));
+}
+
+function safeRelativePath(value) {
+  const raw = String(value ?? '');
+  if (!raw || path.isAbsolute(raw) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(raw)) return false;
+  const normalized = path.posix.normalize(raw.replaceAll('\\', '/'));
+  return normalized !== '..' && !normalized.startsWith('../') && normalized !== '.';
+}
+
+function containsPrivateMaterial(value) {
+  const raw = String(value ?? '');
+  return /(?:[A-Za-z]:\\Users\\|\/Users\/|\/home\/[^/]+\/|BEGIN (?:RSA |OPENSSH )?PRIVATE KEY|(?:api[_-]?key|token|password)\s*[:=]\s*\S+)/i.test(raw);
+}
+
+function safeToken(value) {
+  return /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(String(value ?? ''));
+}
+
+function safeId(value) {
+  return /^[a-z0-9][a-z0-9-]*$/.test(String(value ?? ''));
+}
+
+function safeScenarioId(value) {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(String(value ?? ''));
+}
+
+function sameOrderedValues(actual, expected) {
+  return Array.isArray(actual)
+    && actual.length === expected.length
+    && actual.every((value, index) => value === expected[index]);
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return createHash('sha256').update(String(value)).digest('hex');
+}
+
+function quoteYaml(value) {
+  return JSON.stringify(String(value));
+}
+
+function quotePowerShellArg(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function toProjectPath(root, filePath) {
+  const relative = path.relative(root, filePath);
+  return toPosix(relative || '.');
+}
+
+function toPosix(value) {
+  return String(value).replaceAll(path.sep, '/');
+}
+
+function fromPosix(value) {
+  return String(value).split('/').join(path.sep);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function log(level, event, details = {}) {
+  const configured = String(process.env.AIF_GLOSSARY_LOG_LEVEL ?? process.env.LOG_LEVEL ?? 'warn').toLowerCase();
+  const threshold = LOG_LEVELS[configured] ?? LOG_LEVELS.warn;
+  if ((LOG_LEVELS[level] ?? LOG_LEVELS.info) < threshold) return;
+  process.stderr.write(`${JSON.stringify({ component: 'project-glossary-ai-tester', level, event, ...details })}\n`);
+}
+
+function parseCliArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--catalog') parsed.catalogPath = args[++index];
+    else if (token === '--out') parsed.outDir = args[++index];
+    else if (token === '--source-root') parsed.sourceRoot = args[++index];
+    else if (token === '--run-id') parsed.runId = args[++index];
+    else if (token === '--model') parsed.model = args[++index];
+    else if (token === '--reasoning') parsed.reasoning = args[++index];
+    else if (token === '--runtime') parsed.runtime = args[++index];
+    else if (token === '--dry-run') parsed.dryRun = true;
+    else if (token === '--json') parsed.json = true;
+    else if (token === '--help' || token === '-h') parsed.help = true;
+    else throw new Error(`Unknown argument: ${token}`);
+  }
+  return parsed;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/project-glossary-ai-tester-matrix.mjs --out <dir> --run-id <id> [options]',
+    '',
+    'Options:',
+    `  --catalog <file>       Catalog JSON. Default: ${toPosix(DEFAULT_CATALOG)}.`,
+    '  --source-root <dir>    Repository root containing .agents/skills and skills/shared.',
+    '  --model <id>           Override pinned model for this matrix.',
+    '  --reasoning <level>    Override pinned reasoning level.',
+    '  --runtime <id>         Override runtime. Default from catalog.',
+    '  --dry-run              Validate and select cases without writing files.',
+    '  --json                 Print JSON result.',
+    ''
+  ].join('\n');
+}
+
+async function main() {
+  const parsed = parseCliArgs(process.argv.slice(2));
+  if (parsed.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!parsed.outDir || !parsed.runId) throw new Error('--out and --run-id are required');
+  const result = await generateProjectGlossaryMatrix(parsed);
+  const body = {
+    schema: PROJECT_GLOSSARY_MATRIX_SCHEMA,
+    run_id: result.matrix.run_id,
+    cases: result.matrix.cases.length,
+    dry_run: result.dry_run,
+    written_files: result.written_files.length,
+    model: result.matrix.model,
+    reasoning: result.matrix.reasoning,
+    runtime: result.matrix.runtime
+  };
+  process.stdout.write(parsed.json ? `${JSON.stringify(body, null, 2)}\n` : `Generated ${body.cases} cases for ${body.run_id}.\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((error) => {
+    log('error', 'matrix.failed', { message: error instanceof Error ? error.message : String(error) });
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/project-glossary-ai-tester-matrix.test.mjs
+++ b/scripts/project-glossary-ai-tester-matrix.test.mjs
@@ -1,0 +1,167 @@
+// project-glossary-ai-tester-matrix.test.mjs - controlled glossary matrix contracts
+import assert from 'node:assert/strict';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  GLOSSARY_CONDITIONS,
+  buildAiTesterRunInvocation,
+  buildAiTesterRuntimeEnv,
+  buildProjectGlossaryMatrix,
+  exactScenarioFilter,
+  generateProjectGlossaryMatrix,
+  loadProjectGlossaryScenarioCatalog,
+  renderAiTesterScenario,
+  validateProjectGlossaryScenarioCatalog
+} from './project-glossary-ai-tester-matrix.mjs';
+
+let tempDir;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), 'project-glossary-ai-tester-matrix-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('project glossary ai-tester catalog', () => {
+  it('loads the committed synthetic catalog with pinned Luna settings', async () => {
+    const catalog = await loadProjectGlossaryScenarioCatalog({ cwd: process.cwd() });
+    assert.equal(catalog.defaults.model, 'gpt-5.6-luna');
+    assert.equal(catalog.defaults.reasoning, 'low');
+    assert.equal(catalog.defaults.repetitions, 2);
+    assert.deepEqual(catalog.defaults.conditions, GLOSSARY_CONDITIONS);
+    assert.deepEqual(catalog.scenarios.map((item) => item.skill), ['aif-explore', 'aif-plan']);
+    assert.doesNotMatch(JSON.stringify(catalog), /[A-Za-z]:\\Users\\|BEGIN PRIVATE KEY/i);
+  });
+
+  it('rejects unsafe fixture paths, private-looking content, and incomplete pairing', async () => {
+    const catalog = await loadProjectGlossaryScenarioCatalog({ cwd: process.cwd() });
+    const unsafe = structuredClone(catalog);
+    unsafe.defaults.conditions = ['candidate_with_glossary'];
+    unsafe.fixture.source_files['../escape.txt'] = 'token=secret-value';
+    const errors = validateProjectGlossaryScenarioCatalog(unsafe);
+    assert.ok(errors.some((item) => item.includes('defaults.conditions')));
+    assert.ok(errors.some((item) => item.includes('unsafe path')));
+    assert.ok(errors.some((item) => item.includes('private-looking material')));
+  });
+});
+
+describe('project glossary matrix generation', () => {
+  it('builds two complete repetitions per skill with matching pair fingerprints', async () => {
+    const catalog = await loadProjectGlossaryScenarioCatalog({ cwd: process.cwd() });
+    const matrix = buildProjectGlossaryMatrix({ catalog, runId: 'glossary-luna-low-test' });
+    assert.equal(matrix.cases.length, 8);
+    assert.equal(new Set(matrix.cases.map((item) => item.id)).size, 8);
+    for (const pairId of new Set(matrix.cases.map((item) => item.pair_id))) {
+      const pair = matrix.cases.filter((item) => item.pair_id === pairId);
+      assert.deepEqual(pair.map((item) => item.condition), GLOSSARY_CONDITIONS);
+      assert.equal(new Set(pair.map((item) => item.settings_fingerprint)).size, 1);
+      assert.equal(new Set(pair.map((item) => item.source_fingerprint)).size, 1);
+      assert.equal(pair[0].model, 'gpt-5.6-luna');
+      assert.equal(pair[0].reasoning, 'low');
+    }
+  });
+
+  it('writes identical source fixtures and adds CONTEXT.md only to candidates', async () => {
+    const sourceRoot = path.join(tempDir, 'source');
+    const outDir = path.join(tempDir, 'state', 'matrix');
+    await writeFakeSkillSources(sourceRoot);
+    const catalogPath = path.join(process.cwd(), 'docs', 'project-glossary-research', 'ai-tester-scenarios.json');
+    const result = await generateProjectGlossaryMatrix({
+      catalogPath,
+      outDir,
+      sourceRoot,
+      runId: 'glossary-luna-low-test',
+      cwd: process.cwd()
+    });
+    assert.equal(result.matrix.cases.length, 8);
+    const baseline = path.join(outDir, 'fixtures', 'terminology-synthesis', 'baseline_without_glossary');
+    const candidate = path.join(outDir, 'fixtures', 'terminology-synthesis', 'candidate_with_glossary');
+    await assert.rejects(access(path.join(baseline, 'CONTEXT.md')));
+    assert.match(await readFile(path.join(candidate, 'CONTEXT.md'), 'utf8'), /Dispatch Relay/);
+    assert.equal(
+      await readFile(path.join(baseline, 'README.md'), 'utf8'),
+      await readFile(path.join(candidate, 'README.md'), 'utf8')
+    );
+    assert.match(await readFile(path.join(candidate, 'skills', 'aif-explore', 'SKILL.md'), 'utf8'), /aif-explore/);
+    assert.match(await readFile(path.join(candidate, 'skills', 'shared', 'PROJECT-GLOSSARY.md'), 'utf8'), /glossary/i);
+    const summary = JSON.parse(await readFile(path.join(outDir, 'matrix-summary.json'), 'utf8'));
+    assert.equal(summary.schema, 'aifhub.project_glossary.ai_tester_matrix.v1');
+  });
+
+  it('keeps glossary body out of scenario YAML and renders the pinned runner settings', async () => {
+    const catalog = await loadProjectGlossaryScenarioCatalog({ cwd: process.cwd() });
+    const matrix = buildProjectGlossaryMatrix({ catalog, runId: 'glossary-luna-low-test' });
+    const rendered = renderAiTesterScenario(matrix.cases[1]);
+    assert.match(rendered, /model: "gpt-5\.6-luna"/);
+    assert.match(rendered, /reasoning: "low"/);
+    assert.match(rendered, /candidate_with_glossary/);
+    assert.match(rendered, /pattern: "evaluation_complete"/);
+    assert.doesNotMatch(rendered, /GLOSSARY_SENTINEL_127|Dispatch Relay invokes/);
+  });
+
+  it('validates without writes in dry-run mode', async () => {
+    const sourceRoot = path.join(tempDir, 'source');
+    const outDir = path.join(tempDir, 'not-created');
+    await writeFakeSkillSources(sourceRoot);
+    const result = await generateProjectGlossaryMatrix({
+      outDir,
+      sourceRoot,
+      runId: 'glossary-luna-low-test',
+      cwd: process.cwd(),
+      dryRun: true
+    });
+    assert.equal(result.dry_run, true);
+    assert.equal(result.written_files.length, 0);
+    await assert.rejects(access(outDir));
+  });
+});
+
+describe('ai-tester portable invocation', () => {
+  it('uses an anchored Rust-compatible exact filter', () => {
+    assert.equal(exactScenarioFilter('run__scenario__r01__baseline_without_glossary'), '^run__scenario__r01__baseline_without_glossary$');
+    assert.throws(() => exactScenarioFilter('unsafe.*'), /unsafe filter/);
+  });
+
+  it('creates the Windows which shim and quotes the exact run invocation', async () => {
+    const matrixDir = path.join(tempDir, 'matrix dir');
+    const env = await buildAiTesterRuntimeEnv({
+      matrixDir,
+      platform: 'win32',
+      baseEnv: { Path: 'C:\\tools' },
+      systemRoot: path.join(tempDir, 'missing-windows')
+    });
+    assert.ok(env.Path.startsWith(path.join(matrixDir, '.runner-bin')));
+    assert.equal(await readFile(path.join(matrixDir, '.runner-bin', 'which.cmd'), 'utf8'), '@echo off\r\nwhere.exe %*\r\n');
+    const matrixCase = {
+      id: 'glossary-luna-low__terminology-synthesis__r01__baseline_without_glossary',
+      scenario_file: 'scenarios/case.yaml',
+      runtime: 'codex',
+      model: 'gpt-5.6-luna',
+      reasoning: 'low'
+    };
+    const invocation = buildAiTesterRunInvocation(matrixCase, { matrixDir, platform: 'win32', dryRun: true });
+    assert.equal(invocation.command, 'powershell.exe');
+    const commandText = invocation.args.at(-1);
+    assert.match(commandText, /'--model' 'gpt-5\.6-luna'/);
+    assert.match(commandText, /'--reasoning' 'low'/);
+    assert.match(commandText, /'--filter' '\^glossary-luna-low__terminology-synthesis__r01__baseline_without_glossary\$'/);
+    assert.match(commandText, /--dry-run/);
+  });
+});
+
+async function writeFakeSkillSources(root) {
+  for (const skill of ['aif-explore', 'aif-plan']) {
+    const skillDir = path.join(root, '.agents', 'skills', skill);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, 'SKILL.md'), `---\nname: ${skill}\n---\n# ${skill}\n`, 'utf8');
+  }
+  const shared = path.join(root, 'skills', 'shared');
+  await mkdir(shared, { recursive: true });
+  await writeFile(path.join(shared, 'LANGUAGE-POLICY.md'), '# Language\nRead PROJECT-GLOSSARY.md.\n', 'utf8');
+  await writeFile(path.join(shared, 'PROJECT-GLOSSARY.md'), '# Project glossary\nOptional glossary.\n', 'utf8');
+}

--- a/scripts/project-glossary-ai-tester-results-report.mjs
+++ b/scripts/project-glossary-ai-tester-results-report.mjs
@@ -1,0 +1,580 @@
+// project-glossary-ai-tester-results-report.mjs - evaluate paired glossary traces
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { PROJECT_GLOSSARY_MATRIX_SCHEMA } from './project-glossary-ai-tester-matrix.mjs';
+
+export const PROJECT_GLOSSARY_RESULTS_SCHEMA = 'aifhub.project_glossary.ai_tester_results.v1';
+
+const LOG_LEVELS = Object.freeze({ debug: 10, info: 20, warn: 30, error: 40, silent: 100 });
+
+export async function collectProjectGlossaryTraceIndex({ runsDir } = {}) {
+  if (!runsDir) throw new Error('runsDir is required');
+  const resolvedRuns = path.resolve(runsDir);
+  const latestByScenario = new Map();
+  let filesRead = 0;
+  let filesSkipped = 0;
+  let entries = [];
+  try {
+    entries = await readdir(resolvedRuns, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return { runs_dir: resolvedRuns, files_read: 0, files_skipped: 0, latest_by_scenario: {} };
+    }
+    throw error;
+  }
+
+  log('debug', 'traces.scan.start', { directories: entries.length });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const scenarioDir = path.join(resolvedRuns, entry.name);
+    let files = [];
+    try {
+      files = (await readdir(scenarioDir)).filter((name) => name.endsWith('.json'));
+    } catch {
+      filesSkipped += 1;
+      continue;
+    }
+    for (const fileName of files) {
+      const filePath = path.join(scenarioDir, fileName);
+      try {
+        const record = JSON.parse(await readFile(filePath, 'utf8'));
+        const trace = normalizeTraceRecord(record, {
+          filePath,
+          runsDir: resolvedRuns,
+          directoryName: entry.name,
+          fileName
+        });
+        if (!trace.scenario_name) {
+          filesSkipped += 1;
+          continue;
+        }
+        const existing = latestByScenario.get(trace.scenario_name);
+        if (!existing || compareTraceFreshness(trace, existing) > 0) {
+          latestByScenario.set(trace.scenario_name, trace);
+        }
+        filesRead += 1;
+      } catch (error) {
+        filesSkipped += 1;
+        log('warn', 'trace.read.skipped', {
+          file: toPosix(path.relative(resolvedRuns, filePath)),
+          message: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+  }
+  log('info', 'traces.scan.complete', { files_read: filesRead, files_skipped: filesSkipped });
+  return {
+    runs_dir: resolvedRuns,
+    files_read: filesRead,
+    files_skipped: filesSkipped,
+    latest_by_scenario: Object.fromEntries(latestByScenario)
+  };
+}
+
+export function normalizeTraceRecord(record = {}, {
+  filePath = '',
+  runsDir = process.cwd(),
+  directoryName = '',
+  fileName = ''
+} = {}) {
+  const inputTokens = number(record.cost?.inputTokens);
+  const outputTokens = number(record.cost?.outputTokens);
+  const cacheCreationTokens = number(record.cost?.cacheCreationTokens);
+  const cacheReadTokens = number(record.cost?.cacheReadTokens);
+  const finalOutput = String(record.finalOutput ?? '');
+  const durationMs = number(record.runner?.durationMs);
+  return {
+    scenario_name: getScenarioName(record, directoryName, fileName),
+    scenario_description: String(record.scenario?.description ?? ''),
+    scenario_path: String(record.scenario?.path ?? ''),
+    runtime: String(record.runner?.runtime ?? ''),
+    model: String(record.runner?.model ?? ''),
+    reasoning: String(record.runner?.reasoning ?? ''),
+    finished_at: record.runner?.finishedAt ?? null,
+    duration_ms: durationMs,
+    duration_seconds: round(durationMs / 1000),
+    turns: number(record.runner?.turnsUsed),
+    tool_calls: number(record.toolCallSummary?.total, countToolCalls(record)),
+    ai_tester_pass: record.scoring?.overallPass === true,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_tokens: cacheCreationTokens,
+    cache_read_tokens: cacheReadTokens,
+    total_tokens: inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens,
+    final_output: finalOutput,
+    output_sha256: sha256(finalOutput),
+    trace_file: toPosix(path.relative(runsDir, filePath))
+  };
+}
+
+export function buildProjectGlossaryResultsReport({
+  matrix,
+  traceIndex,
+  matrixDir = '',
+  generatedAt = new Date().toISOString()
+} = {}) {
+  if (matrix?.schema !== PROJECT_GLOSSARY_MATRIX_SCHEMA) {
+    throw new Error(`matrix schema must be ${PROJECT_GLOSSARY_MATRIX_SCHEMA}`);
+  }
+  const latest = traceIndex?.latest_by_scenario ?? {};
+  const rows = matrix.cases.map((matrixCase) => evaluateMatrixCase({
+    matrix,
+    matrixCase,
+    trace: latest[matrixCase.id] ?? null,
+    matrixDir
+  }));
+  const pairs = buildPairResults(rows);
+  const executedRows = rows.filter((row) => row.trace_status !== 'NOT_RUN');
+  const completeRows = rows.filter((row) => row.trace_status === 'PASS');
+  const evidenceComplete = rows.length > 0
+    && completeRows.length === rows.length
+    && pairs.every((pair) => pair.complete);
+  const safetyPass = evidenceComplete && pairs.every((pair) => pair.safety_pass);
+  const baselineScores = rows.filter((row) => row.condition === 'baseline_without_glossary').map((row) => row.terminology_score);
+  const candidateScores = rows.filter((row) => row.condition === 'candidate_with_glossary').map((row) => row.terminology_score);
+  const baselineAverage = average(baselineScores);
+  const candidateAverage = average(candidateScores);
+  const scoreDelta = round(candidateAverage - baselineAverage);
+  const anySafetyRegression = pairs.some((pair) => pair.complete && !pair.safety_pass);
+  const outcome = decideOutcome({ evidenceComplete, safetyPass, scoreDelta, anySafetyRegression });
+  const benefitClaimAllowed = outcome === 'benefit_observed';
+
+  return {
+    schema: PROJECT_GLOSSARY_RESULTS_SCHEMA,
+    generated_at: generatedAt,
+    run_id: matrix.run_id,
+    model: matrix.model,
+    reasoning: matrix.reasoning,
+    runtime: matrix.runtime,
+    repetitions: matrix.repetitions,
+    source_fingerprint: matrix.source_fingerprint,
+    evidence_complete: evidenceComplete,
+    safety_pass: safetyPass,
+    benefit_claim_allowed: benefitClaimAllowed,
+    outcome,
+    summary: {
+      expected_rows: rows.length,
+      executed_rows: executedRows.length,
+      pass_rows: rows.filter((row) => row.trace_status === 'PASS').length,
+      fail_rows: rows.filter((row) => row.trace_status === 'FAIL').length,
+      not_run_rows: rows.filter((row) => row.trace_status === 'NOT_RUN').length,
+      stale_rows: rows.filter((row) => row.trace_status === 'STALE').length,
+      settings_mismatch_rows: rows.filter((row) => row.trace_status === 'SETTINGS_MISMATCH').length,
+      pairs: pairs.length,
+      complete_pairs: pairs.filter((pair) => pair.complete).length,
+      safety_pass_pairs: pairs.filter((pair) => pair.safety_pass).length,
+      baseline_terminology_score_average: baselineAverage,
+      candidate_terminology_score_average: candidateAverage,
+      terminology_score_delta: scoreDelta,
+      baseline_metrics: aggregateMetrics(rows.filter((row) => row.condition === 'baseline_without_glossary')),
+      candidate_metrics: aggregateMetrics(rows.filter((row) => row.condition === 'candidate_with_glossary'))
+    },
+    rows,
+    pairs,
+    trace_files_read: traceIndex?.files_read ?? 0,
+    trace_files_skipped: traceIndex?.files_skipped ?? 0,
+    limitations: [
+      'Model output is stochastic; two repetitions per scenario are a minimum signal, not statistical proof.',
+      'The fixture and glossary are synthetic and sanitised; results do not expose a real project glossary.',
+      'Contract tests prove harness behavior separately from model usefulness.'
+    ]
+  };
+}
+
+export function renderProjectGlossaryResultsMarkdown(report = {}) {
+  const lines = [
+    '# Project Glossary ai-tester Results',
+    '',
+    `- Run: \`${md(report.run_id)}\``,
+    `- Runtime/model/reasoning: \`${md(report.runtime)}\` / \`${md(report.model)}\` / \`${md(report.reasoning)}\``,
+    `- Outcome: \`${md(report.outcome)}\``,
+    `- Evidence complete: \`${report.evidence_complete === true}\``,
+    `- Benefit claim allowed: \`${report.benefit_claim_allowed === true}\``,
+    '',
+    '## Summary',
+    '',
+    '| Metric | Value |',
+    '|---|---:|',
+    `| Expected/executed rows | ${num(report.summary?.expected_rows)} / ${num(report.summary?.executed_rows)} |`,
+    `| Complete pairs | ${num(report.summary?.complete_pairs)} / ${num(report.summary?.pairs)} |`,
+    `| Baseline terminology score | ${num(report.summary?.baseline_terminology_score_average)} |`,
+    `| Candidate terminology score | ${num(report.summary?.candidate_terminology_score_average)} |`,
+    `| Paired score delta | ${signed(report.summary?.terminology_score_delta)} |`,
+    '',
+    '## Rows',
+    '',
+    '| Scenario | Rep | Condition | Trace | Score | Canonical | Avoided | Identifiers | Authority | Duration | Turns | Tools | Total tokens |',
+    '|---|---:|---|---|---:|---:|---:|---|---|---:|---:|---:|---:|'
+  ];
+  for (const row of report.rows ?? []) {
+    lines.push([
+      md(row.scenario_id),
+      num(row.repetition),
+      md(row.condition),
+      md(row.trace_status),
+      num(row.terminology_score),
+      `${num(row.canonical_term_hits)}/${num(row.canonical_term_total)}`,
+      num(row.avoided_term_hits),
+      row.identifiers_preserved ? 'PASS' : 'FAIL',
+      row.authority_preserved ? 'PASS' : 'FAIL',
+      num(row.duration_seconds),
+      num(row.turns),
+      num(row.tool_calls),
+      num(row.total_tokens)
+    ].map((value) => `| ${value} `).join('') + '|');
+  }
+  lines.push(
+    '',
+    '## Pairs',
+    '',
+    '| Pair | Complete | Safety | Baseline | Candidate | Delta | Decision |',
+    '|---|---|---|---:|---:|---:|---|'
+  );
+  for (const pair of report.pairs ?? []) {
+    lines.push(`| ${md(pair.pair_id)} | ${pair.complete ? 'PASS' : 'FAIL'} | ${pair.safety_pass ? 'PASS' : 'FAIL'} | ${num(pair.baseline_score)} | ${num(pair.candidate_score)} | ${signed(pair.score_delta)} | ${md(pair.decision)} |`);
+  }
+  lines.push('', '## Limitations', '');
+  for (const limitation of report.limitations ?? []) lines.push(`- ${limitation}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+export async function writeProjectGlossaryResults({
+  matrixPath,
+  runsDir,
+  outDir,
+  jsonFile = 'project-glossary-ai-tester-results.json',
+  markdownFile = 'project-glossary-ai-tester-results.md'
+} = {}) {
+  if (!matrixPath || !runsDir || !outDir) throw new Error('matrixPath, runsDir, and outDir are required');
+  log('info', 'report.write.start', { matrix: path.basename(matrixPath) });
+  const matrix = JSON.parse(await readFile(matrixPath, 'utf8'));
+  const traceIndex = await collectProjectGlossaryTraceIndex({ runsDir });
+  const report = buildProjectGlossaryResultsReport({
+    matrix,
+    traceIndex,
+    matrixDir: path.dirname(path.resolve(matrixPath))
+  });
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(outDir, jsonFile), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await writeFile(path.join(outDir, markdownFile), renderProjectGlossaryResultsMarkdown(report), 'utf8');
+  log('info', 'report.write.complete', {
+    outcome: report.outcome,
+    expected_rows: report.summary.expected_rows,
+    executed_rows: report.summary.executed_rows
+  });
+  return report;
+}
+
+function evaluateMatrixCase({ matrix, matrixCase, trace, matrixDir }) {
+  const base = {
+    id: matrixCase.id,
+    pair_id: matrixCase.pair_id,
+    scenario_id: matrixCase.scenario_id,
+    skill: matrixCase.skill,
+    repetition: matrixCase.repetition,
+    condition: matrixCase.condition,
+    settings_fingerprint: matrixCase.settings_fingerprint,
+    trace_status: 'NOT_RUN',
+    ai_tester_pass: false,
+    settings_match: false,
+    fresh_trace: false,
+    terminology_score: 0,
+    canonical_term_hits: 0,
+    canonical_term_total: matrixCase.canonical_terms.length,
+    avoided_term_hits: 0,
+    avoided_term_total: matrixCase.avoided_terms.length,
+    identifiers_preserved: false,
+    missing_identifiers: [...matrixCase.required_identifiers],
+    authority_preserved: false,
+    authority_violations: [],
+    leakage_free: false,
+    duration_seconds: null,
+    turns: null,
+    tool_calls: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_creation_tokens: null,
+    cache_read_tokens: null,
+    total_tokens: null,
+    output_sha256: null,
+    trace_file: null,
+    finished_at: null
+  };
+  if (!trace) return base;
+
+  const freshTrace = isFreshTrace(trace.finished_at, matrix.generated_at);
+  const expectedScenarioPath = matrixDir
+    ? path.resolve(matrixDir, fromPosix(matrixCase.scenario_file))
+    : '';
+  const settingsEvidenceMatch = trace.scenario_description.includes(`settings=${matrixCase.settings_fingerprint}`)
+    || samePath(trace.scenario_path, expectedScenarioPath);
+  const settingsMatch = trace.runtime === matrixCase.runtime
+    && trace.model === matrixCase.model
+    && trace.reasoning === matrixCase.reasoning
+    && settingsEvidenceMatch;
+  const canonicalHits = matrixCase.canonical_terms.filter((term) => includesInsensitive(trace.final_output, term)).length;
+  const avoidedHits = matrixCase.avoided_terms.filter((term) => includesInsensitive(trace.final_output, term)).length;
+  const missingIdentifiers = matrixCase.required_identifiers.filter((identifier) => !trace.final_output.includes(identifier));
+  const authorityViolations = matrixCase.forbidden_authority_claims.filter((claim) => includesInsensitive(trace.final_output, claim));
+  const leakageFree = !trace.final_output.includes(matrixCase.sentinel);
+  const terminologyScore = round(
+    ((canonicalHits + (matrixCase.avoided_terms.length - avoidedHits))
+      / (matrixCase.canonical_terms.length + matrixCase.avoided_terms.length)) * 100
+  );
+  const traceStatus = !freshTrace
+    ? 'STALE'
+    : !settingsMatch
+      ? 'SETTINGS_MISMATCH'
+      : trace.ai_tester_pass
+        ? 'PASS'
+        : 'FAIL';
+
+  return {
+    ...base,
+    trace_status: traceStatus,
+    ai_tester_pass: trace.ai_tester_pass,
+    settings_match: settingsMatch,
+    fresh_trace: freshTrace,
+    terminology_score: terminologyScore,
+    canonical_term_hits: canonicalHits,
+    avoided_term_hits: avoidedHits,
+    identifiers_preserved: missingIdentifiers.length === 0,
+    missing_identifiers: missingIdentifiers,
+    authority_preserved: authorityViolations.length === 0,
+    authority_violations: authorityViolations,
+    leakage_free: leakageFree,
+    duration_seconds: trace.duration_seconds,
+    turns: trace.turns,
+    tool_calls: trace.tool_calls,
+    input_tokens: trace.input_tokens,
+    output_tokens: trace.output_tokens,
+    cache_creation_tokens: trace.cache_creation_tokens,
+    cache_read_tokens: trace.cache_read_tokens,
+    total_tokens: trace.total_tokens,
+    output_sha256: trace.output_sha256,
+    trace_file: trace.trace_file,
+    finished_at: trace.finished_at
+  };
+}
+
+function buildPairResults(rows) {
+  const grouped = new Map();
+  for (const row of rows) {
+    if (!grouped.has(row.pair_id)) grouped.set(row.pair_id, []);
+    grouped.get(row.pair_id).push(row);
+  }
+  return [...grouped.entries()].map(([pairId, pairRows]) => {
+    const baseline = pairRows.find((row) => row.condition === 'baseline_without_glossary');
+    const candidate = pairRows.find((row) => row.condition === 'candidate_with_glossary');
+    const complete = Boolean(
+      baseline
+      && candidate
+      && baseline.trace_status === 'PASS'
+      && candidate.trace_status === 'PASS'
+      && baseline.settings_fingerprint === candidate.settings_fingerprint
+    );
+    const safetyPass = Boolean(
+      complete
+      && baseline.identifiers_preserved
+      && baseline.authority_preserved
+      && baseline.leakage_free
+      && candidate.identifiers_preserved
+      && candidate.authority_preserved
+      && candidate.leakage_free
+    );
+    const baselineScore = baseline?.terminology_score ?? 0;
+    const candidateScore = candidate?.terminology_score ?? 0;
+    const scoreDelta = round(candidateScore - baselineScore);
+    const decision = !complete
+      ? 'inconclusive'
+      : !safetyPass
+        ? 'regressive'
+        : scoreDelta > 0
+          ? 'improved'
+          : scoreDelta < 0
+            ? 'regressive'
+            : 'neutral';
+    return {
+      pair_id: pairId,
+      scenario_id: baseline?.scenario_id ?? candidate?.scenario_id ?? null,
+      repetition: baseline?.repetition ?? candidate?.repetition ?? null,
+      complete,
+      safety_pass: safetyPass,
+      baseline_score: baselineScore,
+      candidate_score: candidateScore,
+      score_delta: scoreDelta,
+      decision
+    };
+  }).sort((left, right) => left.pair_id.localeCompare(right.pair_id));
+}
+
+function decideOutcome({ evidenceComplete, safetyPass, scoreDelta, anySafetyRegression }) {
+  if (!evidenceComplete) return 'inconclusive';
+  if (!safetyPass || anySafetyRegression || scoreDelta < 0) return 'regressive';
+  if (scoreDelta === 0) return 'neutral';
+  return 'benefit_observed';
+}
+
+function aggregateMetrics(rows) {
+  return {
+    rows: rows.length,
+    duration_seconds: round(sum(rows.map((row) => row.duration_seconds))),
+    turns: sum(rows.map((row) => row.turns)),
+    tool_calls: sum(rows.map((row) => row.tool_calls)),
+    input_tokens: sum(rows.map((row) => row.input_tokens)),
+    output_tokens: sum(rows.map((row) => row.output_tokens)),
+    cache_creation_tokens: sum(rows.map((row) => row.cache_creation_tokens)),
+    cache_read_tokens: sum(rows.map((row) => row.cache_read_tokens)),
+    total_tokens: sum(rows.map((row) => row.total_tokens))
+  };
+}
+
+function getScenarioName(record, directoryName, fileName) {
+  if (record.scenario?.name) return String(record.scenario.name);
+  if (directoryName.startsWith('inline_')) return directoryName.slice('inline_'.length);
+  const timestampPart = fileName.match(/__(\d{4}-\d{2}-\d{2}T)/);
+  return timestampPart ? fileName.slice(0, timestampPart.index).replace(/^inline_/, '') : null;
+}
+
+function compareTraceFreshness(left, right) {
+  const leftTime = Date.parse(left.finished_at ?? '');
+  const rightTime = Date.parse(right.finished_at ?? '');
+  if (!Number.isNaN(leftTime) && !Number.isNaN(rightTime) && leftTime !== rightTime) return leftTime - rightTime;
+  return left.trace_file.localeCompare(right.trace_file);
+}
+
+function isFreshTrace(finishedAt, matrixGeneratedAt) {
+  const finished = Date.parse(finishedAt ?? '');
+  const generated = Date.parse(matrixGeneratedAt ?? '');
+  return !Number.isNaN(finished) && !Number.isNaN(generated) && finished >= generated;
+}
+
+function countToolCalls(record) {
+  return asArray(record.turns).reduce((total, turn) => total + asArray(turn.toolCalls).length, 0);
+}
+
+function includesInsensitive(value, fragment) {
+  return String(value).toLocaleLowerCase('en-US').includes(String(fragment).toLocaleLowerCase('en-US'));
+}
+
+function average(values) {
+  return values.length === 0 ? 0 : round(sum(values) / values.length);
+}
+
+function sum(values) {
+  return values.reduce((total, value) => total + number(value), 0);
+}
+
+function number(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function round(value) {
+  return Math.round(number(value) * 10) / 10;
+}
+
+function sha256(value) {
+  return createHash('sha256').update(String(value)).digest('hex');
+}
+
+function md(value) {
+  return String(value ?? '').replaceAll('|', ';').replace(/[\r\n]+/g, ' ');
+}
+
+function num(value) {
+  return Number.isFinite(Number(value)) ? Number(value).toLocaleString('en-US', { maximumFractionDigits: 1 }) : '';
+}
+
+function signed(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return '';
+  return `${parsed > 0 ? '+' : ''}${parsed.toLocaleString('en-US', { maximumFractionDigits: 1 })}`;
+}
+
+function toPosix(value) {
+  return String(value).replaceAll(path.sep, '/');
+}
+
+function fromPosix(value) {
+  return String(value).split('/').join(path.sep);
+}
+
+function samePath(left, right) {
+  if (!left || !right) return false;
+  const normalize = (value) => {
+    const withoutExtendedPrefix = String(value).replace(/^\\\\\?\\/, '');
+    const resolved = path.resolve(withoutExtendedPrefix);
+    return process.platform === 'win32' ? resolved.toLocaleLowerCase('en-US') : resolved;
+  };
+  return normalize(left) === normalize(right);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function log(level, event, details = {}) {
+  const configured = String(process.env.AIF_GLOSSARY_LOG_LEVEL ?? process.env.LOG_LEVEL ?? 'warn').toLowerCase();
+  const threshold = LOG_LEVELS[configured] ?? LOG_LEVELS.warn;
+  if ((LOG_LEVELS[level] ?? LOG_LEVELS.info) < threshold) return;
+  process.stderr.write(`${JSON.stringify({ component: 'project-glossary-ai-tester-report', level, event, ...details })}\n`);
+}
+
+function parseCliArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--matrix') parsed.matrixPath = args[++index];
+    else if (token === '--runs-dir') parsed.runsDir = args[++index];
+    else if (token === '--out') parsed.outDir = args[++index];
+    else if (token === '--json-file') parsed.jsonFile = args[++index];
+    else if (token === '--markdown-file') parsed.markdownFile = args[++index];
+    else if (token === '--json') parsed.json = true;
+    else if (token === '--help' || token === '-h') parsed.help = true;
+    else throw new Error(`Unknown argument: ${token}`);
+  }
+  return parsed;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/project-glossary-ai-tester-results-report.mjs --matrix <file> --runs-dir <dir> --out <dir> [options]',
+    '',
+    'Reads real ai-tester traces and writes sanitised JSON/Markdown paired results.',
+    ''
+  ].join('\n');
+}
+
+async function main() {
+  const parsed = parseCliArgs(process.argv.slice(2));
+  if (parsed.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  const report = await writeProjectGlossaryResults(parsed);
+  const body = {
+    schema: report.schema,
+    run_id: report.run_id,
+    outcome: report.outcome,
+    evidence_complete: report.evidence_complete,
+    benefit_claim_allowed: report.benefit_claim_allowed,
+    expected_rows: report.summary.expected_rows,
+    executed_rows: report.summary.executed_rows,
+    complete_pairs: report.summary.complete_pairs
+  };
+  process.stdout.write(parsed.json ? `${JSON.stringify(body, null, 2)}\n` : `${body.outcome}: ${body.executed_rows}/${body.expected_rows} rows.\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((error) => {
+    log('error', 'report.failed', { message: error instanceof Error ? error.message : String(error) });
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/project-glossary-ai-tester-results-report.test.mjs
+++ b/scripts/project-glossary-ai-tester-results-report.test.mjs
@@ -1,0 +1,215 @@
+// project-glossary-ai-tester-results-report.test.mjs - paired trace evaluator contracts
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  buildProjectGlossaryMatrix,
+  loadProjectGlossaryScenarioCatalog
+} from './project-glossary-ai-tester-matrix.mjs';
+import {
+  buildProjectGlossaryResultsReport,
+  collectProjectGlossaryTraceIndex,
+  normalizeTraceRecord,
+  renderProjectGlossaryResultsMarkdown,
+  writeProjectGlossaryResults
+} from './project-glossary-ai-tester-results-report.mjs';
+
+let tempDir;
+let matrix;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), 'project-glossary-ai-tester-results-'));
+  const catalog = await loadProjectGlossaryScenarioCatalog({ cwd: process.cwd() });
+  matrix = buildProjectGlossaryMatrix({
+    catalog,
+    runId: 'glossary-luna-low-report-test',
+    generatedAt: '2026-07-21T12:00:00.000Z'
+  });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('project glossary trace normalization', () => {
+  it('extracts final output, runner settings, metrics, and a relative trace path', () => {
+    const matrixCase = matrix.cases[0];
+    const record = traceRecord(matrixCase, baselineOutput(matrixCase));
+    const normalized = normalizeTraceRecord(record, {
+      filePath: path.join(tempDir, 'runs', 'inline_case', 'trace.json'),
+      runsDir: path.join(tempDir, 'runs'),
+      directoryName: 'inline_case',
+      fileName: 'trace.json'
+    });
+    assert.equal(normalized.scenario_name, matrixCase.id);
+    assert.equal(normalized.model, 'gpt-5.6-luna');
+    assert.equal(normalized.reasoning, 'low');
+    assert.equal(normalized.scenario_path, '');
+    assert.equal(normalized.total_tokens, 175);
+    assert.equal(normalized.tool_calls, 2);
+    assert.equal(normalized.trace_file, 'inline_case/trace.json');
+    assert.equal(normalized.final_output, baselineOutput(matrixCase));
+    assert.match(normalized.output_sha256, /^[a-f0-9]{64}$/);
+  });
+});
+
+describe('project glossary paired evaluation', () => {
+  it('allows a benefit claim only for complete safe improved pairs', async () => {
+    const traceIndex = await writeCompleteTraceSet({ matrix, runsDir: path.join(tempDir, 'runs') });
+    const report = buildProjectGlossaryResultsReport({ matrix, traceIndex });
+    assert.equal(report.summary.expected_rows, 8);
+    assert.equal(report.summary.executed_rows, 8);
+    assert.equal(report.summary.complete_pairs, 4);
+    assert.equal(report.evidence_complete, true);
+    assert.equal(report.safety_pass, true);
+    assert.equal(report.outcome, 'benefit_observed');
+    assert.equal(report.benefit_claim_allowed, true);
+    assert.ok(report.summary.candidate_terminology_score_average > report.summary.baseline_terminology_score_average);
+    assert.ok(report.pairs.every((pair) => pair.decision === 'improved'));
+  });
+
+  it('rejects NOT_RUN, stale, and settings-mismatched rows as evidence', async () => {
+    const runsDir = path.join(tempDir, 'runs');
+    await writeCompleteTraceSet({ matrix, runsDir });
+    await rm(path.join(runsDir, `inline_${matrix.cases[0].id}`), { recursive: true, force: true });
+    const staleCase = matrix.cases[1];
+    await writeTrace(runsDir, staleCase, candidateOutput(staleCase), { finishedAt: '2026-07-21T11:00:00.000Z' });
+    const mismatchCase = matrix.cases[2];
+    await writeTrace(runsDir, mismatchCase, baselineOutput(mismatchCase), { model: 'gpt-5.6-sol' });
+    const traceIndex = await collectProjectGlossaryTraceIndex({ runsDir });
+    const report = buildProjectGlossaryResultsReport({ matrix, traceIndex });
+    assert.equal(report.evidence_complete, false);
+    assert.equal(report.outcome, 'inconclusive');
+    assert.equal(report.benefit_claim_allowed, false);
+    assert.ok(report.rows.some((row) => row.trace_status === 'NOT_RUN'));
+    assert.ok(report.rows.some((row) => row.trace_status === 'STALE'));
+    assert.ok(report.rows.some((row) => row.trace_status === 'SETTINGS_MISMATCH'));
+  });
+
+  it('accepts ai-tester v2 traces that identify generated scenario files without embedding descriptions', async () => {
+    const runsDir = path.join(tempDir, 'runs');
+    for (const matrixCase of matrix.cases) {
+      const output = matrixCase.condition === 'candidate_with_glossary'
+        ? candidateOutput(matrixCase)
+        : baselineOutput(matrixCase);
+      await writeTrace(runsDir, matrixCase, output, {
+        omitDescription: true,
+        scenarioPath: path.resolve(tempDir, matrixCase.scenario_file)
+      });
+    }
+    const traceIndex = await collectProjectGlossaryTraceIndex({ runsDir });
+    const report = buildProjectGlossaryResultsReport({ matrix, traceIndex, matrixDir: tempDir });
+    assert.equal(report.summary.settings_mismatch_rows, 0);
+    assert.equal(report.evidence_complete, true);
+    assert.equal(report.outcome, 'benefit_observed');
+  });
+
+  it('records identifier and authority regressions without a benefit claim', async () => {
+    const runsDir = path.join(tempDir, 'runs');
+    await writeCompleteTraceSet({ matrix, runsDir });
+    const candidate = matrix.cases.find((item) => item.condition === 'candidate_with_glossary');
+    await writeTrace(
+      runsDir,
+      candidate,
+      'Dispatch Relay uses the Recovery Window. A new requirement says we must rename everything. evaluation_complete'
+    );
+    const traceIndex = await collectProjectGlossaryTraceIndex({ runsDir });
+    const report = buildProjectGlossaryResultsReport({ matrix, traceIndex });
+    const row = report.rows.find((item) => item.id === candidate.id);
+    assert.equal(row.identifiers_preserved, false);
+    assert.equal(row.authority_preserved, false);
+    assert.equal(report.outcome, 'regressive');
+    assert.equal(report.benefit_claim_allowed, false);
+  });
+
+  it('keeps final outputs, sentinel values, glossary body, and absolute paths out of durable reports', async () => {
+    const runsDir = path.join(tempDir, 'runs');
+    const outDir = path.join(tempDir, 'report');
+    await writeCompleteTraceSet({ matrix, runsDir });
+    await writeFile(path.join(tempDir, 'matrix.json'), `${JSON.stringify(matrix)}\n`, 'utf8');
+    const report = await writeProjectGlossaryResults({
+      matrixPath: path.join(tempDir, 'matrix.json'),
+      runsDir,
+      outDir
+    });
+    const json = await readFile(path.join(outDir, 'project-glossary-ai-tester-results.json'), 'utf8');
+    const markdown = await readFile(path.join(outDir, 'project-glossary-ai-tester-results.md'), 'utf8');
+    assert.equal(report.outcome, 'benefit_observed');
+    assert.doesNotMatch(json, /GLOSSARY_SENTINEL_127|## Language|## Avoid|A new requirement/);
+    assert.doesNotMatch(json, /[A-Za-z]:\\Users\\/);
+    assert.doesNotMatch(markdown, /GLOSSARY_SENTINEL_127|## Language|## Avoid/);
+    assert.match(markdown, /Candidate terminology score/);
+    assert.match(markdown, /gpt-5\.6-luna/);
+  });
+
+  it('renders a concise metric and limitation report without model prose', async () => {
+    const traceIndex = await writeCompleteTraceSet({ matrix, runsDir: path.join(tempDir, 'runs') });
+    const report = buildProjectGlossaryResultsReport({ matrix, traceIndex });
+    const markdown = renderProjectGlossaryResultsMarkdown(report);
+    assert.match(markdown, /## Rows/);
+    assert.match(markdown, /## Pairs/);
+    assert.match(markdown, /## Limitations/);
+    assert.doesNotMatch(markdown, /The worker invokes/);
+  });
+});
+
+async function writeCompleteTraceSet({ matrix: sourceMatrix, runsDir }) {
+  for (const matrixCase of sourceMatrix.cases) {
+    const output = matrixCase.condition === 'candidate_with_glossary'
+      ? candidateOutput(matrixCase)
+      : baselineOutput(matrixCase);
+    await writeTrace(runsDir, matrixCase, output);
+  }
+  return collectProjectGlossaryTraceIndex({ runsDir });
+}
+
+async function writeTrace(runsDir, matrixCase, output, overrides = {}) {
+  const directory = path.join(runsDir, `inline_${matrixCase.id}`);
+  await mkdir(directory, { recursive: true });
+  const record = traceRecord(matrixCase, output, overrides);
+  await writeFile(path.join(directory, `${matrixCase.id}__2026-07-21T12-10-00Z__test.json`), `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+}
+
+function traceRecord(matrixCase, output, overrides = {}) {
+  return {
+    schemaVersion: 2,
+    scenario: {
+      name: matrixCase.id,
+      ...(!overrides.omitDescription ? {
+        description: overrides.description ?? `project-glossary condition=${matrixCase.condition} repetition=${matrixCase.repetition} settings=${matrixCase.settings_fingerprint}`
+      } : {}),
+      ...(overrides.scenarioPath ? { path: overrides.scenarioPath } : {})
+    },
+    runner: {
+      runtime: overrides.runtime ?? matrixCase.runtime,
+      model: overrides.model ?? matrixCase.model,
+      reasoning: overrides.reasoning ?? matrixCase.reasoning,
+      finishedAt: overrides.finishedAt ?? '2026-07-21T12:10:00.000Z',
+      durationMs: 1250,
+      turnsUsed: 3
+    },
+    turns: [{ toolCalls: [{ name: 'Bash' }, { name: 'Read' }] }],
+    finalOutput: output,
+    toolCallSummary: { total: 2 },
+    scoring: { overallPass: overrides.overallPass ?? true },
+    cost: {
+      inputTokens: 100,
+      outputTokens: 25,
+      cacheCreationTokens: 10,
+      cacheReadTokens: 40
+    }
+  };
+}
+
+function baselineOutput(matrixCase) {
+  const identifiers = matrixCase.required_identifiers.join(', ');
+  return `The worker uses a retry timeout. Preserve ${identifiers}. evaluation_complete`;
+}
+
+function candidateOutput(matrixCase) {
+  const identifiers = matrixCase.required_identifiers.join(', ');
+  return `The Dispatch Relay uses the Recovery Window. Preserve ${identifiers}. evaluation_complete`;
+}

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aif-analyze
 description: Bootstrap project context. Resolves localization and stack, creates/updates config.yaml and rules/base.md, then checks DESCRIPTION and guides core skill execution.
-version: 0.7.0
+version: 0.8.0
 author: ichi
 ---
 
@@ -15,6 +15,7 @@ Bootstrap project context for AI Factory. This skill prepares configuration and 
 |----------|-------|------------|
 | `config.yaml` | **aif-analyze** | Creates/updates |
 | `rules/base.md` | **aif-analyze** | Creates if missing |
+| `paths.context` / project glossary | **aif-analyze** | Registers the path; creates or patch-updates only with explicit user opt-in |
 | `DESCRIPTION.md` | core `aif` | Checks existence, suggests the selected runtime invocation (`$aif` for `codex-app`, `/aif` for slash-command runtimes) if missing |
 | `ARCHITECTURE.md` | core `aif-architecture` | Initiates the selected runtime invocation based on workflow flag |
 | `ROADMAP.md` | core `aif-roadmap` | Initiates the selected runtime invocation based on workflow flag |
@@ -311,6 +312,7 @@ aifhub:
 
 ```yaml
 paths:
+  context: CONTEXT.md
   plans: openspec/changes
   specs: openspec/specs
   state: .ai-factory/state
@@ -318,10 +320,23 @@ paths:
   generated_rules: .ai-factory/rules/generated
 ```
 
-  - Preserve `paths.description`, `paths.architecture`, `paths.roadmap`, `paths.research`, and `paths.rules` unless they are missing.
+  - Preserve `paths.description`, `paths.architecture`, `paths.context`, `paths.roadmap`, `paths.research`, and `paths.rules` unless they are missing.
   - Do not install OpenSpec skills, slash commands, or dependencies.
 
 Use [references/config-template.yaml](references/config-template.yaml) as reference.
+
+### Step 3.25: Optional Project Glossary
+
+`/aif-analyze` is the only AIFHub command allowed to create or update the project glossary. Other AIFHub commands and packaged agents are read-only consumers through the shared glossary policy.
+
+- Register or preserve `paths.context`; use `CONTEXT.md` when the key is missing. The configured value must be a normalized project-relative file path.
+- Reject absolute paths, URI-like values, paths that escape the project root, and directory targets. Do not read or write any rejected target.
+- On rejection, emit one sanitized warning with the rejection reason. Continue without glossary context. Do not include an external absolute path or any glossary contents.
+- Missing glossary files are a normal non-fatal state. Do not create an empty placeholder only because `paths.context` exists.
+- Create the glossary only after explicit user opt-in and only when repository evidence provides concrete source-grounded terms. If no concrete term is available, report `skipped`.
+- For an existing glossary, require an explicit update request or the user accepts a proposed glossary update. Use a patch-style update: preserve manual entries and unknown headings, and change only the accepted terminology entries.
+- Use [references/project-glossary-template.md](references/project-glossary-template.md) as the allowed lexical shape. Do not place requirements, project rules, architecture decisions, task notes, provider output, or scratch notes in the glossary.
+- In the final handoff, report the glossary status as `created`, `updated`, `preserved`, or `skipped` and include only its project-relative path. Never include glossary contents in the handoff.
 
 ### Step 3.5: Detect OpenSpec Capabilities
 
@@ -388,6 +403,8 @@ openspec:
 
 ### Step 5: Ensure Directories Exist
 
+- Create only directory-valued configured paths. File-valued paths such as `paths.description`, `paths.architecture`, `paths.context`, `paths.roadmap`, and `paths.research` must never be created as directories.
+
 - In legacy `ai-factory` mode, create directories from config paths if missing:
   - `paths.plans` (typically `.ai-factory/plans`)
   - `paths.specs` (typically `.ai-factory/specs`)
@@ -427,6 +444,7 @@ openspec init --tools none
 - Report the resolved bootstrap mode.
 - Report the bootstrap mode selection source: existing config, explicit user request, first-bootstrap answer, or autonomous default.
 - Report whether config values were created or preserved.
+- Report the optional glossary status as `created`, `updated`, `preserved`, or `skipped` plus its project-relative path; never report glossary contents.
 - Report project labels from `ai-factory aifhub-memory-tools labels --from-project --json` first: languages, volume, complexity, repo shape, artifact mode, project shape, task signals, matched dimension signals, and short evidence for the labels that affected recommendations.
 - Report optional local tool recommendations from explicit-label `ai-factory aifhub-memory-tools recommend --command aif-analyze ... --json` output when the installed wrapper is available, or from source-tree metadata only when running inside the AIFHub extension repository. Include baseline `rg`, recommended tools with availability/read scope/purge path/skill usefulness, and not-recommended tools with label-based reasons such as `codex-mem`, `eagle-mem`, tools forbidden for the skill, or tools without exact skill+label evidence. Ask which recommendations to enable and write accepted tool ids to `utilities.context_tools.enabled`. If metadata is unavailable, report a degraded note and continue.
 - Report that follow-on skills select their own usable subset with `ai-factory aifhub-memory-tools select --from-project --command <skill> --json`; enabled config entries are not permission to use a tool unless they appear in `selected_tools`.
@@ -485,6 +503,7 @@ aifhub:
 paths:
   description: .ai-factory/DESCRIPTION.md
   architecture: .ai-factory/ARCHITECTURE.md
+  context: CONTEXT.md
   roadmap: .ai-factory/ROADMAP.md
   research: .ai-factory/RESEARCH.md
   plans: .ai-factory/plans
@@ -526,6 +545,7 @@ aifhub:
 paths:
   description: .ai-factory/DESCRIPTION.md
   architecture: .ai-factory/ARCHITECTURE.md
+  context: CONTEXT.md
   roadmap: .ai-factory/ROADMAP.md
   research: .ai-factory/RESEARCH.md
   plans: openspec/changes
@@ -552,7 +572,7 @@ paths:
 - Follow workflow flags to suggest or initiate the selected runtime invocation for `aif-architecture` and `aif-roadmap`.
 - Create `rules/base.md` with project-specific rules, not generic advice.
 - Do NOT create optional area rules — planning owns those when needed.
-- Ensure all directories from config paths exist.
+- Ensure all directory-valued config paths exist; never create file-valued paths such as `paths.context` as directories.
 - Keep the result concise and repository-specific.
 
 ## Example Requests

--- a/skills/aif-analyze/references/config-template.yaml
+++ b/skills/aif-analyze/references/config-template.yaml
@@ -36,6 +36,8 @@ paths:
   # Core AI Factory artifacts (owned by core /aif skills)
   description: .ai-factory/DESCRIPTION.md
   architecture: .ai-factory/ARCHITECTURE.md
+  # Optional project glossary; the file is created only with explicit opt-in
+  context: CONTEXT.md
   roadmap: .ai-factory/ROADMAP.md
   research: .ai-factory/RESEARCH.md
   

--- a/skills/aif-analyze/references/project-glossary-template.md
+++ b/skills/aif-analyze/references/project-glossary-template.md
@@ -1,0 +1,20 @@
+# Project Glossary
+
+> Use only concise, source-grounded terminology.
+> Do not store requirements, rules, architecture decisions, task notes, or scratch notes here.
+
+## Language
+
+- **Canonical term** — concise project-grounded definition.
+
+## Avoid
+
+- Avoid **synonym**; use **Canonical term**.
+
+## Relationships
+
+- **Term A** contains or depends on **Term B**.
+
+## Flagged Ambiguities
+
+- **Word** may mean more than one project concept; confirm the intended context before using it.

--- a/skills/aif-mode/SKILL.md
+++ b/skills/aif-mode/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 allowed-tools: Read Write Grep Glob Bash(ai-factory aifhub-mode *) Bash(ai-factory aifhub-migrate-legacy-plans *) Bash(npm run validate) Bash(npm test)
 metadata:
   author: aifhub-extension
-  version: "1.0.0"
+  version: "1.1.0"
   category: workflow
 ---
 
@@ -90,12 +90,15 @@ aifhub:
       openspecStatus: true
 
 paths:
+  context: CONTEXT.md
   plans: openspec/changes
   specs: openspec/specs
   state: .ai-factory/state
   qa: .ai-factory/qa
   generated_rules: .ai-factory/rules/generated
 ```
+
+`paths.context` is protocol-neutral. Render `CONTEXT.md` when the key is missing, preserve a custom project-relative value, and never create or inspect the optional glossary file during mode operations.
 
 If legacy plans exist, suggest these commands unless `--yes` is explicitly passed:
 
@@ -106,7 +109,7 @@ ai-factory aifhub-migrate-legacy-plans --all
 
 ### `ai-factory`
 
-Switch to legacy AI Factory-only mode and ensure `.ai-factory/plans`, `.ai-factory/specs`, and `.ai-factory/rules`. Never delete `openspec/`.
+Switch to legacy AI Factory-only mode and ensure `.ai-factory/plans`, `.ai-factory/specs`, and `.ai-factory/rules`. Preserve `paths.context` (default `CONTEXT.md`) without creating or inspecting the optional glossary. Never delete `openspec/`.
 
 When `--export-openspec` is passed, export compatibility artifacts from OpenSpec changes into legacy plan files. This is a compatibility export, not a migration, because OpenSpec delta structure can be lossy when flattened.
 
@@ -121,7 +124,7 @@ Refresh derived or compatibility artifacts without changing mode.
 
 ### `doctor`
 
-Read-only diagnostics for config marker, configured paths, OpenSpec CLI capability, Node compatibility, active change ambiguity, generated rules, coverage matrix status, legacy artifacts in OpenSpec-native mode, OpenSpec validation when available, and archive readiness for `/aif-done`.
+Read-only diagnostics for config marker, required configured directories, OpenSpec CLI capability, Node compatibility, active change ambiguity, generated rules, coverage matrix status, legacy artifacts in OpenSpec-native mode, OpenSpec validation when available, and archive readiness for `/aif-done`. Optional `paths.context` file states are not doctor diagnostics.
 
 AI Factory 2.12+ also exposes an optional read-only artifact audit bridge:
 

--- a/skills/aif-mode/references/MODES.md
+++ b/skills/aif-mode/references/MODES.md
@@ -34,6 +34,7 @@ aifhub:
       openspecStatus: true
 
 paths:
+  context: CONTEXT.md
   plans: openspec/changes
   specs: openspec/specs
   state: .ai-factory/state
@@ -50,6 +51,8 @@ utilities:
 ```
 
 Canonical requirements and change intent live under `openspec/`. Runtime state, QA evidence, migration reports, and generated rules live under `.ai-factory/`.
+
+`paths.context` is protocol-neutral optional context. Preserve a custom project-relative value; do not create or validate the glossary file.
 
 Ensure these paths:
 
@@ -73,6 +76,7 @@ aifhub:
   artifactProtocol: ai-factory
 
 paths:
+  context: CONTEXT.md
   plans: .ai-factory/plans
   specs: .ai-factory/specs
   rules: .ai-factory/rules
@@ -87,6 +91,8 @@ utilities:
 ```
 
 Legacy mode uses the companion plan model:
+
+`paths.context` remains protocol-neutral and optional in this profile. Its default is `CONTEXT.md`, and mode operations do not create or inspect the file.
 
 ```text
 .ai-factory/plans/<id>.md

--- a/skills/shared/LANGUAGE-POLICY.md
+++ b/skills/shared/LANGUAGE-POLICY.md
@@ -7,6 +7,7 @@ Apply this policy before producing user-facing responses or generated artifacts 
 - Read `.ai-factory/config.yaml` first when it is available.
 - Treat `language.ui`, `language.artifacts`, and `language.technical_terms` as project-level preferences, not global user memory.
 - Do not infer or persist project language from OS locale, repository programming language, or the current conversation alone.
+- After config resolution, read and follow `skills/shared/PROJECT-GLOSSARY.md` for optional project terminology. That shared contract does not expand artifact ownership or make glossary loading mandatory.
 
 ## Output Rules
 

--- a/skills/shared/PROJECT-GLOSSARY.md
+++ b/skills/shared/PROJECT-GLOSSARY.md
@@ -1,0 +1,49 @@
+# Shared Project Glossary Policy
+
+Apply this policy after `.ai-factory/config.yaml` and `skills/shared/LANGUAGE-POLICY.md` have been resolved. The project glossary is optional terminology context, not a canonical project artifact or completion prerequisite.
+
+## Resolution And Loading
+
+1. Read the non-empty `paths.context` value from `.ai-factory/config.yaml`; if the key is absent or empty, use `CONTEXT.md`.
+2. Accept only a normalized project-relative file path that remains inside the project root. Treat absolute paths, URI-like values, escaping paths, and directory targets as `unsafe`; never read them.
+3. Classify the result without exposing file contents:
+   - `present`: the file is readable and non-empty; load it best-effort.
+   - `missing`: the file does not exist; continue normally without a diagnostic.
+   - `empty`: the file has no substantive content; continue normally without glossary context.
+   - `unreadable`: the safe file cannot be read; continue and emit one bounded diagnostic with the project-relative path and reason.
+   - `unsafe`: path validation failed; continue and emit one bounded diagnostic with the reason, without printing an external absolute path.
+4. Never copy the glossary body into logs, runtime traces, QA evidence, reports, or diagnostics.
+
+## Ownership
+
+- `/aif-analyze` is the only AIFHub command allowed to create or update the glossary, and only under its explicit opt-in lifecycle contract.
+- All other AIFHub skills, injections, and packaged agents are read-only consumers. They must not create, patch, format, move, or delete the glossary.
+- A consumer may report a candidate term in an artifact it already owns and recommend `/aif-analyze` for a durable glossary update.
+
+## Lexical Scope
+
+- Apply preferred glossary terms only to human-readable prose: explanations, summaries, headings, labels, and generated documentation.
+- Preserve code and API identifiers exactly, including commands, filenames, paths, JSON/YAML keys, schema fields, package names, exported symbols, and public wire values.
+- Do not use the glossary to infer behavior, requirements, permissions, architecture, task status, or acceptance criteria.
+
+## Authority And Precedence
+
+Resolve material conflicts in this order:
+
+1. source code, public APIs, schemas, and executable tests, together with verifiable QA facts;
+2. canonical OpenSpec specs and active change requirements;
+3. project rules and accepted architecture decisions;
+4. `DESCRIPTION.md` and `ARCHITECTURE.md` as descriptive context;
+5. the glossary as preferred lexical context.
+
+When glossary terminology disagrees with a higher-authority source, follow that source, preserve its identifiers, and emit at most one concise terminology-drift warning. Do not automatically edit either side of the conflict.
+
+## Protected Artifact Boundary
+
+- Do not add glossary contents to canonical OpenSpec artifacts unless the user explicitly authors the term as part of the requirement being changed.
+- Do not use the glossary in generated-rule inputs, source fingerprints, QA schemas or evidence, runtime traces, provider stores, status checks, doctor checks, verification gates, or done-readiness decisions.
+- Do not recursively load files referenced by the glossary and do not import source, OpenSpec, provider output, or runtime state into it.
+
+## Deferred Knowledge Formats
+
+OKF is deferred. Introducing Open Knowledge Format parsing, schemas, conformance, or knowledge-store infrastructure requires a separate evidence-backed OpenSpec change and architecture decision.


### PR DESCRIPTION
## Summary

- add safe, optional `paths.context` resolution with `CONTEXT.md` as the default project glossary
- keep `/aif-analyze` as the explicit opt-in owner while all other workflows consume glossary terminology read-only
- document the authority boundary, degraded behavior, ADR decision, and deferred OKF scope
- add paired Luna 5.6 low-reasoning ai-tester matrix and durable report tooling

## Why

Issue #127 identified a gap in consistent project terminology. This change adds a lightweight optional glossary without making it a canonical requirement source or mixing it into OpenSpec, generated rules, runtime traces, or QA gates. OKF remains deferred pending a separate evidence-backed decision.

Closes #127

## Validation

- `npm test` — 541/541 tests, 92 suites
- `npm run validate` — passed
- focused glossary/config/prompt/docs tests — 110/110 tests, 12 suites
- `openspec validate add-optional-project-glossary-context-issue-127 --strict` — passed
- `openspec validate --all --strict` — 33/33 passed
- paired ai-tester evidence — Luna 5.6 low reasoning, 8/8 traces, 4/4 complete pairs, 4/4 safety pairs
- `git diff --check` — passed