### PR TITLE
Fix installed-project finalization and OpenSpec CLI resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@
 ## [В разработке]
 
 ### Добавлено
+- Установленная команда `ai-factory aifhub-done-finalizer --change <change-id> --json` для bounded OpenSpec finalization без project-root helper scripts; публичный parser поддерживает только `--change`, `--skip-specs`, `--record-dirty-state` и `--json`, а коды выхода `0`/`1`/`2` разделяют success/warn, policy blocker и invalid/unresolved/unexpected command failure.
 - Optional session context optimization service: `scripts/context-dedup.mjs`, wrapper command `ai-factory aifhub-context-dedup` и MCP tools `read_file_deduplicated`, `context_dedup_status`, `context_dedup_purge`. `aifhub.contextDedup.mode` выбирает `off | aifhub | sqz`; legacy `enabled` остаётся read-compatible. `sqz` запускается только как явно установленный user-owned executable через bounded `compress --no-cache`, exact repeats обслуживает AIFHub session ledger, state-dependent provider output fail-open отклоняется, а protected validation artifacts всегда отдаются полностью.
 - Детерминированный offline replay-харнесс `scripts/context-dedup-benchmark.mjs` для сравнения трёх режимов: baseline без dedup, собственный сервис и bounded raw-stdin external adapter с отдельными compression/delta/reference метриками.
 - Research по external candidate: `docs/memory-tools-research/sqz.md`, трёхстороннее сравнение в `docs/memory-tools-research/sqz-benchmark-results.md` и `ai-tester` matrix на `gpt-5.6-luna` с reasoning `low` (12 rows: baseline `4/4`, AIFHub `4/4`, безопасный `sqz --no-cache` runtime `4/4`; исторический stateful SQZ regression сохранён отдельно как `3/4`).
 - Изолированный fail-closed `ai-tester` harness для issue `#134`: 18-row matrix для `baseline`, MCP-only и Codex plugin на `context-mode 1.0.169` с provenance, authorization, privacy, lifecycle, purge, cleanup и session-continuity gates, а также sanitized append-only evidence.
 
 ### Изменено
+- OpenSpec CLI теперь детерминированно выбирается как explicit non-empty `options.command` -> project-local `node_modules/.bin/openspec(.cmd)` -> `PATH`; selected explicit/local candidate не получает silent fallback, а diagnostics публикуют только safe command/source без auto-install, `npx`, parent-project search или private absolute paths.
 - Recommendation для `context-mode` уточнена по authorized live evaluation: MCP-only остаётся `manual_helper_only` только для >1 MiB truncating output с mandatory purge и без доказанной экономии tokens; tested Codex plugin nested-shell path получает `avoid`, session continuity — `NOT_RUN(resume_driver_parity_unavailable)`, а normal AIFHub commands по-прежнему не выполняют auto-install, MCP registration или hook trust.
 - Reviewed AI Factory baseline обновлён до `2.17.0` при сохранении compatibility range `>=2.11.0 <3.0.0`; полный `2.15.0 -> 2.16.0 -> 2.17.0` audit включает planning, fix, QA, MCP, Control Flow и reviewed no-op adaptations.
 - OpenSpec-native planning сохраняет immutable `## Original Request`, а revision-bound `## Research Context` предупреждает `WARN [research-drift]` без silent scope rebase.
@@ -28,6 +30,7 @@
 - `scripts/validate-extension.mjs` validates `extension.json` against the local synced copy of the upstream AI Factory extension schema.
 
 ### Исправлено
+- OpenSpec-native finalization установленного проекта больше не зависит от отсутствующего root `scripts/openspec-done-finalizer.mjs`: manifest wrapper запускает extension-local module, сохраняет fail-closed readiness/archive policy и возвращает whitelist-based human/JSON output.
 - `/aif-mode sync` в OpenSpec-native mode теперь обновляет `.ai-factory/rules/generated/openspec-base.md` даже после archive, когда активных changes больше нет, и пропускает change-specific rules/validation без ошибки.
 - `/aif-mode sync --all` больше не падает только из-за активных migrated/docs-only changes без delta specs; такие changes помечаются `no-delta-specs`, а changes с delta specs продолжают проходить sync validation.
 - Session context dedup считает net savings после стоимости replay, не заменяет короткий content более длинным replay и публикует `observedBytes`/`servedBytes`. SQZ benchmark adapter больше не помечает unchanged `Fresh` output как compression; отчёт разделяет exact-repeat, first-read, delta, protected-policy и failed-session savings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Изменено
 - OpenSpec CLI теперь детерминированно выбирается как explicit non-empty `options.command` -> project-local `node_modules/.bin/openspec(.cmd)` -> `PATH`; selected explicit/local candidate не получает silent fallback, а diagnostics публикуют только safe command/source без auto-install, `npx`, parent-project search или private absolute paths.
+- `/aif-analyze` теперь сравнивает supported selected OpenSpec CLI с последней reviewed stable версией `1.8.0`: устаревшая CLI сохраняет capabilities, но получает неблокирующую рекомендацию обновить user-owned project-local/PATH/explicit installation без automatic install/update или package-manager guessing.
 - Recommendation для `context-mode` уточнена по authorized live evaluation: MCP-only остаётся `manual_helper_only` только для >1 MiB truncating output с mandatory purge и без доказанной экономии tokens; tested Codex plugin nested-shell path получает `avoid`, session continuity — `NOT_RUN(resume_driver_parity_unavailable)`, а normal AIFHub commands по-прежнему не выполняют auto-install, MCP registration или hook trust.
 - Reviewed AI Factory baseline обновлён до `2.17.0` при сохранении compatibility range `>=2.11.0 <3.0.0`; полный `2.15.0 -> 2.16.0 -> 2.17.0` audit включает planning, fix, QA, MCP, Control Flow и reviewed no-op adaptations.
 - OpenSpec-native planning сохраняет immutable `## Original Request`, а revision-bound `## Research Context` предупреждает `WARN [research-drift]` без silent scope rebase.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-The reviewed OpenSpec baseline is OpenSpec `1.6.0`, replayed sequentially from baseline `1.3.1` and including prerelease `1.6.0-beta.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
+The reviewed OpenSpec baseline is OpenSpec `1.7.0`, replayed sequentially from baseline `1.3.1` and including prerelease `1.6.0-beta.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
@@ -354,7 +354,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.6.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.7.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-The reviewed OpenSpec baseline is OpenSpec `1.4.0`, replayed sequentially from baseline `1.3.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
+The reviewed OpenSpec baseline is OpenSpec `1.4.1`, replayed sequentially from baseline `1.3.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
@@ -354,7 +354,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Installed projects can run the same bounded finalizer directly through the stabl
 ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
+Omitting `--change` delegates to the active-change resolver: exactly one resolvable active change may be selected, while missing or ambiguous scope exits with code `2` before finalization. Automation should always pass an explicit `--change <change-id>`.
+
 Add `--skip-specs` only for docs/tooling-only work. The wrapper returns exit `0` after successful or policy-accepted warning finalization, `1` for a resolved readiness/archive blocker, and `2` for invalid arguments, unresolved or ambiguous scope, or an unexpected command failure. Do not run extension-internal `scripts/openspec-done-finalizer.mjs` from the project root or through an installed-extension path.
 
 A dirty workspace is blocking by default before `/aif-done`. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` when the current dirty state should be recorded in final QA evidence before archive.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-The reviewed OpenSpec baseline is OpenSpec `1.7.0`, replayed sequentially from baseline `1.3.1` and including prerelease `1.6.0-beta.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
+The reviewed OpenSpec baseline is OpenSpec `1.8.0`, replayed sequentially from baseline `1.3.1` and including prerelease `1.6.0-beta.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-The reviewed OpenSpec baseline is OpenSpec `1.4.1`, while the compatible CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the OpenSpec 1.4.1 reviewed baseline, `openspec update` boundary, and adapter-only ownership notes.
+The reviewed OpenSpec baseline is OpenSpec `1.4.0`, replayed sequentially from baseline `1.3.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
@@ -354,7 +354,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-The reviewed OpenSpec baseline is OpenSpec `1.5.0`, replayed sequentially from baseline `1.3.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
+The reviewed OpenSpec baseline is OpenSpec `1.6.0`, replayed sequentially from baseline `1.3.1` and including prerelease `1.6.0-beta.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
@@ -354,7 +354,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.5.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.6.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,15 @@ OpenSpec validation overlay:
 
 `/aif-done` finalizes the OpenSpec lifecycle. It archives the accepted OpenSpec change through the OpenSpec CLI when archive is required and writes final evidence under `.ai-factory/qa/<change-id>/` plus final summaries under `.ai-factory/state/<change-id>/`.
 
-A dirty workspace is blocking by default before `/aif-done`. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` when the current dirty state should be recorded in final QA evidence before archive.
+Installed projects can run the same bounded finalizer directly through the stable extension command:
+
+```bash
+ai-factory aifhub-done-finalizer --change <change-id> --json
+```
+
+Add `--skip-specs` only for docs/tooling-only work. The wrapper returns exit `0` after successful or policy-accepted warning finalization, `1` for a resolved readiness/archive blocker, and `2` for invalid arguments, unresolved or ambiguous scope, or an unexpected command failure. Do not run extension-internal `scripts/openspec-done-finalizer.mjs` from the project root or through an installed-extension path.
+
+A dirty workspace is blocking by default before `/aif-done`. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` when the current dirty state should be recorded in final QA evidence before archive.
 
 It does not replace `/aif-commit`. After `/aif-done`, run `/aif-commit` or your normal git workflow to commit implementation changes, OpenSpec archive/spec changes, QA evidence, and final summaries.
 
@@ -279,6 +287,8 @@ The reviewed OpenSpec baseline is OpenSpec `1.4.1`, while the compatible CLI ran
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
+For each OpenSpec operation, the shared resolver selects exactly one CLI source in this order: an explicit non-empty extension API `options.command`, project-local `node_modules/.bin/openspec` (`openspec.cmd` on Windows), then `openspec` from `PATH`. An explicit or project-local selection is authoritative: a failure never silently falls through to another installation. AIFHub does not use `npx`, search parent projects, download, or auto-install OpenSpec. Diagnostics expose only the bounded command plus `explicit`, `project-local`, or `path` source.
+
 If the OpenSpec CLI is present but outside `>=1.3.1 <2.0.0`, update or reinstall the CLI before relying on validation/archive. The bootstrap still reports this as degraded capability rather than an install failure.
 
 OpenSpec CLI integration is adapter-only: users keep calling `/aif-plan`, `/aif-improve`, `/aif-implement`, `/aif-verify`, `/aif-done`, and `/aif-mode`; the extension never installs OpenSpec command skills.
@@ -333,7 +343,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | Ambiguous active change | Pass an explicit `<change-id>` or update `.ai-factory/state/current.yaml`. |
 | Missing or stale generated rules | Regenerate derived rules from OpenSpec specs before relying on rules guidance. |
 | Missing or stale coverage | Rerun `/aif-verify <change-id>` to refresh `.ai-factory/qa/<change-id>/coverage.json` before `/aif-done`. |
-| Dirty working tree before `/aif-done` | Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` to record the dirty workspace in final QA evidence before archive. |
+| Dirty working tree before `/aif-done` | Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` to record the dirty workspace in final QA evidence before archive. |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.7.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec `1.8.0` reviewed baseline from `1.3.1`, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ OpenSpec is optional for extension install and AI Factory-only workflows.
 | OpenSpec CLI runtime | Node `>=20.19.0` |
 | OpenSpec skills/commands | Not installed by this extension |
 
-The reviewed OpenSpec baseline is OpenSpec `1.4.1`, replayed sequentially from baseline `1.3.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
+The reviewed OpenSpec baseline is OpenSpec `1.5.0`, replayed sequentially from baseline `1.3.1`, while the compatible stable CLI range remains `>=1.3.1 <2.0.0`. See [OpenSpec Compatibility](docs/openspec-compatibility.md) for the reviewed-release ledger and adapter-only ownership notes.
 
 When the OpenSpec CLI is missing or unsupported, OpenSpec-aware commands report degraded validate/archive capabilities. Planning and filesystem-based context loading can continue, but archive-required `/aif-done` fails until a compatible CLI is available.
 
@@ -354,7 +354,7 @@ Switching to AI Factory-only mode updates the legacy path profile and preserves 
 | [Context Providers](docs/context-providers.md) | Optional Graphify and Context7 provider guidance, reviewed-note paths, degraded behavior, and user-owned setup boundaries |
 | [Memory Tool Recommendations](docs/memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations and installed wrapper commands |
 | [Context Loading Policy](docs/context-loading-policy.md) | Consumer context, Optional Project Glossary, optional provider context, GitHub-aware roadmap evidence, command ownership, upstream utility boundaries, and legacy boundaries |
-| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.4.1 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
+| [OpenSpec Compatibility](docs/openspec-compatibility.md) | Optional CLI adapter policy, OpenSpec 1.5.0 reviewed baseline from 1.3.1, AI Factory 2.17 planning/fix/QA/MCP/Control Flow adaptations, reviewed no-ops, archive boundary, and capability flags |
 | [OpenSpec Artifact Validation](docs/openspec-validation.md) | Read-only AIFHub contract validator for OpenSpec-native artifacts |
 | [OpenSpec Coverage Matrix](docs/spec-coverage.md) | Requirement-to-code coverage artifact and verify/done policy |
 | [Legacy Plan Migration](docs/legacy-plan-migration.md) | Explicit migration from legacy plans to OpenSpec-native changes |

--- a/agent-files/claude/aifhub-done-finalizer.md
+++ b/agent-files/claude/aifhub-done-finalizer.md
@@ -16,17 +16,17 @@ Follow `skills/shared/LANGUAGE-POLICY.md` before producing user-facing responses
 
 Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 
-- Finalize exactly one verification-passing active OpenSpec change through `scripts/openspec-done-finalizer.mjs`.
+- Finalize exactly one verification-passing active OpenSpec change by running `ai-factory aifhub-done-finalizer --change <change-id> --json`. The command resolves `scripts/openspec-done-finalizer.mjs` as an extension-local implementation module; never execute that module from the consumer root or an internal installed path.
 - Resolve effective policy with `scripts/openspec-policy.mjs`.
 - Read QA evidence from `.ai-factory/qa/<change-id>/` and proceed only when `/aif-verify` clearly passed for this change, the latest final `aif-gate-result` block has `"gate": "verify"` with `status` `pass` or `warn`, `coverage.json` is current with status `pass` or policy-accepted `warn`, generated rules satisfy `requireGeneratedRulesForDone`, and durable rules gate evidence satisfies `requireRulesPassForDone`. Refuse unverified changes, missing/invalid/failed verify gates, missing/stale/failed/disallowed-warning coverage, missing/stale generated rules when required, missing/invalid/failed/disallowed-warning rules gate evidence when required, and `Code verification: PENDING`.
 - Read canonical artifacts: `openspec/specs/**` plus `openspec/changes/<change-id>/proposal.md`, `design.md`, `tasks.md`, and `specs/**/spec.md`.
 - Read generated rules from `.ai-factory/rules/generated/` when present and runtime state from `.ai-factory/state/<change-id>/` when relevant.
-- Dirty workspace state is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` to record dirty state in final QA evidence before archive.
-- For docs/tooling-only changes that also need explicit dirty-state recording, preserve both flags with `/aif-done <change-id> --skip-specs --record-dirty-state`.
-- Archive only through `archiveOpenSpecChange` from `scripts/openspec-runner.mjs`: normal archive is `openspec archive <change-id> --yes`, and docs/tooling-only finalization uses `--skip-specs`.
+- Dirty workspace state is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` to record dirty state in final QA evidence before archive.
+- For docs/tooling-only changes that also need explicit dirty-state recording, preserve both flags with `ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json`.
+- The installed wrapper is the only executable finalizer route. Inside the extension implementation, `archiveOpenSpecChange` from `scripts/openspec-runner.mjs` owns normal `openspec archive <change-id> --yes` behavior and docs/tooling-only `--skip-specs` behavior.
 - `/aif-verify` does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
 - Allowed writes are `.ai-factory/qa/<change-id>/` final evidence and `.ai-factory/state/<change-id>/` final summaries; do not write runtime-only files into `openspec/changes/<change-id>/`.
-- Return selected active OpenSpec change, effective policy summary, verification status, coverage status, rules gate status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for `/aif-mode sync`, next-step recommendation for `/aif-commit`, and any `/aif-evolve` recommendation.
+- Return only bounded finalizer human/JSON fields: selected active OpenSpec change, readiness and verification status, coverage and rules gate status, dirty working tree summary, archive result, safe OpenSpec command/source, runtime and QA paths, commit/PR summary draft, governance follow-up result, next-step recommendation for `/aif-mode sync`, next-step recommendation for `/aif-commit`, and any `/aif-evolve` recommendation. Never return full context, environment, raw stdout/stderr, or artifact contents.
 - After successful finalization, recommend `/aif-mode sync` to refresh derived artifacts after archive, recommend `/aif-commit` as the next AI Factory command, and optionally recommend `/aif-evolve` when durable learning evidence exists.
 
 ## Legacy AI Factory-only mode
@@ -40,6 +40,7 @@ Use this mode when OpenSpec-native mode is not enabled.
 - Archive the companion plan file as `plan.md` alongside folder artifacts.
 
 Rules:
+- Reject `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, `--summary-only`, and unknown finalizer options; never bypass readiness or archive policy.
 - Follow the finalization contract from `skills/aif-done/references/finalization-contract.md`.
 - Draft a conventional commit message and PR body for user review; do not auto-create PRs.
 - Do not create commits automatically, do not create PRs automatically, and do not present `/aif-done` as replacing `/aif-commit`.

--- a/agent-files/codex/aifhub-done-finalizer.toml
+++ b/agent-files/codex/aifhub-done-finalizer.toml
@@ -13,17 +13,17 @@ Follow `skills/shared/LANGUAGE-POLICY.md` before producing user-facing responses
 
 Use this mode when config declares aifhub.artifactProtocol: openspec.
 
-- Finalize exactly one verification-passing active OpenSpec change through scripts/openspec-done-finalizer.mjs.
+- Finalize exactly one verification-passing active OpenSpec change by running ai-factory aifhub-done-finalizer --change <change-id> --json. The command resolves scripts/openspec-done-finalizer.mjs as an extension-local implementation module; never execute that module from the consumer root or an internal installed path.
 - Resolve effective policy with scripts/openspec-policy.mjs.
 - Read QA evidence from .ai-factory/qa/<change-id>/ and proceed only when /aif-verify clearly passed for this change, the latest final aif-gate-result block has "gate": "verify" with status pass or warn, coverage.json is current with status pass or policy-accepted warn, generated rules satisfy requireGeneratedRulesForDone, and durable rules gate evidence satisfies requireRulesPassForDone. Refuse unverified changes, missing/invalid/failed verify gates, missing/stale/failed/disallowed-warning coverage, missing/stale generated rules when required, missing/invalid/failed/disallowed-warning rules gate evidence when required, and Code verification: PENDING.
 - Read canonical artifacts: openspec/specs/** plus openspec/changes/<change-id>/proposal.md, design.md, tasks.md, and specs/**/spec.md.
 - Read generated rules from .ai-factory/rules/generated/ when present and runtime state from .ai-factory/state/<change-id>/ when relevant.
-- Dirty workspace state is blocking by default before archive. Inspect with git status --short; commit or stash unrelated changes, or rerun /aif-done <change-id> --record-dirty-state to record dirty state in final QA evidence before archive.
-- For docs/tooling-only changes that also need explicit dirty-state recording, preserve both flags with /aif-done <change-id> --skip-specs --record-dirty-state.
-- Archive only through archiveOpenSpecChange from scripts/openspec-runner.mjs: normal archive is openspec archive <change-id> --yes, and docs/tooling-only finalization uses --skip-specs.
+- Dirty workspace state is blocking by default before archive. Inspect with git status --short; commit or stash unrelated changes, or rerun ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json to record dirty state in final QA evidence before archive.
+- For docs/tooling-only changes that also need explicit dirty-state recording, preserve both flags with ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json.
+- The installed wrapper is the only executable finalizer route. Inside the extension implementation, archiveOpenSpecChange from scripts/openspec-runner.mjs owns normal openspec archive <change-id> --yes behavior and docs/tooling-only --skip-specs behavior.
 - /aif-verify does not archive; never use custom OpenSpec archive logic, and OpenSpec-native mode does not use legacy .ai-factory/specs archive.
 - Allowed writes are .ai-factory/qa/<change-id>/ final evidence and .ai-factory/state/<change-id>/ final summaries; do not write runtime-only files into openspec/changes/<change-id>/.
-- Return selected active OpenSpec change, effective policy summary, verification status, coverage status, rules gate status, dirty working tree state, archive result, canonical artifacts inspected, generated rules state, runtime state path, QA evidence path, commit/PR summary draft, governance follow-up result, next-step recommendation for /aif-mode sync, next-step recommendation for /aif-commit, and any /aif-evolve recommendation.
+- Return only bounded finalizer human/JSON fields: selected active OpenSpec change, readiness and verification status, coverage and rules gate status, dirty working tree summary, archive result, safe OpenSpec command/source, runtime and QA paths, commit/PR summary draft, governance follow-up result, next-step recommendation for /aif-mode sync, next-step recommendation for /aif-commit, and any /aif-evolve recommendation. Never return full context, environment, raw stdout/stderr, or artifact contents.
 - After successful finalization, recommend /aif-mode sync to refresh derived artifacts after archive, recommend /aif-commit as the next AI Factory command, and optionally recommend /aif-evolve when durable learning evidence exists.
 
 ## Legacy AI Factory-only mode
@@ -37,6 +37,7 @@ Use this mode when OpenSpec-native mode is not enabled.
 - Archive the companion plan file as plan.md alongside folder artifacts.
 
 Rules:
+- Reject --force, --no-validate, --skip-archive, --dry-run, --summary-only, and unknown finalizer options; never bypass readiness or archive policy.
 - Follow the finalization contract from skills/aif-done/references/finalization-contract.md.
 - Draft a conventional commit message and PR body for user review; do not auto-create PRs.
 - Do not create commits automatically, do not create PRs automatically, and do not present /aif-done as replacing /aif-commit.

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,19 +13,20 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "baselineVersion": "1.3.1",
       "supportedRange": ">=1.3.1 <2.0.0",
       "reviewedStableVersions": [
         "1.3.1",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ],
       "reviewedPrereleaseVersions": [],
       "lastSync": "2026-08-09",
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.4.0 while keeping the supported stable CLI range >=1.3.1 <2.0.0. OpenSpec 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.4.1 while keeping the supported stable CLI range >=1.3.1 <2.0.0. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, workspace beta state, or openspec update."
     }
   }
 }

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,13 +13,19 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.4.1",
+      "version": "1.4.0",
+      "baselineVersion": "1.3.1",
       "supportedRange": ">=1.3.1 <2.0.0",
-      "lastSync": "2026-06-10",
+      "reviewedStableVersions": [
+        "1.3.1",
+        "1.4.0"
+      ],
+      "reviewedPrereleaseVersions": [],
+      "lastSync": "2026-08-09",
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated against upstream OpenSpec 1.4.1 while keeping the supported CLI range >=1.3.1 <2.0.0. Reviewed baseline includes the 1.4.1 openspec update workspace.yaml fix and the 1.4.0 Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.4.0 while keeping the supported stable CLI range >=1.3.1 <2.0.0. OpenSpec 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, workspace beta state, or openspec update."
     }
   }
 }

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,7 +13,7 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "baselineVersion": "1.3.1",
       "supportedRange": ">=1.3.1 <2.0.0",
       "reviewedStableVersions": [
@@ -22,7 +22,8 @@
         "1.4.1",
         "1.5.0",
         "1.6.0",
-        "1.7.0"
+        "1.7.0",
+        "1.8.0"
       ],
       "reviewedPrereleaseVersions": [
         "1.6.0-beta.1"
@@ -31,7 +32,7 @@
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.7.0, including reviewed prerelease 1.6.0-beta.1, while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.7.0 adds native skip_specs metadata, apply/archive instructions, numeric-leading change IDs, nested spec folders, UTF-8 BOM handling, a default Store, new tool adapters, and a self-upgrading openspec update. AIFHub now honors native .openspec.yaml skip_specs during artifact validation and all-change sync, keeps recursive nested-spec discovery, supports archive instructions through the shared runner, and preserves the older numeric-ID status fallback for pre-1.7 CLIs. OpenSpec 1.6.0 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, handles nested specs and task files, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and fresh Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.8.0, including reviewed prerelease 1.6.0-beta.1, while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.8.0 adds explicit retire_capabilities metadata, scenario-loss validation, nested task progress, non-TTY archive guidance, and new agent targets. AIFHub version-gates retirement metadata in its planning prompt, preserves fail-closed validation diagnostics, already counts nested task checkboxes, and leaves agent generation upstream-owned. OpenSpec 1.7.0 adds native skip_specs metadata, apply/archive instructions, numeric-leading change IDs, nested spec folders, UTF-8 BOM handling, a default Store, new tool adapters, and a self-upgrading openspec update. AIFHub honors native .openspec.yaml skip_specs during artifact validation and all-change sync, keeps recursive nested-spec discovery, supports archive instructions through the shared runner, and preserves the older numeric-ID status fallback for pre-1.7 CLIs. OpenSpec 1.6.0 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, handles nested specs and task files, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and fresh Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, agent targets, or openspec update."
     }
   }
 }

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -22,12 +22,14 @@
         "1.4.1",
         "1.5.0"
       ],
-      "reviewedPrereleaseVersions": [],
+      "reviewedPrereleaseVersions": [
+        "1.6.0-beta.1"
+      ],
       "lastSync": "2026-08-09",
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.5.0 while keeping the supported stable CLI range >=1.3.1 <2.0.0. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON; the AIFHub adapter accepts that forward-compatible JSON without owning Stores. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, Stores, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.5.0 and reviewed prerelease 1.6.0-beta.1 while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.6.0-beta.1 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and empty Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON; the AIFHub adapter accepts that forward-compatible JSON without owning Stores. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, or openspec update."
     }
   }
 }

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,14 +13,15 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "baselineVersion": "1.3.1",
       "supportedRange": ">=1.3.1 <2.0.0",
       "reviewedStableVersions": [
         "1.3.1",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.6.0"
       ],
       "reviewedPrereleaseVersions": [
         "1.6.0-beta.1"
@@ -29,7 +30,7 @@
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.5.0 and reviewed prerelease 1.6.0-beta.1 while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.6.0-beta.1 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and empty Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON; the AIFHub adapter accepts that forward-compatible JSON without owning Stores. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.6.0, including reviewed prerelease 1.6.0-beta.1, while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.6.0 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, handles nested specs and task files, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and fresh Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON; the AIFHub adapter accepts that forward-compatible JSON without owning Stores. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, or openspec update."
     }
   }
 }

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,20 +13,21 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "baselineVersion": "1.3.1",
       "supportedRange": ">=1.3.1 <2.0.0",
       "reviewedStableVersions": [
         "1.3.1",
         "1.4.0",
-        "1.4.1"
+        "1.4.1",
+        "1.5.0"
       ],
       "reviewedPrereleaseVersions": [],
       "lastSync": "2026-08-09",
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.4.1 while keeping the supported stable CLI range >=1.3.1 <2.0.0. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.5.0 while keeping the supported stable CLI range >=1.3.1 <2.0.0. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON; the AIFHub adapter accepts that forward-compatible JSON without owning Stores. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, Kimi/Mistral integrations, Stores, workspace beta state, or openspec update."
     }
   }
 }

--- a/aifhub-extension.json
+++ b/aifhub-extension.json
@@ -13,7 +13,7 @@
     },
     "openspec": {
       "url": "https://github.com/Fission-AI/OpenSpec",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "baselineVersion": "1.3.1",
       "supportedRange": ">=1.3.1 <2.0.0",
       "reviewedStableVersions": [
@@ -21,7 +21,8 @@
         "1.4.0",
         "1.4.1",
         "1.5.0",
-        "1.6.0"
+        "1.6.0",
+        "1.7.0"
       ],
       "reviewedPrereleaseVersions": [
         "1.6.0-beta.1"
@@ -30,7 +31,7 @@
       "optional": true,
       "requiresNode": ">=20.19.0",
       "mode": "optional-cli-adapter",
-      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.6.0, including reviewed prerelease 1.6.0-beta.1, while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.6.0 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, handles nested specs and task files, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and fresh Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON; the AIFHub adapter accepts that forward-compatible JSON without owning Stores. OpenSpec 1.4.1 fixes openspec update for projects with their own workspace.yaml; 1.4.0 adds Kimi CLI, Mistral Vibe, default sync skills, case-insensitive requirement headers, and clearer validation hints. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, or openspec update."
+      "notes": "Validated sequentially from upstream OpenSpec 1.3.1 through 1.7.0, including reviewed prerelease 1.6.0-beta.1, while keeping the supported stable CLI range >=1.3.1 <2.0.0; prereleases remain unsupported for production capabilities. OpenSpec 1.7.0 adds native skip_specs metadata, apply/archive instructions, numeric-leading change IDs, nested spec folders, UTF-8 BOM handling, a default Store, new tool adapters, and a self-upgrading openspec update. AIFHub now honors native .openspec.yaml skip_specs during artifact validation and all-change sync, keeps recursive nested-spec discovery, supports archive instructions through the shared runner, and preserves the older numeric-ID status fallback for pre-1.7 CLIs. OpenSpec 1.6.0 unifies validate/view/archive resolution, makes archive validation failures exit non-zero, handles nested specs and task files, adds /opsx:update, Oh My Pi and Trae support, and fixes requirement parsing, archive drift, skill permissions, and fresh Store registration. OpenSpec 1.5.0 introduces Stores in very early beta, fixes config parsing and CRLF YAML frontmatter generation, and adds an additive root field to command JSON. AIFHub remains adapter-only and does not install or manage OpenSpec skills, /opsx:* commands, tool integrations, Stores, workspace beta state, or openspec update."
     }
   }
 }

--- a/commands/aifhub-done-finalizer.mjs
+++ b/commands/aifhub-done-finalizer.mjs
@@ -2,6 +2,8 @@
 import { normalizeWrapperArgs, runInstalledScript } from './run-installed-script.mjs';
 
 const DESCRIPTION = 'Finalize a verified AIFHub OpenSpec change from an installed project.';
+const FINALIZER_TIMEOUT_MS = 15 * 60 * 1000;
+const FINALIZER_KILL_TIMEOUT_MS = 5000;
 
 export function register(program) {
   program
@@ -11,6 +13,15 @@ export function register(program) {
     .allowExcessArguments(true)
     .argument('[args...]')
     .action(async (args, command) => {
-      await runInstalledScript('../scripts/openspec-done-finalizer.mjs', normalizeWrapperArgs(args, command), import.meta.url);
+      await runInstalledScript(
+        '../scripts/openspec-done-finalizer.mjs',
+        normalizeWrapperArgs(args, command),
+        import.meta.url,
+        {
+          timeout: FINALIZER_TIMEOUT_MS,
+          killTimeout: FINALIZER_KILL_TIMEOUT_MS,
+          timeoutExitCode: 2
+        }
+      );
     });
 }

--- a/commands/aifhub-done-finalizer.mjs
+++ b/commands/aifhub-done-finalizer.mjs
@@ -1,0 +1,16 @@
+// aifhub-done-finalizer.mjs - installed-project wrapper for verified OpenSpec finalization
+import { normalizeWrapperArgs, runInstalledScript } from './run-installed-script.mjs';
+
+const DESCRIPTION = 'Finalize a verified AIFHub OpenSpec change from an installed project.';
+
+export function register(program) {
+  program
+    .command('aifhub-done-finalizer')
+    .description(DESCRIPTION)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument('[args...]')
+    .action(async (args, command) => {
+      await runInstalledScript('../scripts/openspec-done-finalizer.mjs', normalizeWrapperArgs(args, command), import.meta.url);
+    });
+}

--- a/commands/run-installed-script.mjs
+++ b/commands/run-installed-script.mjs
@@ -2,6 +2,9 @@
 import { spawn as spawnChildProcess } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
+const DEFAULT_KILL_TIMEOUT_MS = 5000;
+const TIMEOUT_EXIT_CODE = 124;
+
 export function resolveInstalledScriptPath(scriptRelativePath, moduleUrl) {
   return fileURLToPath(new URL(scriptRelativePath, moduleUrl));
 }
@@ -10,6 +13,14 @@ export async function runInstalledScript(scriptRelativePath, args = [], moduleUr
   const processLike = options.processLike ?? process;
   const spawn = options.spawn ?? spawnChildProcess;
   const stdio = options.stdio ?? 'inherit';
+  const timeout = normalizeTimeout(options.timeout, 'timeout');
+  const killTimeout = normalizeTimeout(
+    options.killTimeout ?? DEFAULT_KILL_TIMEOUT_MS,
+    'killTimeout'
+  );
+  const timeoutExitCode = normalizeExitCode(options.timeoutExitCode ?? TIMEOUT_EXIT_CODE);
+  const setTimeoutImplementation = options.setTimeout ?? globalThis.setTimeout;
+  const clearTimeoutImplementation = options.clearTimeout ?? globalThis.clearTimeout;
   const scriptPath = resolveInstalledScriptPath(scriptRelativePath, moduleUrl);
   const forwardedArgs = Array.isArray(args) ? args : [];
 
@@ -19,11 +30,61 @@ export async function runInstalledScript(scriptRelativePath, args = [], moduleUr
       env: processLike.env,
       stdio
     });
+    let settled = false;
+    let timedOut = false;
+    let timeoutHandle = null;
+    let killHandle = null;
 
-    child.once('error', reject);
-    child.once('close', (code, signal) => {
-      resolve(code ?? (signal ? 1 : 0));
+    const clearTimers = () => {
+      if (timeoutHandle !== null) clearTimeoutImplementation(timeoutHandle);
+      if (killHandle !== null) clearTimeoutImplementation(killHandle);
+    };
+    const finish = (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolve(code);
+    };
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      reject(error);
+    };
+
+    child.once('error', (error) => {
+      if (timedOut) {
+        finish(timeoutExitCode);
+        return;
+      }
+      fail(error);
     });
+    child.once('close', (code, signal) => {
+      finish(timedOut ? timeoutExitCode : (code ?? (signal ? 1 : 0)));
+    });
+
+    if (timeout > 0) {
+      timeoutHandle = setTimeoutImplementation(() => {
+        timedOut = true;
+        try {
+          child.kill?.('SIGTERM');
+        } catch {
+          // Continue to the bounded force-kill fallback.
+        }
+        if (settled) return;
+
+        killHandle = setTimeoutImplementation(() => {
+          try {
+            child.kill?.('SIGKILL');
+            child.unref?.();
+          } finally {
+            finish(timeoutExitCode);
+          }
+        }, killTimeout);
+        killHandle?.unref?.();
+      }, timeout);
+      timeoutHandle?.unref?.();
+    }
   });
 
   if (exitCode !== 0) {
@@ -44,4 +105,20 @@ export function normalizeWrapperArgs(args, command) {
     return [];
   }
   return [args];
+}
+
+function normalizeTimeout(value, name) {
+  if (value === undefined || value === null) return 0;
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    throw new TypeError(`${name} must be a non-negative finite number.`);
+  }
+  return normalized;
+}
+
+function normalizeExitCode(value) {
+  if (!Number.isInteger(value) || value < 1 || value > 255) {
+    throw new TypeError('timeoutExitCode must be an integer between 1 and 255.');
+  }
+  return value;
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Session Context Dedup](context-dedup.md) - optional `off | aifhub | sqz` context optimization, protected artifacts, ledger paths, external-tool consent, CLI и MCP surface.
 6. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
-7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.7.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.8.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 8. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 9. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 10. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -48,7 +48,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Session Context Dedup](context-dedup.md) | Optional `off | aifhub | sqz` context optimization: decision table, protected artifacts, ledger/purge paths, external-tool consent, CLI и MCP surface |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.7.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.8.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -84,7 +84,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
-- OpenSpec 1.7.0 reviewed baseline from 1.3.1, including `1.6.0-beta.1`, native `skip_specs`, archive instructions, numeric-leading IDs and nested specs, plus adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, tool integrations, Stores, workspace beta state, and `openspec update`
+- OpenSpec 1.8.0 reviewed baseline from 1.3.1, including `1.6.0-beta.1`, native `skip_specs`, explicit capability retirement, scenario-loss validation, nested task progress, archive instructions, numeric-leading IDs and nested specs, plus adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, agent targets, tool integrations, Stores, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Session Context Dedup](context-dedup.md) - optional `off | aifhub | sqz` context optimization, protected artifacts, ledger paths, external-tool consent, CLI и MCP surface.
 6. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
-7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 8. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 9. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 10. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -48,7 +48,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Session Context Dedup](context-dedup.md) | Optional `off | aifhub | sqz` context optimization: decision table, protected artifacts, ledger/purge paths, external-tool consent, CLI и MCP surface |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -84,7 +84,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
-- OpenSpec 1.4.0 reviewed baseline from 1.3.1 and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`
+- OpenSpec 1.4.1 reviewed baseline from 1.3.1 and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Session Context Dedup](context-dedup.md) - optional `off | aifhub | sqz` context optimization, protected artifacts, ledger paths, external-tool consent, CLI и MCP surface.
 6. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
-7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 8. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 9. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 10. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -48,7 +48,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Session Context Dedup](context-dedup.md) | Optional `off | aifhub | sqz` context optimization: decision table, protected artifacts, ledger/purge paths, external-tool consent, CLI и MCP surface |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -84,7 +84,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
-- OpenSpec 1.4.1 reviewed baseline and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`
+- OpenSpec 1.4.0 reviewed baseline from 1.3.1 and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Session Context Dedup](context-dedup.md) - optional `off | aifhub | sqz` context optimization, protected artifacts, ledger paths, external-tool consent, CLI и MCP surface.
 6. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
-7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.6.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.7.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 8. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 9. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 10. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -48,7 +48,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Session Context Dedup](context-dedup.md) | Optional `off | aifhub | sqz` context optimization: decision table, protected artifacts, ledger/purge paths, external-tool consent, CLI и MCP surface |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.6.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.7.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -84,7 +84,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
-- OpenSpec 1.6.0 reviewed baseline from 1.3.1, including `1.6.0-beta.1`, and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, Stores beta, workspace beta state, and `openspec update`
+- OpenSpec 1.7.0 reviewed baseline from 1.3.1, including `1.6.0-beta.1`, native `skip_specs`, archive instructions, numeric-leading IDs and nested specs, plus adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, tool integrations, Stores, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Session Context Dedup](context-dedup.md) - optional `off | aifhub | sqz` context optimization, protected artifacts, ledger paths, external-tool consent, CLI и MCP surface.
 6. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
-7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.4.1 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.5.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 8. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 9. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 10. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -48,7 +48,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Session Context Dedup](context-dedup.md) | Optional `off | aifhub | sqz` context optimization: decision table, protected artifacts, ledger/purge paths, external-tool consent, CLI и MCP surface |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.4.1 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.5.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -84,7 +84,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
-- OpenSpec 1.4.1 reviewed baseline from 1.3.1 and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, workspace beta state, and `openspec update`
+- OpenSpec 1.5.0 reviewed baseline from 1.3.1 and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, Stores beta, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 4. [Memory Tool Recommendations](memory-tool-recommendations.md) - local metadata-driven optional tool recommendations и installed wrapper commands.
 5. [Session Context Dedup](context-dedup.md) - optional `off | aifhub | sqz` context optimization, protected artifacts, ledger paths, external-tool consent, CLI и MCP surface.
 6. [Context Loading Policy](context-loading-policy.md) - Base Context including the optional project glossary, optional Graphify/CodeGraph/Context7 guidance, GitHub-aware roadmap evidence, ownership boundaries, generated rules, quality gates, parent-owned commit grouping, upstream architecture/docs/QA/archive/distillation utilities, commit handoff и legacy path rules.
-7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.5.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
+7. [OpenSpec Compatibility](openspec-compatibility.md) - optional CLI adapter support, OpenSpec 1.6.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline compatibility, Original Request/Research Context, regression-first fix, branch-scoped QA-check, Universal MCP, Control Flow и reviewed no-op boundaries, плюс archive/distillation compatibility, artifact sync points, rules gate behavior, Node requirements, validation policy flags и degraded mode.
 8. [OpenSpec Artifact Validation](openspec-validation.md) - AIFHub contract validator поверх OpenSpec CLI validation.
 9. [OpenSpec Coverage Matrix](spec-coverage.md) - requirement-to-task-to-code coverage evidence и verify/done policy.
 10. [Legacy Plan Migration](legacy-plan-migration.md) - если существующие `.ai-factory/plans` artifacts нужно перенести в OpenSpec-native changes.
@@ -48,7 +48,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 | [Memory Tool Recommendations](memory-tool-recommendations.md) | Local metadata-driven optional memory/context tool recommendations и installed wrapper commands |
 | [Session Context Dedup](context-dedup.md) | Optional `off | aifhub | sqz` context optimization: decision table, protected artifacts, ledger/purge paths, external-tool consent, CLI и MCP surface |
 | [Context Loading Policy](context-loading-policy.md) | Runtime context, Optional Project Glossary, optional Graphify/CodeGraph/Context7 context, GitHub-aware roadmap evidence, ownership, gates, commit handoff, upstream `/aif-architecture`, `/aif-docs`, `/aif-qa`, `/aif-archive` and `/aif-distillation` boundaries и legacy boundaries |
-| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.5.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
+| [OpenSpec Compatibility](openspec-compatibility.md) | CLI adapter policy, OpenSpec 1.6.0 reviewed baseline from 1.3.1, AI Factory 2.17 baseline with planning/fix/QA/MCP/Control Flow adaptations and reviewed no-ops, upstream archive/distillation boundaries, validation policy flags, sync points, rules gate, version support и degraded mode |
 | [OpenSpec Artifact Validation](openspec-validation.md) | Read-only AIFHub contract validator для canonical artifacts, runtime evidence, QA и generated rules |
 | [OpenSpec Coverage Matrix](spec-coverage.md) | Requirement-to-task-to-code coverage evidence, policy, staleness и integration points |
 | [Legacy Plan Migration](legacy-plan-migration.md) | Explicit migration commands и artifact mapping |
@@ -84,7 +84,7 @@ OpenSpec CLI features вызываются через AIFHub wrappers и `script
 - upstream `/aif-architecture`, `/aif-docs`, and `/aif-qa` project-context utility boundaries; they are not required per-change OpenSpec lifecycle gates
 - AI Factory 2.13+ parent-owned `/aif-commit` `## Commit Plan` grouping
 - upstream `/aif-distillation` utility skill boundaries; it is not an AIFHub lifecycle stage and writes generated skill packages to the current agent skills directory
-- OpenSpec 1.5.0 reviewed baseline from 1.3.1 and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, Stores beta, workspace beta state, and `openspec update`
+- OpenSpec 1.6.0 reviewed baseline from 1.3.1, including `1.6.0-beta.1`, and adapter-only ownership boundaries for OpenSpec skills, `/opsx:*`, Kimi CLI, Mistral Vibe, Stores beta, workspace beta state, and `openspec update`
 - OpenSpec requirement coverage evidence и policy
 - canonical OpenSpec artifact ownership
 - AI Factory runtime state, QA evidence и generated rules

--- a/docs/claude-agents.md
+++ b/docs/claude-agents.md
@@ -26,7 +26,7 @@
 - `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it uses `aif-rules-check` and reads generated markdown plus trace metadata under `.ai-factory/rules/generated/*` in OpenSpec-native mode.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
-- `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, and prepares summary/archive evidence.
+- `finalization helper`: `aifhub-done-finalizer`. Для OpenSpec-native installed project он запускает `ai-factory aifhub-done-finalizer --change <change-id> --json`; extension-local implementation выполняет readiness и `openspec archive <change-id> --yes`. Поддерживаются `--skip-specs` и `--record-dirty-state`, результат остаётся bounded.
 
 ## Как это работает
 
@@ -89,8 +89,12 @@ Verifier writes QA evidence under `.ai-factory/qa/<change-id>/`.
 ### Finalization
 
 - `aifhub-done-finalizer`
+- installed command: `ai-factory aifhub-done-finalizer --change <change-id> --json`
 - requires passing verify gate
 - archives only through OpenSpec CLI
+- returns bounded output and exit `0` for success/accepted warning, `1` for a resolved blocker, or `2` for invalid/unresolved/unexpected command failure
+- rejects unknown options and `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, and `--summary-only`
+- never runs extension-local `scripts/openspec-*.mjs` modules through a consumer-root or installed-internal path
 - writes final evidence/summaries
 - recommends `/aif-mode sync`
 - recommends `/aif-commit`
@@ -111,7 +115,7 @@ Verifier writes QA evidence under `.ai-factory/qa/<change-id>/`.
 - Попросить plan polisher: `Используй aifhub-plan-polisher для точечной полировки текущего OpenSpec change или legacy плана без редактирования source code.`
 - Попросить verifier: `Запусти aifhub-verifier для active OpenSpec change or legacy plan pair и changed files. Обнови только verification artifacts и верни verdict с counts по findings.`
 - Попросить fixer: `Используй aifhub-fixer и исправь только findings B001 и I002, затем верни files modified и re-verify recommendation.`
-- Попросить done finalizer: `Запусти aifhub-done-finalizer для passing OpenSpec change или legacy plan. Для OpenSpec-native scope проверь /aif-verify evidence, archive through openspec archive <change-id> --yes, use --skip-specs for docs/tooling-only work, and report .ai-factory/qa/<change-id>/ plus .ai-factory/state/<change-id>/ outputs. Для legacy scope используй `.ai-factory/specs/<plan-id>/` archive path. Подготовь commit/PR summary draft.`
+- Попросить done finalizer: `Запусти ai-factory aifhub-done-finalizer --change <change-id> --json для passing OpenSpec change. Используй --skip-specs только для docs/tooling-only work, верни bounded status, safe paths, OpenSpec command/source и suggested next; не запускай scripts/openspec-*.mjs из consumer root или installed-internal path. Для legacy scope следуй agent contract. Подготовь commit/PR summary draft.`
 
 Во всех случаях полезно явно задавать scope: какой plan, какие файлы или какой changed range должен анализироваться.
 

--- a/docs/codex-agents.md
+++ b/docs/codex-agents.md
@@ -37,7 +37,7 @@ The `aifhub-*` Codex agents are extension helpers for bounded planning, implemen
 - `aifhub-rules-sidecar` keeps the upstream `rules-sidecar` contract instead of replacing it: it is namespaced for AIFHub and reads generated markdown plus trace metadata under `.ai-factory/rules/generated/*` in OpenSpec-native mode.
 - `low-write verifier`: `aifhub-verifier`. Агент может обновлять только verification artifacts, но не implementation files.
 - `bounded worker`: `aifhub-plan-polisher`, `aifhub-implement-worker`, `aifhub-fixer`. Они write-capable, но у каждого есть жёстко ограниченный рабочий scope.
-- `finalization helper`: `aifhub-done-finalizer`. Он завершает verification-passing OpenSpec change through `openspec archive <change-id> --yes` or legacy plan archive work, supports `--skip-specs`, prepares summary/archive evidence, and does not bypass owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md`.
+- `finalization helper`: `aifhub-done-finalizer`. Для OpenSpec-native installed project он запускает `ai-factory aifhub-done-finalizer --change <change-id> --json`; extension-local implementation выполняет readiness и `openspec archive <change-id> --yes`. Поддерживаются `--skip-specs` и `--record-dirty-state`, а owner boundaries для `.ai-factory/ROADMAP.md`, `.ai-factory/RULES.md` и `.ai-factory/ARCHITECTURE.md` не обходятся.
 
 ## Как это работает
 
@@ -95,8 +95,12 @@ Verifier writes QA evidence under `.ai-factory/qa/<change-id>/`.
 ### Finalization
 
 - `aifhub-done-finalizer`
+- installed command: `ai-factory aifhub-done-finalizer --change <change-id> --json`
 - requires passing verify gate
 - archives only through OpenSpec CLI
+- returns bounded output and exit `0` for success/accepted warning, `1` for a resolved blocker, or `2` for invalid/unresolved/unexpected command failure
+- rejects unknown options and `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, and `--summary-only`
+- never runs extension-local `scripts/openspec-*.mjs` modules through a consumer-root or installed-internal path
 - writes final evidence/summaries
 - recommends `/aif-mode sync`
 - recommends `/aif-commit`
@@ -117,7 +121,7 @@ Verifier writes QA evidence under `.ai-factory/qa/<change-id>/`.
 - Попросить plan polisher: `Используй aifhub-plan-polisher для точечной полировки текущего OpenSpec change или legacy плана без редактирования source code.`
 - Попросить verifier: `Запусти aifhub-verifier для active OpenSpec change or legacy plan pair и changed files. Обнови только verification artifacts и верни verdict с counts по findings.`
 - Попросить fixer: `Используй aifhub-fixer и исправь только findings B001 и I002, затем верни files modified и re-verify recommendation.`
-- Попросить done finalizer: `Запусти aifhub-done-finalizer для passing OpenSpec change или legacy plan. Для OpenSpec-native scope проверь /aif-verify evidence, archive through openspec archive <change-id> --yes, use --skip-specs for docs/tooling-only work, and report .ai-factory/qa/<change-id>/ plus .ai-factory/state/<change-id>/ outputs. Для legacy scope используй `.ai-factory/specs/<plan-id>/` archive path. Подготовь commit/PR summary draft.`
+- Попросить done finalizer: `Запусти ai-factory aifhub-done-finalizer --change <change-id> --json для passing OpenSpec change. Используй --skip-specs только для docs/tooling-only work, верни bounded status, safe paths, OpenSpec command/source и suggested next; не запускай scripts/openspec-*.mjs из consumer root или installed-internal path. Для legacy scope следуй agent contract. Подготовь commit/PR summary draft.`
 
 Во всех случаях полезно явно задавать scope: какой plan, какие файлы или какой changed range должен анализироваться.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,12 +26,12 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## OpenSpec 1.4.1 Reviewed Baseline
+## OpenSpec 1.5.0 Reviewed Baseline
 
-AIFHub metadata records OpenSpec `1.4.1` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
+AIFHub metadata records OpenSpec `1.5.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
 
 - Baseline `1.3.1` is the first supported and reviewed release.
-- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`.
+- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`.
 - Reviewed prereleases: none. A prerelease review does not imply production support.
 
 | Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
@@ -39,14 +39,17 @@ AIFHub metadata records OpenSpec `1.4.1` as the latest reviewed upstream baselin
 | `1.3.1` | stable | supported baseline | version detection and existing validate/archive adapter contract | baseline |
 | `1.4.0` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | reviewed-release metadata and no-op ownership documentation |
 | `1.4.1` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | `openspec update` remains upstream-owned |
+| `1.5.0` | stable | supported | `--version`, validate/status/show/instructions JSON including additive `root`, archive flags, store help | forward-compatible JSON regression and Stores ownership boundary |
 
 Reviewed upstream behavior:
 
+- OpenSpec `1.5.0` introduces Stores in very early beta, fixes config parsing for values wrapped in JSON containers, and escapes carriage returns in generated YAML frontmatter for CRLF-authored values.
+- OpenSpec `1.5.0` adds an additive `root` field to JSON command results. AIFHub parses additive fields without requiring a closed response schema, so no command or prompt rewrite is required.
 - OpenSpec `1.4.1` fixes `openspec update` for projects that already have their own `workspace.yaml`.
 - OpenSpec `1.4.0` includes Kimi CLI support, Mistral Vibe support, sync skills by default through `/opsx:sync`, case-insensitive requirement headers, and clearer validation hints.
 - OpenSpec workspace beta view state is OpenSpec-owned and lives under `.openspec-workspace/view.yaml`.
 
-AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, Kimi CLI or Mistral Vibe integrations, OpenSpec workspace beta state, or `openspec update`. AIFHub does not install or manage Kimi CLI or Mistral Vibe integrations, does not own OpenSpec workspace beta state, and does not run or manage `openspec update`.
+AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, Kimi CLI or Mistral Vibe integrations, Stores, OpenSpec workspace beta state, or `openspec update`. Stores registration, config parsing, and generated CRLF YAML frontmatter remain upstream-owned. AIFHub does not install or manage Kimi CLI or Mistral Vibe integrations, does not own OpenSpec workspace beta state, and does not run or manage `openspec update`.
 
 `openspec update` is upstream OpenSpec behavior. `/aif-mode sync` compiles AIFHub generated rules and requests OpenSpec validate/status through the adapter when configured and available.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,12 +26,12 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## OpenSpec 1.6.0 Reviewed Baseline
+## OpenSpec 1.7.0 Reviewed Baseline
 
-AIFHub metadata records OpenSpec `1.6.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
+AIFHub metadata records OpenSpec `1.7.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
 
 - Baseline `1.3.1` is the first supported and reviewed release.
-- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`, `1.6.0`.
+- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`, `1.6.0`, `1.7.0`.
 - Reviewed prereleases: `1.6.0-beta.1`. A prerelease review does not imply production support; prerelease detection remains unavailable for production capabilities.
 
 | Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
@@ -42,9 +42,13 @@ AIFHub metadata records OpenSpec `1.6.0` as the latest reviewed upstream baselin
 | `1.5.0` | stable | supported | `--version`, validate/status/show/instructions JSON including additive `root`, archive flags, store help | forward-compatible JSON regression and Stores ownership boundary |
 | `1.6.0-beta.1` | prerelease | reviewed but unsupported | exact CLI validate/status/show/instructions smoke, archive flags, invalid-change archive exit | preserve stable-only production gate; no prerelease support claim |
 | `1.6.0` | stable | supported | exact CLI validate/status/show/instructions JSON, archive flags, invalid-change archive exit | stable ledger advancement; beta-to-stable code diff only changes version/changelog |
+| `1.7.0` | stable | supported | exact CLI native `skip_specs: true`, `openspec instructions archive --change <id> --json`, leading-digit IDs, nested spec folders, standard command smoke | native metadata reader for artifact/sync gates plus focused no-op regressions for already-compatible surfaces |
 
 Reviewed upstream behavior:
 
+- OpenSpec `1.7.0` makes `.openspec.yaml` with `skip_specs: true` the native declaration for changes without spec deltas. AIFHub honors it in the artifact contract and in `/aif-mode sync --all`; an invalid marker is sent through validation instead of being silently skipped. The older proposal reason remains the compatibility path for pre-1.7 CLIs and already-authored plans.
+- OpenSpec `1.7.0` adds project context to `instructions apply|archive`; the shared runner now has an explicit regression for `openspec instructions archive --change <id> --json` while final archive mutation remains owned by the installed AIFHub finalizer wrapper.
+- Change IDs with leading digits, nested spec folders, and UTF-8 BOM input are supported upstream. AIFHub's resolver already accepts numeric-leading IDs, recursive spec discovery already handles nested folders, and the pre-1.7 status rejection remains a bounded compatibility fallback only when status actually fails.
 - OpenSpec `1.6.0` promotes the reviewed beta behavior to stable, including consistent resolution and task progress for nested specs and task files. The beta-to-stable source diff contains only release metadata and changelog updates, so no additional AIFHub command rewrite is required.
 - OpenSpec `1.6.0-beta.1` converges validate, view, and archive resolution, and archive validation failures return a non-zero exit code. AIFHub's existing non-zero fail-closed handling remains compatible.
 - The prerelease adds `/opsx:update`, Oh My Pi and Trae adapters, automatic OpenSpec CLI permission in generated skills, unified requirement parsing, archive scenario-drift fixes, and empty Store registration. Those integrations and generated skills remain upstream-owned.
@@ -54,7 +58,7 @@ Reviewed upstream behavior:
 - OpenSpec `1.4.0` includes Kimi CLI support, Mistral Vibe support, sync skills by default through `/opsx:sync`, case-insensitive requirement headers, and clearer validation hints.
 - OpenSpec workspace beta view state is OpenSpec-owned and lives under `.openspec-workspace/view.yaml`.
 
-AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, Kimi CLI or Mistral Vibe integrations, Stores, OpenSpec workspace beta state, or `openspec update`. Stores registration, config parsing, and generated CRLF YAML frontmatter remain upstream-owned. AIFHub does not install or manage Kimi CLI or Mistral Vibe integrations, does not own OpenSpec workspace beta state, and does not run or manage `openspec update`.
+AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, tool integrations, Stores, OpenSpec workspace beta state, or `openspec update`. In particular, it does not install or manage Kimi CLI or Mistral Vibe integrations. The default Store, self-upgrade flow, tool command names, config parsing, and generated command/frontmatter content remain upstream-owned. AIFHub does not own OpenSpec workspace beta state and does not run or manage `openspec update`.
 
 `openspec update` is upstream OpenSpec behavior. `/aif-mode sync` compiles AIFHub generated rules and requests OpenSpec validate/status through the adapter when configured and available.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,12 +26,12 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## OpenSpec 1.7.0 Reviewed Baseline
+## OpenSpec 1.8.0 Reviewed Baseline
 
-AIFHub metadata records OpenSpec `1.7.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
+AIFHub metadata records OpenSpec `1.8.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
 
 - Baseline `1.3.1` is the first supported and reviewed release.
-- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`, `1.6.0`, `1.7.0`.
+- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`.
 - Reviewed prereleases: `1.6.0-beta.1`. A prerelease review does not imply production support; prerelease detection remains unavailable for production capabilities.
 
 | Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
@@ -43,9 +43,14 @@ AIFHub metadata records OpenSpec `1.7.0` as the latest reviewed upstream baselin
 | `1.6.0-beta.1` | prerelease | reviewed but unsupported | exact CLI validate/status/show/instructions smoke, archive flags, invalid-change archive exit | preserve stable-only production gate; no prerelease support claim |
 | `1.6.0` | stable | supported | exact CLI validate/status/show/instructions JSON, archive flags, invalid-change archive exit | stable ledger advancement; beta-to-stable code diff only changes version/changelog |
 | `1.7.0` | stable | supported | exact CLI native `skip_specs: true`, `openspec instructions archive --change <id> --json`, leading-digit IDs, nested spec folders, standard command smoke | native metadata reader for artifact/sync gates plus focused no-op regressions for already-compatible surfaces |
+| `1.8.0` | stable | supported | exact CLI capability retirement, scenario-loss validation, nested task progress, non-TTY archive guidance, and standard command smoke | version-gated retirement planning plus fail-closed and nested-task regressions; agent targets remain upstream-owned |
 
 Reviewed upstream behavior:
 
+- OpenSpec `1.8.0` allows explicitly destructive capability retirement through `retire_capabilities: true`. AIFHub planning writes this native marker only when the selected CLI is `>=1.8.0` and the user explicitly authorizes retirement; it must not infer retirement merely from an empty resulting capability.
+- OpenSpec `1.8.0` moves scenario loss detection into validation and names omitted scenarios. AIFHub already fails closed on non-zero validation and now has a regression that preserves the upstream path and diagnostic in QA evidence.
+- OpenSpec `1.8.0` counts nested task progress. AIFHub's recursive task-line parser already counts indented checkboxes, with a focused regression covering that no-op compatibility result.
+- The vendor-neutral agents target (`agents`), MiniMax Code, Rovo Dev CLI, opt-in Copilot cloud-agent files, and generated agent assets remain OpenSpec-owned. AIFHub does not generate or manage those targets.
 - OpenSpec `1.7.0` makes `.openspec.yaml` with `skip_specs: true` the native declaration for changes without spec deltas. AIFHub honors it in the artifact contract and in `/aif-mode sync --all`; an invalid marker is sent through validation instead of being silently skipped. The older proposal reason remains the compatibility path for pre-1.7 CLIs and already-authored plans.
 - OpenSpec `1.7.0` adds project context to `instructions apply|archive`; the shared runner now has an explicit regression for `openspec instructions archive --change <id> --json` while final archive mutation remains owned by the installed AIFHub finalizer wrapper.
 - Change IDs with leading digits, nested spec folders, and UTF-8 BOM input are supported upstream. AIFHub's resolver already accepts numeric-leading IDs, recursive spec discovery already handles nested folders, and the pre-1.7 status rejection remains a bounded compatibility fallback only when status actually fails.
@@ -58,7 +63,7 @@ Reviewed upstream behavior:
 - OpenSpec `1.4.0` includes Kimi CLI support, Mistral Vibe support, sync skills by default through `/opsx:sync`, case-insensitive requirement headers, and clearer validation hints.
 - OpenSpec workspace beta view state is OpenSpec-owned and lives under `.openspec-workspace/view.yaml`.
 
-AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, tool integrations, Stores, OpenSpec workspace beta state, or `openspec update`. In particular, it does not install or manage Kimi CLI or Mistral Vibe integrations. The default Store, self-upgrade flow, tool command names, config parsing, and generated command/frontmatter content remain upstream-owned. AIFHub does not own OpenSpec workspace beta state and does not run or manage `openspec update`.
+AIFHub remains adapter-only: it does not install or manage OpenSpec skills, `/opsx:*` commands, tool integrations, agent targets, Stores, OpenSpec workspace beta state, or `openspec update`. In particular, it does not install or manage Kimi CLI or Mistral Vibe integrations. It also does not install or manage MiniMax Code or Rovo Dev CLI integrations. The default Store, self-upgrade flow, tool command names, config parsing, and generated command/frontmatter content remain upstream-owned. AIFHub does not own OpenSpec workspace beta state and does not run or manage `openspec update`.
 
 `openspec update` is upstream OpenSpec behavior. `/aif-mode sync` compiles AIFHub generated rules and requests OpenSpec validate/status through the adapter when configured and available.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -470,6 +470,8 @@ Installed projects invoke archive-required finalization through:
 ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
+Omitting `--change` delegates to the active-change resolver: exactly one resolvable active change may be selected, while missing or ambiguous scope exits with code `2` before finalization. Automation should always pass an explicit `--change <change-id>`.
+
 The wrapper returns exit `0` for success or policy-accepted warning, `1` for a resolved blocker, and `2` for invalid arguments, unresolved/ambiguous scope, or unexpected command failure. It rejects bypass flags and emits only bounded human/JSON fields. The extension-local runner then uses:
 
 ```bash

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -400,6 +400,8 @@ openspec:
   canArchive: boolean
   version: string | null
   supportedRange: ">=1.3.1 <2.0.0"
+  latestReviewedVersion: "1.8.0"
+  versionOutdated: boolean | null
   requiresNode: ">=20.19.0"
 ```
 
@@ -419,6 +421,12 @@ openspec:
 ```
 
 Commands should treat the stable minimum as the contract and the operational detail fields as diagnostics.
+
+## Version Freshness in `/aif-analyze`
+
+`/aif-analyze` reads the installed-project `openspecCli` result from `ai-factory aifhub-mode status --json`. When a selected CLI is compatible but older than the latest reviewed stable version, bootstrap remains available and the skill emits a non-blocking update recommendation. `versionOutdated` is `null` when the CLI version is missing or unsupported, so freshness never replaces the existing degraded reason.
+
+The recommendation follows the selected user-owned source: update the project dependency for `project-local`, the existing PATH/global installation for `path`, or the caller-owned executable for `explicit`. Do not guess a package manager, and do not install, update, replace, or re-resolve OpenSpec automatically. A supported version equal to or newer than `latestReviewedVersion` does not receive an update or downgrade recommendation.
 
 ## Degraded Mode
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,13 +26,21 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## OpenSpec 1.4.1 Reviewed Baseline
+## OpenSpec 1.4.0 Reviewed Baseline
 
-AIFHub metadata records OpenSpec `1.4.1` as the reviewed upstream baseline while keeping the supported CLI range `>=1.3.1 <2.0.0`.
+AIFHub metadata records OpenSpec `1.4.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
+
+- Baseline `1.3.1` is the first supported and reviewed release.
+- Reviewed stable releases: `1.3.1`, `1.4.0`.
+- Reviewed prereleases: none. A prerelease review does not imply production support.
+
+| Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
+|---|---|---|---|---|
+| `1.3.1` | stable | supported baseline | version detection and existing validate/archive adapter contract | baseline |
+| `1.4.0` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | reviewed-release metadata and no-op ownership documentation |
 
 Reviewed upstream behavior:
 
-- OpenSpec `1.4.1` includes an `openspec update` fix for projects that already have their own `workspace.yaml`.
 - OpenSpec `1.4.0` includes Kimi CLI support, Mistral Vibe support, sync skills by default through `/opsx:sync`, case-insensitive requirement headers, and clearer validation hints.
 - OpenSpec workspace beta view state is OpenSpec-owned and lives under `.openspec-workspace/view.yaml`.
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,12 +26,12 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## OpenSpec 1.5.0 Reviewed Baseline
+## OpenSpec 1.6.0 Reviewed Baseline
 
-AIFHub metadata records OpenSpec `1.5.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
+AIFHub metadata records OpenSpec `1.6.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
 
 - Baseline `1.3.1` is the first supported and reviewed release.
-- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`.
+- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`, `1.6.0`.
 - Reviewed prereleases: `1.6.0-beta.1`. A prerelease review does not imply production support; prerelease detection remains unavailable for production capabilities.
 
 | Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
@@ -41,9 +41,11 @@ AIFHub metadata records OpenSpec `1.5.0` as the latest reviewed upstream baselin
 | `1.4.1` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | `openspec update` remains upstream-owned |
 | `1.5.0` | stable | supported | `--version`, validate/status/show/instructions JSON including additive `root`, archive flags, store help | forward-compatible JSON regression and Stores ownership boundary |
 | `1.6.0-beta.1` | prerelease | reviewed but unsupported | exact CLI validate/status/show/instructions smoke, archive flags, invalid-change archive exit | preserve stable-only production gate; no prerelease support claim |
+| `1.6.0` | stable | supported | exact CLI validate/status/show/instructions JSON, archive flags, invalid-change archive exit | stable ledger advancement; beta-to-stable code diff only changes version/changelog |
 
 Reviewed upstream behavior:
 
+- OpenSpec `1.6.0` promotes the reviewed beta behavior to stable, including consistent resolution and task progress for nested specs and task files. The beta-to-stable source diff contains only release metadata and changelog updates, so no additional AIFHub command rewrite is required.
 - OpenSpec `1.6.0-beta.1` converges validate, view, and archive resolution, and archive validation failures return a non-zero exit code. AIFHub's existing non-zero fail-closed handling remains compatible.
 - The prerelease adds `/opsx:update`, Oh My Pi and Trae adapters, automatic OpenSpec CLI permission in generated skills, unified requirement parsing, archive scenario-drift fixes, and empty Store registration. Those integrations and generated skills remain upstream-owned.
 - OpenSpec `1.5.0` introduces Stores in very early beta, fixes config parsing for values wrapped in JSON containers, and escapes carriage returns in generated YAML frontmatter for CRLF-authored values.

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -350,6 +350,18 @@ openspec/changes/<change-id>/
 
 It does not create `.ai-factory/plans/<id>.md` or `.ai-factory/plans/<id>/task.md` in OpenSpec-native mode. Missing or unsupported OpenSpec CLI is degraded validation, not planning failure.
 
+## CLI Resolution
+
+Every shared-runner operation resolves one OpenSpec executable with this precedence:
+
+1. Explicit non-empty extension API `options.command`.
+2. Project-local `node_modules/.bin/openspec` (`node_modules/.bin/openspec.cmd` on Windows).
+3. Global `openspec` from `PATH`.
+
+The resolver does not search parent projects, invoke `npx`, download packages, or auto-install OpenSpec. Once an explicit or project-local candidate is selected it is authoritative; unsupported versions and execution failures do not silently fall through to another installation. Windows `.cmd`/`.bat` candidates use the bounded `ComSpec` route, while native POSIX executables use direct execution.
+
+Diagnostics separate the internal executable from a safe display value. Project-local and in-project explicit paths are project-relative; external explicit paths are reduced to a bounded identifier. Neither human nor JSON output exposes `PATH`, environment values, or private absolute project paths.
+
 ## Capability Shape
 
 `scripts/openspec-runner.mjs` exposes capability detection with this stable minimum:
@@ -372,6 +384,7 @@ openspec:
   nodeSupported: boolean
   versionSupported: boolean
   command: string
+  commandSource: "explicit" | "project-local" | "path"
   reason: string | null
   errors:
     - code: string
@@ -390,6 +403,8 @@ When the OpenSpec CLI is missing or unsupported:
 - `/aif-verify` records degraded validation unless strict config requires CLI availability
 - `/aif-done` fails archive-required finalization because archive requires a compatible CLI
 
+Filesystem-based artifact discovery, planning, and context loading continue without installing anything. Degraded mode never simulates CLI validation or archive success.
+
 When Node is below `>=20.19.0`, the CLI is treated as unavailable for validate/archive capabilities even if an `openspec` command exists.
 
 When `detectOpenSpec()` reports `reason: unsupported-version`, update or reinstall OpenSpec CLI to `>=1.3.1 <2.0.0`. This remains degraded capability for bootstrap and planning unless a command-specific policy requires CLI availability.
@@ -402,25 +417,31 @@ Scoped runtime integrations are already documented in the active prompt assets: 
 
 ## Validation and Archive
 
-Validation uses:
+Inside the extension, the shared runner performs validation with:
 
 ```bash
 openspec validate <change-id> --type change --strict --json --no-interactive --no-color
 ```
 
-Status evidence uses:
+Inside the extension, status evidence uses:
 
 ```bash
 openspec status --change <change-id> --json --no-color
 ```
 
-Archive-required finalization uses:
+Installed projects invoke archive-required finalization through:
+
+```bash
+ai-factory aifhub-done-finalizer --change <change-id> --json
+```
+
+The wrapper returns exit `0` for success or policy-accepted warning, `1` for a resolved blocker, and `2` for invalid arguments, unresolved/ambiguous scope, or unexpected command failure. It rejects bypass flags and emits only bounded human/JSON fields. The extension-local runner then uses:
 
 ```bash
 openspec archive <change-id> --yes --no-color
 ```
 
-`/aif-done --skip-specs` may add `--skip-specs` for docs/tooling-only changes.
+`ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --json` adds `--skip-specs` for docs/tooling-only changes. Do not execute `scripts/openspec-done-finalizer.mjs` or other `scripts/openspec-*.mjs` modules from a consumer root or internal installed-extension path; they are extension-local implementation modules.
 
 AIFHub artifact contract validation is a separate read-only layer over the CLI adapter. It checks workflow ownership, runtime evidence placement, generated-rule freshness, and pre-archive verification evidence. See [OpenSpec Artifact Validation](openspec-validation.md).
 

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -32,7 +32,7 @@ AIFHub metadata records OpenSpec `1.5.0` as the latest reviewed upstream baselin
 
 - Baseline `1.3.1` is the first supported and reviewed release.
 - Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`, `1.5.0`.
-- Reviewed prereleases: none. A prerelease review does not imply production support.
+- Reviewed prereleases: `1.6.0-beta.1`. A prerelease review does not imply production support; prerelease detection remains unavailable for production capabilities.
 
 | Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
 |---|---|---|---|---|
@@ -40,9 +40,12 @@ AIFHub metadata records OpenSpec `1.5.0` as the latest reviewed upstream baselin
 | `1.4.0` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | reviewed-release metadata and no-op ownership documentation |
 | `1.4.1` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | `openspec update` remains upstream-owned |
 | `1.5.0` | stable | supported | `--version`, validate/status/show/instructions JSON including additive `root`, archive flags, store help | forward-compatible JSON regression and Stores ownership boundary |
+| `1.6.0-beta.1` | prerelease | reviewed but unsupported | exact CLI validate/status/show/instructions smoke, archive flags, invalid-change archive exit | preserve stable-only production gate; no prerelease support claim |
 
 Reviewed upstream behavior:
 
+- OpenSpec `1.6.0-beta.1` converges validate, view, and archive resolution, and archive validation failures return a non-zero exit code. AIFHub's existing non-zero fail-closed handling remains compatible.
+- The prerelease adds `/opsx:update`, Oh My Pi and Trae adapters, automatic OpenSpec CLI permission in generated skills, unified requirement parsing, archive scenario-drift fixes, and empty Store registration. Those integrations and generated skills remain upstream-owned.
 - OpenSpec `1.5.0` introduces Stores in very early beta, fixes config parsing for values wrapped in JSON containers, and escapes carriage returns in generated YAML frontmatter for CRLF-authored values.
 - OpenSpec `1.5.0` adds an additive `root` field to JSON command results. AIFHub parses additive fields without requiring a closed response schema, so no command or prompt rewrite is required.
 - OpenSpec `1.4.1` fixes `openspec update` for projects that already have their own `workspace.yaml`.

--- a/docs/openspec-compatibility.md
+++ b/docs/openspec-compatibility.md
@@ -26,21 +26,23 @@ AI Factory = execution runtime
 
 AI Factory-only workflows follow AI Factory's runtime support. OpenSpec validation/archive follows the OpenSpec CLI runtime requirement.
 
-## OpenSpec 1.4.0 Reviewed Baseline
+## OpenSpec 1.4.1 Reviewed Baseline
 
-AIFHub metadata records OpenSpec `1.4.0` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
+AIFHub metadata records OpenSpec `1.4.1` as the latest reviewed upstream baseline while keeping the supported stable CLI range `>=1.3.1 <2.0.0`.
 
 - Baseline `1.3.1` is the first supported and reviewed release.
-- Reviewed stable releases: `1.3.1`, `1.4.0`.
+- Reviewed stable releases: `1.3.1`, `1.4.0`, `1.4.1`.
 - Reviewed prereleases: none. A prerelease review does not imply production support.
 
 | Release | Channel | Adapter result | Checked AIFHub surfaces | Required adaptation |
 |---|---|---|---|---|
 | `1.3.1` | stable | supported baseline | version detection and existing validate/archive adapter contract | baseline |
 | `1.4.0` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | reviewed-release metadata and no-op ownership documentation |
+| `1.4.1` | stable | supported | `--version`, validate JSON, status JSON, spec show JSON, apply instructions JSON, archive flags | `openspec update` remains upstream-owned |
 
 Reviewed upstream behavior:
 
+- OpenSpec `1.4.1` fixes `openspec update` for projects that already have their own `workspace.yaml`.
 - OpenSpec `1.4.0` includes Kimi CLI support, Mistral Vibe support, sync skills by default through `/opsx:sync`, case-insensitive requirement headers, and clearer validation hints.
 - OpenSpec workspace beta view state is OpenSpec-owned and lives under `.openspec-workspace/view.yaml`.
 

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -61,7 +61,7 @@ The validator checks:
 |---|---|
 | `proposal.md` and `tasks.md` exist | `fail` when missing |
 | `design.md` exists | `warn` when missing, or `fail` when `aifhub.openspec.requireDesign: true` |
-| `specs/**/spec.md` delta exists | `fail` unless `proposal.md` has an explicit docs/tooling-only `skip-specs` reason |
+| `specs/**/spec.md` delta exists | `fail` unless `.openspec.yaml` declares native `skip_specs: true`; an explicit legacy proposal reason remains accepted for compatibility |
 | runtime or evidence files inside `openspec/changes/<change-id>/` | `fail` |
 | `.ai-factory/qa/<change-id>/openspec-validation.json` and `verify.md` | required only with `--require-verification-evidence` |
 | final verify `aif-gate-result` block | `fail` when verification evidence is required and the block is missing, invalid, or failing |
@@ -115,7 +115,7 @@ Run finalization from an installed project through the stable wrapper:
 ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
-Docs/tooling-only finalization can use `--skip-specs`; explicit dirty-state evidence can use `--record-dirty-state`:
+New docs/tooling-only changes on OpenSpec `>=1.7.0` should declare `skip_specs: true` in `.openspec.yaml`; older supported CLIs keep the explicit proposal reason. The compatibility finalizer can still use `--skip-specs`, and explicit dirty-state evidence can use `--record-dirty-state`:
 
 ```bash
 ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -117,6 +117,8 @@ Run finalization from an installed project through the stable wrapper:
 ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
+Omitting `--change` delegates to the active-change resolver: exactly one resolvable active change may be selected, while missing or ambiguous scope exits with code `2` before finalization. Automation should always pass an explicit `--change <change-id>`.
+
 New docs/tooling-only changes on OpenSpec `>=1.7.0` should declare `skip_specs: true` in `.openspec.yaml`; older supported CLIs keep the explicit proposal reason. Explicit capability retirement on OpenSpec `>=1.8.0` uses native `retire_capabilities: true` and is never inferred from an empty delta. The compatibility finalizer can still use `--skip-specs`, and explicit dirty-state evidence can use `--record-dirty-state`:
 
 ```bash

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -68,6 +68,8 @@ The validator checks:
 | generated rules under `.ai-factory/rules/generated/` | `warn` when missing or stale |
 | supplied changed paths under `openspec/specs/**` | `fail` unless direct base spec mutation is explicitly allowed |
 
+OpenSpec `1.8.0` strict validation also reports scenario loss when a `MODIFIED` requirement omits an existing scenario. AIFHub preserves that upstream path and message in validation QA evidence and stops code verification. Capability retirement remains an OpenSpec-owned archive operation and requires explicit `retire_capabilities: true` metadata; AIFHub planning must not infer the marker.
+
 Generated-rule warnings suggest:
 
 ```text
@@ -115,7 +117,7 @@ Run finalization from an installed project through the stable wrapper:
 ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
-New docs/tooling-only changes on OpenSpec `>=1.7.0` should declare `skip_specs: true` in `.openspec.yaml`; older supported CLIs keep the explicit proposal reason. The compatibility finalizer can still use `--skip-specs`, and explicit dirty-state evidence can use `--record-dirty-state`:
+New docs/tooling-only changes on OpenSpec `>=1.7.0` should declare `skip_specs: true` in `.openspec.yaml`; older supported CLIs keep the explicit proposal reason. Explicit capability retirement on OpenSpec `>=1.8.0` uses native `retire_capabilities: true` and is never inferred from an empty delta. The compatibility finalizer can still use `--skip-specs`, and explicit dirty-state evidence can use `--record-dirty-state`:
 
 ```bash
 ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json

--- a/docs/openspec-validation.md
+++ b/docs/openspec-validation.md
@@ -86,7 +86,7 @@ Missing verification evidence suggests:
 
 Doctor also reports `effectivePolicy` from `scripts/openspec-policy.mjs`, including CLI, generated-rules, rules-gate, spec-coverage, and `allowWarnOnDone` settings. Human diagnostics show whether missing or warning evidence is only degraded or blocking under the current policy.
 
-`/aif-done` runs `scripts/openspec-done-readiness.mjs` before archive and writes `.ai-factory/qa/<change-id>/done-readiness.json`. The readiness gate checks OpenSpec validate, OpenSpec status, artifact contract, generated rules freshness, rules gate evidence, coverage, verify gate evidence, and dirty workspace state. Blocking failures refuse archive and include an exact suggested next command, such as `/aif-mode sync --change <change-id>`, `ai-factory aifhub-write-gate-evidence --change <change-id> --gate rules --from <rules-output.md>`, `/aif-verify <change-id>`, or `/aif-done <change-id> --record-dirty-state`.
+`/aif-done` runs its extension-local `scripts/openspec-done-readiness.mjs` implementation module before archive and writes `.ai-factory/qa/<change-id>/done-readiness.json`. Installed projects do not execute that internal module directly. The readiness gate checks OpenSpec validate, OpenSpec status, artifact contract, generated rules freshness, rules gate evidence, coverage, verify gate evidence, and dirty workspace state. Blocking failures refuse archive and include an exact suggested next command, such as `/aif-mode sync --change <change-id>`, `ai-factory aifhub-write-gate-evidence --change <change-id> --gate rules --from <rules-output.md>`, `/aif-verify <change-id>`, or `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json`.
 
 When `requireRulesPassForDone` is true, save the final `/aif-rules-check` output, or at least its final `aif-gate-result` block, to `.ai-factory/qa/<change-id>/rules.md` before `/aif-done`:
 
@@ -107,6 +107,30 @@ The readiness gate runs the artifact validator with verification evidence requir
 
 `/aif-verify` still writes validation/status/verify evidence under `.ai-factory/qa/<change-id>/` and does not archive. It also writes the separate OpenSpec coverage matrix described in [OpenSpec Coverage Matrix](spec-coverage.md).
 
+## Done Finalization
+
+Run finalization from an installed project through the stable wrapper:
+
+```bash
+ai-factory aifhub-done-finalizer --change <change-id> --json
+```
+
+Docs/tooling-only finalization can use `--skip-specs`; explicit dirty-state evidence can use `--record-dirty-state`:
+
+```bash
+ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json
+```
+
+Do not run `scripts/openspec-done-finalizer.mjs`, `scripts/openspec-done-readiness.mjs`, or `scripts/openspec-runner.mjs` from the consumer root or an internal installed-extension path. They are extension-local implementation modules. The public parser rejects unknown options and bypass flags including `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, and `--summary-only` before finalization starts.
+
+| Code | Meaning |
+|---|---|
+| `0` | Finalization succeeded or completed with a policy-accepted warning |
+| `1` | A resolved readiness/archive blocker refused finalization |
+| `2` | Invalid arguments, unresolved or ambiguous scope, or unexpected command failure |
+
+Human and JSON output is whitelist-based and bounded. It can include status, selected change, safe project-relative evidence paths, suggested next action, and the selected OpenSpec command/source. It does not include raw stdout/stderr, environment data, full runtime context, artifact contents, or private absolute paths.
+
 ## Done Readiness
 
 Run the pre-archive gate directly when diagnosing `/aif-done` refusal:
@@ -117,7 +141,7 @@ ai-factory aifhub-done-readiness --change <change-id> --json
 
 It writes `.ai-factory/qa/<change-id>/done-readiness.json` unless `--no-write` is passed. Exit codes are `0` for `pass` or policy-accepted `warn`, `1` for blocking readiness failure, and `2` for invalid arguments or unresolved changes.
 
-A dirty workspace is blocking by default. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` when the current dirty state should be recorded in final QA evidence before archive.
+A dirty workspace is blocking by default. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` when the current dirty state should be recorded in final QA evidence before archive.
 
 Stable JSON fields:
 
@@ -156,7 +180,7 @@ Readiness checks:
 | `rules_gate` | blocks missing, failed, or disallowed warning rules evidence when `requireRulesPassForDone` is true |
 | `coverage` | blocks missing, stale, failed, or disallowed warning coverage when `requireSpecCoverageForDone` is true |
 | `verify_gate` | blocks missing, invalid, failed, or ambiguous final verify gate evidence |
-| `dirty_workspace` | blocks uncommitted changes unless explicit dirty-state recording is enabled with `/aif-done <change-id> --record-dirty-state`; inspect first with `git status --short` |
+| `dirty_workspace` | blocks uncommitted changes unless explicit dirty-state recording is enabled with `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json`; inspect first with `git status --short` |
 
 Policy is intentionally stricter for done than verify. Verify can run degraded when CLI, generated rules, rules gate, or coverage evidence is unavailable unless the matching verify flag is true. Done requires archive readiness and applies `allowWarnOnDone` before accepting warning-only rules, coverage, or OpenSpec status.
 
@@ -171,7 +195,7 @@ The validator never:
 - writes QA evidence
 - moves files between `openspec/changes` and archives
 
-Use `/aif-mode sync --change <change-id>` to regenerate derived rules and `/aif-done` to archive after passing verification.
+Use `/aif-mode sync --change <change-id>` to regenerate derived rules and `ai-factory aifhub-done-finalizer --change <change-id> --json` to archive after passing verification.
 
 ## See Also
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -803,6 +803,8 @@ The stable installed-project executable route is:
 ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
+Omitting `--change` delegates to the active-change resolver: exactly one resolvable active change may be selected, while missing or ambiguous scope exits with code `2` before finalization. Automation should always pass an explicit `--change <change-id>`.
+
 For docs/tooling-only finalization, use `ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --json`. Do not execute `scripts/openspec-done-finalizer.mjs`, `scripts/openspec-done-readiness.mjs`, or `scripts/openspec-runner.mjs` as consumer-project commands. The wrapper rejects unknown options and bypass flags such as `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, and `--summary-only`. Its bounded output omits raw stdout/stderr, environment data, full runtime context, and private absolute paths.
 
 Exit codes are `0` for successful or policy-accepted warning finalization, `1` for a resolved readiness/archive blocker, and `2` for invalid arguments, unresolved or ambiguous scope, or an unexpected command failure.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -384,6 +384,8 @@ If localization questions run first, `/aif-analyze` carries those answers forwar
 
 The selected artifact protocol owns its config profile. Legacy `artifactProtocol: ai-factory` configs do not include `aifhub.openspec` settings or OpenSpec runtime path defaults; OpenSpec-native `artifactProtocol: openspec` configs include those settings and paths explicitly.
 
+In OpenSpec-native mode, `/aif-analyze` also compares the selected compatible CLI with AIFHub's latest reviewed stable version. An older supported CLI remains usable for validation/archive capabilities, but the handoff recommends a user-owned update and identifies whether the selected source is `project-local`, `path`, or `explicit`. The skill never guesses a package manager, installs or updates OpenSpec, or recommends downgrading a supported version that is already equal to or newer than the reviewed baseline.
+
 Shared protocol-neutral settings such as `utilities.context_tools.enabled`, `utilities.graphify.enabled`, and `utilities.codegraph.enabled` may appear in either profile. They record optional tooling preferences and do not make that tool an AIFHub dependency. Optional memory/context tool recommendations are resolved from local installed metadata with `ai-factory aifhub-memory-tools recommend --from-project --json`; runtime tool selection uses `ai-factory aifhub-memory-tools select --from-project --command <skill> --json`. Missing metadata is degraded context and leaves `rg` as the baseline.
 
 ### `/aif-architecture`
@@ -1045,6 +1047,7 @@ See [Codex Plan Mode](codex-plan-mode.md) for question-format guidance.
 | Problem | Meaning | Action |
 |---|---|---|
 | OpenSpec CLI missing | `openspec` is not available on `PATH`. | Continue degraded planning or install a compatible CLI before validation/archive-required finalization. |
+| OpenSpec CLI supported but outdated | `/aif-analyze` reports `versionOutdated: true` against `latestReviewedVersion`. | Keep working if needed, then update the user-owned project-local, PATH/global, or explicit installation with its existing package manager and rerun `ai-factory aifhub-mode status --json`. |
 | Node too old | OpenSpec validate/archive requires Node `>=20.19.0`. | Use Node `>=20.19.0` for OpenSpec commands. |
 | Invalid delta spec | OpenSpec validation failed for `specs/**/spec.md`. | Fix the delta spec and rerun `/aif-verify <change-id>`. |
 | Ambiguous active change | More than one active change can be selected. | Pass `<change-id>` explicitly or update `.ai-factory/state/current.yaml`. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,7 +49,9 @@ Upstream project-context utilities such as `/aif-architecture`, `/aif-roadmap`, 
 
 The `aifhub-extension` package repository stays artifact-light: root `openspec/`, `.ai-factory/state/`, `.ai-factory/qa/`, `.ai-factory/plans/`, and `.ai-factory/rules/generated/` are not extension package source. Root `.ai-factory/rules/generated/` is derived in user projects and safe to regenerate. OpenSpec examples may be committed only under fixture paths such as `test/fixtures/` or `scripts/fixtures/`.
 
-AIFHub commands request OpenSpec validation, status, instructions, and archive through `scripts/openspec-runner.mjs` when the CLI is available. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
+AIFHub commands request OpenSpec validation, status, instructions, and archive through the extension-local `scripts/openspec-runner.mjs` implementation module when the CLI is available. Installed projects must not execute that module from the consumer root or an internal installed path. Slash-command runtimes should keep using `/aif-*` commands. Codex app uses `$aif-*` skill invocations, as shown in the Recommended Codex App Flow. This extension does not install or rely on OpenSpec slash commands.
+
+The shared resolver selects one CLI source per operation in deterministic order: explicit non-empty extension API `options.command`, project-local `node_modules/.bin/openspec` (`openspec.cmd` on Windows), then `openspec` from `PATH`. An explicit or project-local selection is authoritative and never silently falls through after failure. AIFHub does not run `npx`, search parent projects, download, or auto-install OpenSpec. Missing or unsupported CLI remains degraded for filesystem-based planning/context loading; archive-required finalization still refuses until a compatible CLI is available. Human and JSON diagnostics expose only a safe project-relative/bounded command and `explicit`, `project-local`, or `path` source.
 
 ## Optional Project Glossary
 
@@ -771,7 +773,7 @@ Reads:
 - current coverage evidence from `.ai-factory/qa/<change-id>/coverage.json`
 - durable rules gate evidence from `.ai-factory/qa/<change-id>/rules.md` when policy requires it
 - the read-only AIFHub OpenSpec artifact contract result
-- the pre-archive readiness result from `scripts/openspec-done-readiness.mjs`
+- the pre-archive readiness result produced by the extension-local `scripts/openspec-done-readiness.mjs` implementation module
 - git working tree state
 
 Writes:
@@ -791,7 +793,17 @@ Does not write:
 
 Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
 
-A dirty workspace is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` when the current dirty state should be recorded in final QA evidence before archive. For docs/tooling-only finalization, preserve both public flags with `/aif-done <change-id> --skip-specs --record-dirty-state`.
+The stable installed-project executable route is:
+
+```bash
+ai-factory aifhub-done-finalizer --change <change-id> --json
+```
+
+For docs/tooling-only finalization, use `ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --json`. Do not execute `scripts/openspec-done-finalizer.mjs`, `scripts/openspec-done-readiness.mjs`, or `scripts/openspec-runner.mjs` as consumer-project commands. The wrapper rejects unknown options and bypass flags such as `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, and `--summary-only`. Its bounded output omits raw stdout/stderr, environment data, full runtime context, and private absolute paths.
+
+Exit codes are `0` for successful or policy-accepted warning finalization, `1` for a resolved readiness/archive blocker, and `2` for invalid arguments, unresolved or ambiguous scope, or an unexpected command failure.
+
+A dirty workspace is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` when the current dirty state should be recorded in final QA evidence before archive. For docs/tooling-only finalization, preserve both public flags with `ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json`.
 
 If `requireRulesPassForDone` is true and readiness reports missing rules gate evidence, `suggested_next.command` points to `ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules --from <rules-output.md>`. The accompanying reason tells you to rerun `/aif-rules-check` first and persist its final output, or at least the final `aif-gate-result` block, to `.ai-factory/qa/<change-id>/rules.md`.
 
@@ -1038,7 +1050,7 @@ See [Codex Plan Mode](codex-plan-mode.md) for question-format guidance.
 | Stale generated rules | Generated rules do not match canonical OpenSpec artifacts. | Regenerate them; do not edit generated rules as source of truth. |
 | Missing or stale coverage | `.ai-factory/qa/<change-id>/coverage.json` is absent or fingerprints no longer match source artifacts. | Rerun `/aif-verify <change-id>` to regenerate coverage before `/aif-done`. |
 | Artifact contract failure | Canonical OpenSpec artifacts, runtime state, QA evidence, or generated rules violate the AIFHub contract. | Fix the reported path or run the suggested command from `artifactContract.suggested_next`. |
-| Dirty working tree before `/aif-done` | Finalization cannot prove archive/summary scope safely. | Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` to record the dirty workspace in final QA evidence before archive. |
+| Dirty working tree before `/aif-done` | Finalization cannot prove archive/summary scope safely. | Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` to record the dirty workspace in final QA evidence before archive. |
 
 ## Release Smoke Checks
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -312,7 +312,7 @@ Use `--dry-run` for planned switching or sync writes. Use `--all` or `--change <
 
 `/aif-mode sync` without `--change` is recommended after `/aif-done`. After archive, there may be no active change. Sync still refreshes `.ai-factory/rules/generated/openspec-base.md` and `.ai-factory/rules/generated/index.json` from `openspec/specs/**`, skips change-specific generated rules and change validation when no active changes exist, and writes a sync report. OpenSpec skills are not installed.
 
-`/aif-mode sync --all` is a maintenance sweep. It refreshes generated rules for active changes, validates only selected changes that contain `openspec/changes/<change-id>/specs/**/spec.md` delta specs, and reports selected no-delta changes as `no-delta-specs` warnings instead of failing solely because old or docs-only active changes have no delta specs. `/aif-verify <change-id>` remains the stricter verification gate for a specific change.
+`/aif-mode sync --all` is a maintenance sweep. It refreshes generated rules for active changes and validates selected changes that contain `openspec/changes/<change-id>/specs/**/spec.md` delta specs or declare native `skip_specs: true` in `openspec/changes/<change-id>/.openspec.yaml`. It reports older unmarked no-delta changes as `no-delta-specs` warnings. Invalid native markers are validated fail-closed instead of being silently skipped. `/aif-verify <change-id>` remains the stricter verification gate for a specific change.
 
 `/aif-mode doctor --change <change-id>` includes the read-only AIFHub OpenSpec artifact contract check and the latest coverage matrix diagnostic. It reports the full JSON result as `artifactContract`, reports coverage as `coverage`, and treats missing verification evidence as a pre-archive readiness failure. See [OpenSpec Artifact Validation](openspec-validation.md) and [OpenSpec Coverage Matrix](spec-coverage.md).
 
@@ -791,7 +791,7 @@ Does not write:
 - manual file moves from `openspec/changes` to archives
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
-Use `--skip-specs` for docs/tooling-only changes where no accepted spec update is expected. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
+For newly authored docs/tooling-only changes on OpenSpec `>=1.7.0`, prefer native `.openspec.yaml` metadata with `skip_specs: true`; preserve the schema selected for the change. With an older supported CLI, keep the explicit proposal reason and compatibility finalizer path. The public `--skip-specs` finalizer flag remains supported for explicit compatibility finalization. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
 
 The stable installed-project executable route is:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -513,6 +513,8 @@ OpenSpec-native planning includes task intake normalization inside `/aif-plan fu
 
 Docs/tooling-only changes may omit delta specs only when the proposal explains why no product or workflow behavior changes.
 
+When an explicitly requested behavior change removes the final requirement of a capability, OpenSpec `>=1.8.0` planning may add `retire_capabilities: true` to `.openspec.yaml`. This destructive intent must come from the user; planning must not infer capability retirement merely because a `REMOVED` delta leaves no requirements. Older supported CLIs require an upgrade before that change can be archived.
+
 When `aifhub.openspec.validateOnPlan` is enabled, planning requests `openspec validate` through the AIFHub OpenSpec runner if a compatible CLI is available. Missing CLI is a degraded warning unless `aifhub.openspec.requireCliForPlan` is true.
 
 ### `/aif-explore`
@@ -791,7 +793,7 @@ Does not write:
 - manual file moves from `openspec/changes` to archives
 - legacy `.ai-factory/specs` archives in OpenSpec-native mode
 
-For newly authored docs/tooling-only changes on OpenSpec `>=1.7.0`, prefer native `.openspec.yaml` metadata with `skip_specs: true`; preserve the schema selected for the change. With an older supported CLI, keep the explicit proposal reason and compatibility finalizer path. The public `--skip-specs` finalizer flag remains supported for explicit compatibility finalization. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
+For newly authored docs/tooling-only changes on OpenSpec `>=1.7.0`, prefer native `.openspec.yaml` metadata with `skip_specs: true`; preserve the schema selected for the change. With an older supported CLI, keep the explicit proposal reason and compatibility finalizer path. For explicitly authorized capability retirement on OpenSpec `>=1.8.0`, preserve `retire_capabilities: true`; never infer this destructive marker. The public `--skip-specs` finalizer flag remains supported for explicit compatibility finalization. Archive-required finalization needs a compatible OpenSpec CLI when `aifhub.openspec.requireCliForDone` is true. `/aif-done` runs a pre-archive readiness gate and refuses archive on blocking OpenSpec validate, artifact contract, generated rules, rules gate, coverage, verify gate, or dirty workspace failures. The readiness output includes the exact next command to run.
 
 The stable installed-project executable route is:
 

--- a/extension.json
+++ b/extension.json
@@ -35,6 +35,11 @@
       "module": "./commands/aifhub-done-readiness.mjs"
     },
     {
+      "name": "aifhub-done-finalizer",
+      "description": "Finalize a verified AIFHub OpenSpec change from an installed project.",
+      "module": "./commands/aifhub-done-finalizer.mjs"
+    },
+    {
       "name": "aifhub-validate-artifacts",
       "description": "Run AIFHub OpenSpec artifact contract validation.",
       "module": "./commands/aifhub-validate-artifacts.mjs"

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -31,6 +31,8 @@ Do not create legacy `.ai-factory/plans` plan files or companion folders in this
 
 If the task is docs/tooling-only and does not change product or workflow behavior, a delta spec may be omitted only when the plan explicitly explains why no delta spec is needed. When the selected OpenSpec CLI is `>=1.7.0`, also declare native OpenSpec `skip_specs: true` in `openspec/changes/<change-id>/.openspec.yaml`; preserve the selected `schema` and other existing metadata. For an older supported CLI, preserve the explicit proposal reason and compatibility finalizer path instead of writing metadata that the selected CLI does not understand.
 
+When a behavior change removes the final requirement of a capability and the selected OpenSpec CLI is `>=1.8.0`, add native `retire_capabilities: true` to `openspec/changes/<change-id>/.openspec.yaml`, preserving the selected `schema` and other existing metadata. Do this only when the user's request explicitly authorizes capability retirement. Planning must not infer retirement merely because a `REMOVED` delta would leave the base capability empty. For an older supported CLI, record the required OpenSpec upgrade as a blocking archive prerequisite instead of writing unsupported retirement metadata.
+
 #### Task Intake Normalization
 
 Before normalizing task content, preserve the explicit planning request as canonical raw source when one was supplied:

--- a/injections/core/aif-plan-plan-folder.md
+++ b/injections/core/aif-plan-plan-folder.md
@@ -29,7 +29,7 @@ Use canonical OpenSpec artifacts under `openspec/changes/<change-id>/`:
 
 Do not create legacy `.ai-factory/plans` plan files or companion folders in this mode. Do not write runtime-only files into `openspec/changes/<change-id>/`.
 
-If the task is docs/tooling-only and does not change product or workflow behavior, a delta spec may be omitted only when the plan explicitly explains why no delta spec is needed.
+If the task is docs/tooling-only and does not change product or workflow behavior, a delta spec may be omitted only when the plan explicitly explains why no delta spec is needed. When the selected OpenSpec CLI is `>=1.7.0`, also declare native OpenSpec `skip_specs: true` in `openspec/changes/<change-id>/.openspec.yaml`; preserve the selected `schema` and other existing metadata. For an older supported CLI, preserve the explicit proposal reason and compatibility finalizer path instead of writing metadata that the selected CLI does not understand.
 
 #### Task Intake Normalization
 

--- a/schemas/aifhub-extension.schema.json
+++ b/schemas/aifhub-extension.schema.json
@@ -42,7 +42,7 @@
     "SourceMetadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["url", "version", "lastSync"],
+      "required": ["url", "version", "baselineVersion", "lastSync"],
       "properties": {
         "url": {
           "type": "string",

--- a/schemas/aifhub-extension.schema.json
+++ b/schemas/aifhub-extension.schema.json
@@ -57,6 +57,23 @@
         "supportedRange": {
           "type": "string"
         },
+        "reviewedStableVersions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "reviewedPrereleaseVersions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9A-Za-z.-]+$"
+          },
+          "uniqueItems": true
+        },
         "lastSync": {
           "type": "string",
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$"

--- a/scripts/aif-analyze-openspec-bootstrap.test.mjs
+++ b/scripts/aif-analyze-openspec-bootstrap.test.mjs
@@ -26,7 +26,83 @@ function assertNotIncludes(source, unexpected, filePath) {
   );
 }
 
+function parseFrontmatter(source, filePath) {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  assert.ok(match, `${filePath} should include YAML frontmatter`);
+
+  return new Map(match[1].split(/\r?\n/).flatMap((line) => {
+    const separator = line.indexOf(':');
+    if (separator <= 0) {
+      return [];
+    }
+
+    return [[line.slice(0, separator).trim(), line.slice(separator + 1).trim()]];
+  }));
+}
+
+function compareSemver(left, right) {
+  const parse = (value) => String(value).replace(/^['"]|['"]$/g, '').split('.').map(Number);
+  const leftParts = parse(left);
+  const rightParts = parse(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+
+  return 0;
+}
+
 describe('aif-analyze OpenSpec-native bootstrap contract', () => {
+  it('declares bounded metadata for the extension-owned aif-analyze skill', async () => {
+    const filePath = 'skills/aif-analyze/SKILL.md';
+    const frontmatter = parseFrontmatter(await readRepoFile(filePath), filePath);
+
+    for (const required of ['name', 'description', 'allowed-tools']) {
+      assert.ok(frontmatter.get(required), `${filePath} frontmatter should declare ${required}`);
+    }
+
+    assert.equal(frontmatter.get('name'), 'aif-analyze');
+
+    const allowedTools = frontmatter.get('allowed-tools');
+    for (const requiredTool of [
+      'Read',
+      'Write',
+      'Edit',
+      'Glob',
+      'Grep',
+      'Bash(mkdir *)',
+      'Bash(ai-factory aifhub-memory-tools *)',
+      'Bash(ai-factory aifhub-mode status --json)',
+      'Bash(node --input-type=module -e *openspec-runner.mjs*)',
+      'Bash(openspec init --tools none)',
+      'Skill',
+      'AskUserQuestion',
+      'Questions'
+    ]) {
+      assertIncludes(allowedTools, requiredTool, `${filePath} allowed-tools`);
+    }
+
+    assert.doesNotMatch(allowedTools, /(?:^|\s)Bash(?:\s|$)/, 'allowed-tools must not permit unrestricted Bash');
+    for (const overlyBroad of ['Bash(ai-factory *)', 'Bash(npx *)', 'Bash(openspec *)']) {
+      assertNotIncludes(allowedTools, overlyBroad, `${filePath} allowed-tools`);
+    }
+  });
+
+  it('declares the feature-level aif-analyze version freshness bump', async () => {
+    const filePath = 'skills/aif-analyze/SKILL.md';
+    const frontmatter = parseFrontmatter(await readRepoFile(filePath), filePath);
+    const version = frontmatter.get('version');
+
+    assert.ok(version, `${filePath} frontmatter should declare version`);
+    assert.match(version, /^['"]?\d+\.\d+\.\d+['"]?$/);
+    assert.ok(
+      compareSemver(version, '0.10.0') >= 0,
+      `${filePath} should include the feature-level metadata bump introduced with analyze version freshness`
+    );
+  });
+
   it('derives base-rule control flow from evidence without duplicating the generated-rules compiler', async () => {
     const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
     const template = await readRepoFile('skills/aif-analyze/references/rules-base-template.md');
@@ -388,6 +464,33 @@ describe('aif-analyze OpenSpec-native bootstrap contract', () => {
     ]) {
       assertIncludes(skill, expected, 'skills/aif-analyze/SKILL.md');
     }
+  });
+
+  it('recommends a user-owned update for supported but outdated OpenSpec without degrading bootstrap', async () => {
+    const skill = await readRepoFile('skills/aif-analyze/SKILL.md');
+    const compatibility = await readRepoFile('docs/openspec-compatibility.md');
+    const usage = await readRepoFile('docs/usage.md');
+    const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
+    const latestReviewedVersion = metadata.sources.openspec.version;
+    const combined = [skill, compatibility, usage].join('\n');
+
+    for (const expected of [
+      `latestReviewedVersion: "${latestReviewedVersion}"`,
+      'versionOutdated: boolean | null',
+      'compatible but older than the latest reviewed stable version',
+      'non-blocking update recommendation',
+      '`project-local`',
+      '`path`',
+      '`explicit`',
+      'Do not guess a package manager',
+      'Do not install, update, replace, or re-resolve OpenSpec automatically',
+      'do not recommend a downgrade'
+    ]) {
+      assertIncludes(combined, expected, 'OpenSpec analyze version freshness contract');
+    }
+
+    assertIncludes(skill, `latestReviewedVersion: "${latestReviewedVersion}"`, 'skills/aif-analyze/SKILL.md reviewed version');
+    assertIncludes(compatibility, `latestReviewedVersion: "${latestReviewedVersion}"`, 'docs/openspec-compatibility.md reviewed version');
   });
 
   it('documents compatible CLI initialization, manual skeletons, and no skill installation', async () => {

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -1851,6 +1851,8 @@ function summarizeOpenSpecDetection(detection) {
     nodeVersion: detection?.nodeVersion ?? null,
     nodeSupported: detection?.nodeSupported ?? null,
     versionSupported: detection?.versionSupported ?? null,
+    latestReviewedVersion: detection?.latestReviewedVersion ?? null,
+    versionOutdated: detection?.versionOutdated ?? null,
     command: detection?.command ?? null,
     commandSource: detection?.commandSource ?? null,
     reason: detection?.reason ?? null,

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -816,6 +816,7 @@ async function syncGeneratedRules(options = {}) {
       dryRun,
       baseOnly: true,
       changeSpecificSkipped: true,
+      openspecCli: result.openspecCli ?? null,
       results: [result],
       files: result.files ?? [],
       warnings: dedupeDiagnostics([
@@ -836,6 +837,7 @@ async function syncGeneratedRules(options = {}) {
   return {
     ok: results.every((result) => result.ok),
     dryRun,
+    openspecCli: results.find((result) => result.openspecCli !== null)?.openspecCli ?? null,
     results,
     files: results.flatMap((result) => result.files ?? []),
     warnings: dedupeDiagnostics(results.flatMap((result) => result.warnings ?? [])),
@@ -1839,6 +1841,8 @@ function summarizeOpenSpecDetection(detection) {
     nodeVersion: detection?.nodeVersion ?? null,
     nodeSupported: detection?.nodeSupported ?? null,
     versionSupported: detection?.versionSupported ?? null,
+    command: detection?.command ?? null,
+    commandSource: detection?.commandSource ?? null,
     reason: detection?.reason ?? null,
     errors: detection?.errors ?? []
   };
@@ -1867,7 +1871,11 @@ function createRunOptions(rootDir, options = {}) {
     command: options.command,
     env: options.env,
     executor: options.executor,
-    nodeVersion: options.nodeVersion
+    nodeVersion: options.nodeVersion,
+    platform: options.platform,
+    candidateExists: options.candidateExists,
+    execFile: options.execFile,
+    comSpec: options.comSpec
   };
 }
 
@@ -1942,6 +1950,7 @@ function renderSyncSection(sync) {
     '',
     `Generated rules files: ${sync.generatedRules?.files?.length ?? 0}`,
     `Validation skipped: ${sync.validation?.skipped ? 'yes' : 'no'}`,
+    ...renderOpenSpecCommand(sync.generatedRules?.openspecCli ?? sync.validation?.detection),
     ...renderDiagnostics('Warnings', sync.warnings ?? []),
     ...renderDiagnostics('Errors', sync.errors ?? [])
   ].join('\n');
@@ -1975,6 +1984,7 @@ function renderGeneratedRulesSection(generatedRules) {
     `Files: ${generatedRules.files.length}`,
     `Base-only sync: ${generatedRules.baseOnly ? 'yes' : 'no'}`,
     `Change-specific rules skipped: ${generatedRules.changeSpecificSkipped ? 'yes' : 'no'}`,
+    ...renderOpenSpecCommand(generatedRules.openspecCli),
     ...renderDiagnostics('Warnings', generatedRules.warnings),
     ...renderDiagnostics('Errors', generatedRules.errors)
   ].join('\n');
@@ -1987,9 +1997,21 @@ function renderValidationSection(validation) {
     `Skipped: ${validation.skipped ? 'yes' : 'no'}`,
     `Results: ${validation.results.length}`,
     `Skipped changes: ${validation.skippedChanges?.length ?? 0}`,
+    ...renderOpenSpecCommand(validation.detection),
     ...renderDiagnostics('Warnings', validation.warnings),
     ...renderDiagnostics('Errors', validation.errors)
   ].join('\n');
+}
+
+function renderOpenSpecCommand(detection) {
+  if (detection?.command === null || detection?.command === undefined) {
+    return [];
+  }
+
+  return [
+    `OpenSpec command: ${detection.command}`,
+    `OpenSpec command source: ${detection.commandSource ?? 'unknown'}`
+  ];
 }
 
 function renderLegacyDetectionSection(legacy) {
@@ -2163,6 +2185,7 @@ function createSkippedGeneratedRulesSync(dryRun, reason) {
     dryRun,
     skipped: true,
     reason,
+    openspecCli: null,
     results: [],
     files: [],
     warnings: [

--- a/scripts/aif-artifact-sync.mjs
+++ b/scripts/aif-artifact-sync.mjs
@@ -35,6 +35,9 @@ import {
   summarizeOpenSpecCoverage
 } from './openspec-coverage-matrix.mjs';
 import {
+  readOpenSpecSkipSpecsMarker
+} from './openspec-change-metadata.mjs';
+import {
   readOpenSpecRulesGateEvidence,
   resolveOpenSpecPolicy,
   summarizeOpenSpecPolicy
@@ -977,10 +980,17 @@ async function selectValidatableChanges(rootDir, changeIds) {
   const skippedChanges = [];
 
   for (const changeId of changeIds) {
-    const specRoot = path.join(rootDir, 'openspec', 'changes', changeId, 'specs');
+    const changeDir = path.join(rootDir, 'openspec', 'changes', changeId);
+    const specRoot = path.join(changeDir, 'specs');
     const specFiles = await listSpecFiles(specRoot, rootDir);
 
     if (specFiles.length === 0) {
+      const skipSpecs = await readOpenSpecSkipSpecsMarker(changeDir);
+      if (skipSpecs.declared || !skipSpecs.valid) {
+        validatable.push(changeId);
+        continue;
+      }
+
       skippedChanges.push({
         changeId,
         reason: 'no-delta-specs'

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -55,11 +55,13 @@ function missingCliDetection() {
     canValidate: false,
     canArchive: false,
     version: null,
+    command: 'openspec',
+    commandSource: 'path',
     reason: 'missing-cli',
     errors: [
       {
         code: 'missing-cli',
-        message: 'OpenSpec CLI is not available on PATH.'
+        message: "Selected OpenSpec CLI 'openspec' (path) is unavailable."
       }
     ]
   };
@@ -71,6 +73,8 @@ function availableCliDetection(overrides = {}) {
     canValidate: true,
     canArchive: true,
     version: '1.3.1',
+    command: overrides.command ?? 'openspec',
+    commandSource: overrides.commandSource ?? 'path',
     nodeVersion: overrides.nodeVersion ?? '20.19.0',
     nodeSupported: overrides.nodeSupported ?? true,
     versionSupported: overrides.versionSupported ?? true,
@@ -633,7 +637,88 @@ describe('artifact sync and export', () => {
     assert.equal(status.generatedRules.state, 'ok');
     assert.equal(result.validation.skipped, true);
     assert.equal(result.validation.reason, 'missing-cli');
+    assert.equal(result.generatedRules.openspecCli.command, 'openspec');
+    assert.equal(result.generatedRules.openspecCli.commandSource, 'path');
+    assert.equal(result.validation.detection.command, 'openspec');
+    assert.equal(result.validation.detection.commandSource, 'path');
+    const report = await readFixture(rootDir, '.ai-factory/state/mode-switches/2026-04-29T00-00-00-000Z-sync-openspec.md');
+    assert.match(report, /OpenSpec command: openspec/);
+    assert.match(report, /OpenSpec command source: path/);
     assert.equal(await pathExists(rootDir, '.ai-factory/state/mode-switches/2026-04-29T00-00-00-000Z-sync-openspec.md'), true);
+  });
+
+  it('propagates one explicit OpenSpec command through compiler detection, show, JSON, and human report', async () => {
+    const rootDir = await createTempRoot();
+    const detectionCalls = [];
+    const showCalls = [];
+    const command = 'custom-openspec';
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      '  openspec:',
+      '    validateOnSync: false',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/changes/explicit-cli/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/explicit-cli/specs/auth/spec.md', [
+      '# Auth',
+      '',
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Explicit CLI',
+      '',
+      'The system MUST preserve explicit CLI selection.',
+      ''
+    ].join('\n'));
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      changeId: 'explicit-cli',
+      command,
+      detectOpenSpec: async (options) => {
+        detectionCalls.push(options);
+        return availableCliDetection({ command, commandSource: 'explicit' });
+      },
+      showOpenSpecItem: async (itemName, options) => {
+        showCalls.push({ itemName, options });
+        return {
+          ok: true,
+          json: {
+            requirements: [{
+              title: 'Explicit CLI',
+              description: 'The system MUST preserve explicit CLI selection.',
+              scenarios: []
+            }]
+          }
+        };
+      },
+      timestamp: '2026-04-29T00-10-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(detectionCalls.length, 1);
+    assert.equal(detectionCalls[0].command, command);
+    assert.equal(showCalls.length, 1);
+    assert.equal(showCalls[0].options.command, command);
+    assert.deepEqual(result.generatedRules.openspecCli, {
+      available: true,
+      canValidate: true,
+      canArchive: true,
+      version: '1.3.1',
+      command,
+      commandSource: 'explicit',
+      reason: null
+    });
+    const report = await readFixture(rootDir, '.ai-factory/state/mode-switches/2026-04-29T00-10-00-000Z-sync-openspec.md');
+    assert.match(report, /OpenSpec command: custom-openspec/);
+    assert.match(report, /OpenSpec command source: explicit/);
   });
 
   it('syncs generated rules for all active OpenSpec changes', async () => {

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -843,6 +843,68 @@ describe('artifact sync and export', () => {
     assert.ok(result.validation.warnings.some((warning) => warning.code === 'no-delta-specs'));
   });
 
+  it('validates native skip_specs changes during all-change sync', async () => {
+    const rootDir = await createTempRoot();
+    const validated = [];
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      '  openspec:',
+      '    compileRulesOnSync: false',
+      'paths:',
+      '  plans: openspec/changes',
+      '  specs: openspec/specs',
+      '  state: .ai-factory/state',
+      '  qa: .ai-factory/qa',
+      '  generated_rules: .ai-factory/rules/generated',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/config.yaml', 'project: test\n');
+    await writeFixture(rootDir, 'openspec/changes/docs-only/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/docs-only/.openspec.yaml', [
+      'schema: spec-driven',
+      'created: 2026-08-09',
+      'skip_specs: true',
+      ''
+    ].join('\n'));
+    await writeFixture(rootDir, 'openspec/changes/nested-change/proposal.md', '# Proposal\n');
+    await writeFixture(rootDir, 'openspec/changes/nested-change/specs/area/capability/spec.md', [
+      '## ADDED Requirements',
+      '',
+      '### Requirement: Nested capability',
+      '',
+      'The system SHALL validate nested capability paths.',
+      '',
+      '#### Scenario: nested path is present',
+      '',
+      '- **WHEN** the nested delta is validated',
+      '- **THEN** validation succeeds',
+      ''
+    ].join('\n'));
+
+    const result = await syncOpenSpecArtifacts({
+      rootDir,
+      all: true,
+      detectOpenSpec: async () => availableCliDetection(),
+      validateOpenSpecChange: async (changeId) => {
+        validated.push(changeId);
+        return { ok: true, stdout: '{"valid":true}', stderr: '', json: { valid: true } };
+      },
+      getOpenSpecStatus: async (changeId) => ({
+        ok: true,
+        stdout: JSON.stringify({ changeId }),
+        stderr: '',
+        json: { changeId }
+      }),
+      timestamp: '2026-08-09T00-00-00-000Z'
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(validated, ['docs-only', 'nested-change']);
+    assert.equal(result.validation.skippedChanges.length, 0);
+    assert.ok(!result.validation.warnings.some((warning) => warning.code === 'no-delta-specs'));
+  });
+
   it('treats numeric-leading OpenSpec status rejection as non-blocking during sync', async () => {
     const rootDir = await createTempRoot();
     const changeId = '81-command-wrappers';

--- a/scripts/aif-artifact-sync.test.mjs
+++ b/scripts/aif-artifact-sync.test.mjs
@@ -55,6 +55,8 @@ function missingCliDetection() {
     canValidate: false,
     canArchive: false,
     version: null,
+    latestReviewedVersion: '1.8.0',
+    versionOutdated: null,
     command: 'openspec',
     commandSource: 'path',
     reason: 'missing-cli',
@@ -68,11 +70,14 @@ function missingCliDetection() {
 }
 
 function availableCliDetection(overrides = {}) {
+  const version = overrides.version ?? '1.3.1';
   return {
     available: true,
     canValidate: true,
     canArchive: true,
-    version: '1.3.1',
+    version,
+    latestReviewedVersion: '1.8.0',
+    versionOutdated: overrides.versionOutdated ?? version.localeCompare('1.8.0', 'en', { numeric: true }) < 0,
     command: overrides.command ?? 'openspec',
     commandSource: overrides.commandSource ?? 'path',
     nodeVersion: overrides.nodeVersion ?? '20.19.0',
@@ -91,6 +96,30 @@ afterEach(async () => {
 });
 
 describe('mode status', () => {
+  it('surfaces reviewed-version freshness for a supported old CLI', async () => {
+    const rootDir = await createTempRoot();
+    await writeFixture(rootDir, '.ai-factory/config.yaml', [
+      'aifhub:',
+      '  artifactProtocol: openspec',
+      ''
+    ].join('\n'));
+
+    const status = await getModeStatus({
+      rootDir,
+      detectOpenSpec: async () => availableCliDetection({
+        version: '1.4.0',
+        versionOutdated: true
+      })
+    });
+
+    assert.equal(status.openspecCli.state, 'available');
+    assert.equal(status.openspecCli.version, '1.4.0');
+    assert.equal(status.openspecCli.latestReviewedVersion, '1.8.0');
+    assert.equal(status.openspecCli.versionOutdated, true);
+    assert.equal(status.openspecCli.canValidate, true);
+    assert.equal(status.openspecCli.canArchive, true);
+  });
+
   it('reports OpenSpec mode and drift fields', async () => {
     const rootDir = await createTempRoot();
     await writeFixture(rootDir, '.ai-factory/config.yaml', [

--- a/scripts/aif-plan-openspec-artifacts.test.mjs
+++ b/scripts/aif-plan-openspec-artifacts.test.mjs
@@ -132,7 +132,10 @@ describe('aif-plan OpenSpec-native planning contract', () => {
       'openspec/changes/<change-id>/.openspec.yaml',
       'skip_specs: true',
       '>=1.7.0',
-      'older supported CLI'
+      'older supported CLI',
+      'retire_capabilities: true',
+      'explicitly authorizes capability retirement',
+      'must not infer retirement'
     ]) {
       assertIncludes(openspec, expected, 'OpenSpec-native section');
     }

--- a/scripts/aif-plan-openspec-artifacts.test.mjs
+++ b/scripts/aif-plan-openspec-artifacts.test.mjs
@@ -128,7 +128,11 @@ describe('aif-plan OpenSpec-native planning contract', () => {
       '## ADDED Requirements',
       '## MODIFIED Requirements',
       '## REMOVED Requirements',
-      '#### Scenario: <Scenario name>'
+      '#### Scenario: <Scenario name>',
+      'openspec/changes/<change-id>/.openspec.yaml',
+      'skip_specs: true',
+      '>=1.7.0',
+      'older supported CLI'
     ]) {
       assertIncludes(openspec, expected, 'OpenSpec-native section');
     }

--- a/scripts/aifhub-command-wrappers-contract.test.mjs
+++ b/scripts/aifhub-command-wrappers-contract.test.mjs
@@ -392,17 +392,41 @@ describe('AIFHub wrapper guidance contract', () => {
     const expectations = [
       ['README.md', [
         'ai-factory aifhub-migrate-legacy-plans --list',
-        'ai-factory aifhub-migrate-legacy-plans <change-id> --dry-run'
+        'ai-factory aifhub-migrate-legacy-plans <change-id> --dry-run',
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
       ]],
       ['docs/usage.md', [
         'ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules',
         'ai-factory aifhub-migrate-legacy-plans <change-id> --dry-run',
-        'ai-factory aifhub-migrate-legacy-plans --all --dry-run'
+        'ai-factory aifhub-migrate-legacy-plans --all --dry-run',
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
       ]],
       ['docs/openspec-validation.md', [
         'ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules',
         'ai-factory aifhub-done-readiness --change <change-id> --json',
-        'ai-factory aifhub-validate-artifacts --change <change-id> --json'
+        'ai-factory aifhub-validate-artifacts --change <change-id> --json',
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['docs/openspec-compatibility.md', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['docs/codex-agents.md', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['docs/claude-agents.md', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['skills/aif-done/SKILL.md', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['skills/aif-done/references/finalization-contract.md', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['agent-files/codex/aifhub-done-finalizer.toml', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+      ]],
+      ['agent-files/claude/aifhub-done-finalizer.md', [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json'
       ]],
       ['docs/spec-coverage.md', [
         'ai-factory aifhub-coverage --change <change-id> --write --json'

--- a/scripts/aifhub-command-wrappers-contract.test.mjs
+++ b/scripts/aifhub-command-wrappers-contract.test.mjs
@@ -1,14 +1,17 @@
 // aifhub-command-wrappers-contract.test.mjs - installed command wrapper contract tests
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
+const execFileAsync = promisify(execFile);
 
 const WRAPPER_COMMANDS = [
   {
@@ -45,6 +48,13 @@ const WRAPPER_COMMANDS = [
     module: './commands/aifhub-done-readiness.mjs',
     script: 'openspec-done-readiness.mjs',
     args: ['--change', 'add-oauth', '--json']
+  },
+  {
+    name: 'aifhub-done-finalizer',
+    description: 'Finalize a verified AIFHub OpenSpec change from an installed project.',
+    module: './commands/aifhub-done-finalizer.mjs',
+    script: 'openspec-done-finalizer.mjs',
+    args: ['--change', 'add-oauth', '--skip-specs', '--record-dirty-state', '--json']
   },
   {
     name: 'aifhub-validate-artifacts',
@@ -130,6 +140,76 @@ async function copyInstalledCommandLayout(userProjectDir) {
   }
 
   return extensionDir;
+}
+
+async function copyRealFinalizerLayout(userProjectDir) {
+  const extensionDir = path.join(userProjectDir, '.ai-factory', 'extensions', 'aifhub-extension');
+  await mkdir(path.join(extensionDir, 'commands'), { recursive: true });
+  await copyFile(
+    path.join(REPO_ROOT, 'commands', 'run-installed-script.mjs'),
+    path.join(extensionDir, 'commands', 'run-installed-script.mjs')
+  );
+  await copyFile(
+    path.join(REPO_ROOT, 'commands', 'aifhub-done-finalizer.mjs'),
+    path.join(extensionDir, 'commands', 'aifhub-done-finalizer.mjs')
+  );
+  await cp(
+    path.join(REPO_ROOT, 'scripts'),
+    path.join(extensionDir, 'scripts'),
+    { recursive: true }
+  );
+  return extensionDir;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runFinalizerWrapperHarness(userProjectDir, extensionDir) {
+  const harnessPath = path.join(tmpDir, 'run-finalizer-wrapper.mjs');
+  await writeFile(harnessPath, [
+    "import { pathToFileURL } from 'node:url';",
+    'const wrapperPath = process.env.AIFHUB_FINALIZER_WRAPPER_PATH;',
+    'const mod = await import(pathToFileURL(wrapperPath).href);',
+    'let actionHandler = null;',
+    'const chain = {',
+    '  description() { return this; },',
+    '  allowUnknownOption() { return this; },',
+    '  allowExcessArguments() { return this; },',
+    '  argument() { return this; },',
+    '  action(handler) { actionHandler = handler; return this; }',
+    '};',
+    'mod.register({ command() { return chain; } });',
+    'await actionHandler(process.argv.slice(2));'
+  ].join('\n'), 'utf8');
+
+  try {
+    const result = await execFileAsync(process.execPath, [
+      harnessPath,
+      '--change',
+      'missing-change',
+      '--json'
+    ], {
+      cwd: userProjectDir,
+      env: {
+        ...process.env,
+        AIFHUB_FINALIZER_WRAPPER_PATH: path.join(extensionDir, 'commands', 'aifhub-done-finalizer.mjs')
+      },
+      windowsHide: true
+    });
+    return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (err) {
+    return {
+      exitCode: typeof err?.code === 'number' ? err.code : (err?.status ?? 1),
+      stdout: String(err?.stdout ?? ''),
+      stderr: String(err?.stderr ?? '')
+    };
+  }
 }
 
 function createFakeProgram() {
@@ -240,6 +320,31 @@ describe('AIFHub installed command wrappers', () => {
       restoreEnvValue('AIFHUB_WRAPPER_TEST_MARKER', originalEnv.marker);
       process.exitCode = originalExitCode;
     }
+  });
+
+  it('runs the real installed finalizer graph without project-root helper scripts', async () => {
+    const userProjectDir = path.join(tmpDir, 'installed-finalizer-project');
+    await mkdir(userProjectDir, { recursive: true });
+    const extensionDir = await copyRealFinalizerLayout(userProjectDir);
+
+    assert.equal(
+      await pathExists(path.join(userProjectDir, 'scripts', 'openspec-done-finalizer.mjs')),
+      false,
+      'consumer project must not need a root finalizer script'
+    );
+
+    const command = await runFinalizerWrapperHarness(userProjectDir, extensionDir);
+    const output = JSON.parse(command.stdout);
+
+    assert.equal(command.exitCode, 2, 'unresolved explicit change should propagate command exit 2');
+    assert.equal(command.stderr, '');
+    assert.equal(output.ok, false);
+    assert.equal(output.mode, 'openspec-native');
+    assert.equal(output.change_id, null);
+    assert.equal(output.status, 'FAIL');
+    assert.equal(output.archive.status, 'SKIPPED');
+    assert.equal(output.errors[0].code, 'explicit-change-not-found');
+    assert.equal(Object.hasOwn(output, 'context'), false);
   });
 
   it('runInstalledScript forwards process settings and reports child failures', async () => {

--- a/scripts/aifhub-command-wrappers-contract.test.mjs
+++ b/scripts/aifhub-command-wrappers-contract.test.mjs
@@ -388,6 +388,55 @@ describe('AIFHub installed command wrappers', () => {
 });
 
 describe('AIFHub wrapper guidance contract', () => {
+  it('declares aif-done metadata for installed finalization', async () => {
+    const source = await readRepoFile('skills/aif-done/SKILL.md');
+    const frontmatterMatch = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+
+    assert.ok(frontmatterMatch, 'skills/aif-done/SKILL.md should include YAML frontmatter');
+
+    const fields = new Map(frontmatterMatch[1].split(/\r?\n/).map((line) => {
+      const separator = line.indexOf(':');
+      return separator === -1
+        ? [line.trim(), '']
+        : [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+    }));
+    const version = fields.get('version') ?? '';
+    const versionParts = version.split('.').map((part) => Number.parseInt(part, 10));
+    const argumentHint = fields.get('argument-hint') ?? '';
+    const allowedTools = fields.get('allowed-tools') ?? '';
+
+    assert.equal(fields.get('name'), 'aif-done');
+    assert.ok(fields.get('description'), 'aif-done description should be non-empty');
+    assert.match(version, /^\d+\.\d+\.\d+$/, 'aif-done version should use X.Y.Z semver');
+    assert.ok(
+      versionParts[0] > 1 || (versionParts[0] === 1 && versionParts[1] >= 3),
+      'aif-done version should be at least 1.3.0 for the installed finalizer capability'
+    );
+    for (const expected of ['change-id', 'plan-id', '--skip-specs', '--record-dirty-state']) {
+      assert.ok(argumentHint.includes(expected), `aif-done argument-hint should include ${expected}`);
+    }
+    for (const expected of [
+      'Read',
+      'Write',
+      'Edit',
+      'Glob',
+      'Grep',
+      'Bash(ai-factory aifhub-done-finalizer *)',
+      'Bash(git status *)',
+      'Bash(git branch --show-current)',
+      'Bash(git diff *)',
+      'Bash(git log *)',
+      'Bash(gh --version)'
+    ]) {
+      assert.ok(allowedTools.includes(expected), `aif-done allowed-tools should include ${expected}`);
+    }
+    assert.doesNotMatch(
+      allowedTools,
+      /(?:^|\s)Bash(?:\s|$)/,
+      'aif-done allowed-tools should not include unrestricted Bash'
+    );
+  });
+
   it('documents installed-project wrapper commands instead of root scripts', async () => {
     const expectations = [
       ['README.md', [

--- a/scripts/aifhub-command-wrappers-contract.test.mjs
+++ b/scripts/aifhub-command-wrappers-contract.test.mjs
@@ -385,6 +385,69 @@ describe('AIFHub installed command wrappers', () => {
     assert.deepEqual(calls[0].options.env, processLike.env);
     assert.equal(calls[0].options.stdio, 'inherit');
   });
+
+  it('runInstalledScript bounds a hanging child with TERM and KILL fallback', async () => {
+    const { runInstalledScript } = await import('../commands/run-installed-script.mjs');
+    const moduleUrl = pathToFileURL(path.join(tmpDir, 'installed', 'commands', 'wrapper.mjs')).href;
+    const processLike = {
+      execPath: 'node-bin',
+      env: {},
+      exitCode: undefined,
+      cwd: () => path.join(tmpDir, 'user-project')
+    };
+    const scheduled = [];
+    const cleared = [];
+    const signals = [];
+    let unrefCalls = 0;
+    const child = new EventEmitter();
+    child.kill = (signal) => {
+      signals.push(signal);
+      return true;
+    };
+    child.unref = () => {
+      unrefCalls += 1;
+    };
+    const setTimeoutImplementation = (callback, delay) => {
+      const handle = { callback, delay };
+      scheduled.push(handle);
+      return handle;
+    };
+    const clearTimeoutImplementation = (handle) => {
+      cleared.push(handle);
+    };
+
+    const pending = runInstalledScript('../scripts/example.mjs', [], moduleUrl, {
+      processLike,
+      spawn: () => child,
+      timeout: 100,
+      killTimeout: 25,
+      setTimeout: setTimeoutImplementation,
+      clearTimeout: clearTimeoutImplementation
+    });
+
+    assert.equal(scheduled.length, 1);
+    assert.equal(scheduled[0].delay, 100);
+    scheduled[0].callback();
+    assert.deepEqual(signals, ['SIGTERM']);
+    assert.equal(scheduled.length, 2);
+    assert.equal(scheduled[1].delay, 25);
+    scheduled[1].callback();
+
+    assert.equal(await pending, 124);
+    assert.equal(processLike.exitCode, 124);
+    assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+    assert.equal(unrefCalls, 1);
+    assert.ok(cleared.length >= 1);
+  });
+
+  it('configures a bounded timeout for the installed done finalizer wrapper', async () => {
+    const source = await readRepoFile('commands/aifhub-done-finalizer.mjs');
+
+    assert.match(source, /FINALIZER_TIMEOUT_MS/);
+    assert.match(source, /timeout:\s*FINALIZER_TIMEOUT_MS/);
+    assert.match(source, /killTimeout:\s*FINALIZER_KILL_TIMEOUT_MS/);
+    assert.match(source, /timeoutExitCode:\s*2/);
+  });
 });
 
 describe('AIFHub wrapper guidance contract', () => {
@@ -442,7 +505,8 @@ describe('AIFHub wrapper guidance contract', () => {
       ['README.md', [
         'ai-factory aifhub-migrate-legacy-plans --list',
         'ai-factory aifhub-migrate-legacy-plans <change-id> --dry-run',
-        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+        'ai-factory aifhub-done-finalizer --change <change-id> --json',
+        'Omitting `--change` delegates to the active-change resolver'
       ]],
       ['docs/usage.md', [
         'ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules',
@@ -454,7 +518,8 @@ describe('AIFHub wrapper guidance contract', () => {
         'ai-factory aifhub-write-gate-evidence --change add-oauth-login --gate rules',
         'ai-factory aifhub-done-readiness --change <change-id> --json',
         'ai-factory aifhub-validate-artifacts --change <change-id> --json',
-        'ai-factory aifhub-done-finalizer --change <change-id> --json'
+        'ai-factory aifhub-done-finalizer --change <change-id> --json',
+        'Omitting `--change` delegates to the active-change resolver'
       ]],
       ['docs/openspec-compatibility.md', [
         'ai-factory aifhub-done-finalizer --change <change-id> --json'

--- a/scripts/context-dedup.mjs
+++ b/scripts/context-dedup.mjs
@@ -35,6 +35,7 @@ const PURGE_LOCK_ATTEMPTS = Math.ceil((SQZ_TIMEOUT_MS + 5_000) / LOCK_RETRY_MS);
 const SQZ_REFERENCE_PATTERN = /^§ref:[0-9a-f]{8,64}§\s*$/iu;
 const SQZ_DELTA_PATTERN = /^§delta:[0-9a-f]{8,64}§(?:\r?\n|$)/iu;
 const UNSAFE_YAML_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const PROCESS_LEDGER_TRANSACTIONS = new Map();
 
 export function defaultContextDedupPolicy() {
   return {
@@ -265,22 +266,23 @@ export async function recordRead(options = {}) {
   const stateDir = resolveDedupStateDir({ ...options, policy });
   await assertSafeStateDir(rootDir, stateDir);
   const ledgerPath = resolveLedgerPath(sessionId, { ...options, rootDir, policy });
+  const releaseProcessTransaction = await acquireProcessLedgerTransaction(ledgerPath);
   let sessionLock;
   try {
-    sessionLock = await acquireSessionTransactionLock(rootDir, stateDir, ledgerPath);
-  } catch (error) {
-    return {
-      ...decision('full', 'Ledger lock could not be acquired; serving full content.', {
-        relativePath,
-        digest,
-        bytes,
-        content
-      }),
-      warnings: [{ code: 'context-dedup-ledger-unwritable', severity: 'warning', message: error.message }]
-    };
-  }
+    try {
+      sessionLock = await acquireSessionTransactionLock(rootDir, stateDir, ledgerPath);
+    } catch (error) {
+      return {
+        ...decision('full', 'Ledger lock could not be acquired; serving full content.', {
+          relativePath,
+          digest,
+          bytes,
+          content
+        }),
+        warnings: [{ code: 'context-dedup-ledger-unwritable', severity: 'warning', message: error.message }]
+      };
+    }
 
-  try {
     const { ledger, warnings } = await loadLedger({ ...options, rootDir, policy, sessionId });
     const existing = ledger.entries[relativePath] ?? null;
     const now = new Date().toISOString();
@@ -417,6 +419,7 @@ export async function recordRead(options = {}) {
     };
   } finally {
     await releaseLedgerLock(sessionLock);
+    releaseProcessTransaction();
   }
 }
 
@@ -774,12 +777,15 @@ export async function purgeSession(options = {}) {
     rootDir,
     stateDir
   );
-  const sessionLock = await acquireLedgerLock(resolveSessionLockPath(ledgerPath), rootDir);
+  const releaseProcessTransaction = await acquireProcessLedgerTransaction(ledgerPath);
+  let sessionLock;
   try {
+    sessionLock = await acquireLedgerLock(resolveSessionLockPath(ledgerPath), rootDir);
     await rm(sessionDir, { recursive: true, force: true });
     return { all: false, sessionId, removed: [toPosix(path.relative(rootDir, sessionDir))] };
   } finally {
     await releaseLedgerLock(sessionLock);
+    releaseProcessTransaction();
   }
 }
 
@@ -1062,6 +1068,28 @@ function resolveSessionLockPath(ledgerPath) {
   const sessionDir = path.dirname(ledgerPath);
   const dedupDir = path.dirname(sessionDir);
   return path.join(path.dirname(dedupDir), '.context-dedup-locks', `${path.basename(sessionDir)}.lock`);
+}
+
+async function acquireProcessLedgerTransaction(ledgerPath) {
+  const resolvedPath = path.resolve(ledgerPath);
+  const key = process.platform === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
+  const previous = PROCESS_LEDGER_TRANSACTIONS.get(key) ?? Promise.resolve();
+  let releaseCurrent;
+  const current = new Promise((resolve) => {
+    releaseCurrent = resolve;
+  });
+  PROCESS_LEDGER_TRANSACTIONS.set(key, current);
+  await previous;
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    releaseCurrent();
+    if (PROCESS_LEDGER_TRANSACTIONS.get(key) === current) {
+      PROCESS_LEDGER_TRANSACTIONS.delete(key);
+    }
+  };
 }
 
 async function acquireLedgerLock(lockPath, rootDir, options = {}) {

--- a/scripts/context-dedup.test.mjs
+++ b/scripts/context-dedup.test.mjs
@@ -1103,18 +1103,28 @@ describe('session summary and purge', () => {
   it('serializes concurrent updates without losing read totals', async () => {
     const policy = await enabledPolicy();
     const content = body('concurrent');
+    const concurrentReads = 200;
 
     const results = await Promise.all(
-      Array.from({ length: 12 }, () =>
+      Array.from({ length: concurrentReads }, () =>
         recordRead({ filePath: 'src/session.ts', content, rootDir, policy, sessionId: 'parallel' }))
     );
     const summary = await summarizeSession({ rootDir, policy, sessionId: 'parallel' });
 
-    assert.equal(summary.reads, 12);
-    assert.equal(summary.dedupHits, 11);
-    assert.equal(results.filter((result) => result.decision === 'full').length, 1);
-    assert.equal(results.filter((result) => result.decision === 'deduplicated').length, 11);
-    assert.ok(results.every((result) => !result.warnings.some((warning) => warning.code === 'context-dedup-ledger-unwritable')));
+    assert.deepEqual({
+      reads: summary.reads,
+      dedupHits: summary.dedupHits,
+      fullReads: results.filter((result) => result.decision === 'full').length,
+      deduplicatedReads: results.filter((result) => result.decision === 'deduplicated').length,
+      unwritableWarnings: results.filter((result) =>
+        result.warnings.some((warning) => warning.code === 'context-dedup-ledger-unwritable')).length
+    }, {
+      reads: concurrentReads,
+      dedupHits: concurrentReads - 1,
+      fullReads: 1,
+      deduplicatedReads: concurrentReads - 1,
+      unwritableWarnings: 0
+    });
   });
 
   it('writes a schema-versioned ledger', async () => {

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -779,6 +779,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const docsIndex = await readRepoFile('docs/README.md');
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
+    const readmeCompatibility = extractSection(readme, '## OpenSpec Compatibility');
 
     assert.equal(openspec.version, '1.8.0');
     assert.equal(openspec.baselineVersion, '1.3.1');
@@ -789,7 +790,11 @@ describe('complete OpenSpec workflow documentation contract', () => {
     assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.8.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec `1.8.0`', 'README.md');
+    assertIncludes(
+      readmeCompatibility,
+      `The reviewed OpenSpec baseline is OpenSpec \`${openspec.version}\``,
+      'README.md OpenSpec Compatibility reviewed baseline'
+    );
     assertIncludes(docsIndex, 'OpenSpec 1.8.0', 'docs/README.md');
 
     for (const expected of [

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -374,7 +374,11 @@ describe('complete OpenSpec workflow documentation contract', () => {
       ['docs/usage.md', usage],
       ['docs/openspec-validation.md', validation]
     ]) {
-      assertIncludes(source, '/aif-done <change-id> --record-dirty-state', label);
+      assertIncludes(
+        source,
+        'ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json',
+        label
+      );
       assertIncludes(source, 'git status --short', label);
       assertIncludes(source, 'final QA evidence', label);
       assertIncludes(source, 'dirty workspace', label);
@@ -382,7 +386,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
 
     assertIncludes(
       usage,
-      '/aif-done <change-id> --skip-specs --record-dirty-state',
+      'ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json',
       'docs/usage.md'
     );
     assertNotIncludes(
@@ -398,7 +402,13 @@ describe('complete OpenSpec workflow documentation contract', () => {
   });
 
   it('documents installed-project helper execution through AIFHub wrappers', async () => {
+    const readme = await readRepoFile('README.md');
+    const usage = await readRepoFile('docs/usage.md');
     const validation = await readRepoFile('docs/openspec-validation.md');
+    const compatibility = await readRepoFile('docs/openspec-compatibility.md');
+    const codexAgents = await readRepoFile('docs/codex-agents.md');
+    const claudeAgents = await readRepoFile('docs/claude-agents.md');
+    const changelog = await readRepoFile('CHANGELOG.md');
     const handoffProfile = await readRepoFile('docs/handoff-validation-profile.md');
 
     for (const expected of [
@@ -408,6 +418,33 @@ describe('complete OpenSpec workflow documentation contract', () => {
       assertIncludes(validation, expected, 'docs/openspec-validation.md');
     }
 
+    for (const [label, source] of [
+      ['README.md', readme],
+      ['docs/usage.md', usage],
+      ['docs/openspec-validation.md', validation],
+      ['docs/openspec-compatibility.md', compatibility],
+      ['docs/codex-agents.md', codexAgents],
+      ['docs/claude-agents.md', claudeAgents],
+      ['CHANGELOG.md', changelog]
+    ]) {
+      assertIncludes(
+        source,
+        'ai-factory aifhub-done-finalizer --change <change-id> --json',
+        label
+      );
+    }
+
+    for (const expected of [
+      'Explicit non-empty',
+      'project-local',
+      '`PATH`',
+      'auto-install',
+      'commandSource',
+      'Filesystem-based'
+    ]) {
+      assertIncludes(compatibility, expected, 'docs/openspec-compatibility.md');
+    }
+
     assertIncludes(
       handoffProfile,
       'ai-factory aifhub-handoff-gate-summary --change <change-id> --stage review --json',
@@ -415,13 +452,30 @@ describe('complete OpenSpec workflow documentation contract', () => {
     );
 
     for (const [label, source] of [
+      ['README.md', readme],
+      ['docs/usage.md', usage],
       ['docs/openspec-validation.md', validation],
+      ['docs/openspec-compatibility.md', compatibility],
+      ['docs/codex-agents.md', codexAgents],
+      ['docs/claude-agents.md', claudeAgents],
       ['docs/handoff-validation-profile.md', handoffProfile]
     ]) {
       assert.doesNotMatch(
         source,
         /\bnode\s+scripts\/[A-Za-z0-9_.-]+\.mjs\b/,
         `${label} should not expose root scripts as installed-project helper commands`
+      );
+    }
+
+    for (const [label, source] of [
+      ['docs/usage.md', usage],
+      ['docs/openspec-validation.md', validation],
+      ['docs/openspec-compatibility.md', compatibility]
+    ]) {
+      assert.match(
+        source,
+        /scripts\/openspec-[A-Za-z0-9_.-]+\.mjs[^\n]*(?:extension-local|implementation module)|(?:extension-local|implementation module)[^\n]*scripts\/openspec-[A-Za-z0-9_.-]+\.mjs/i,
+        `${label} should identify internal OpenSpec module references as implementation-only`
       );
     }
   });

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.4.0 reviewed baseline and adapter-only boundaries', async () => {
+  it('documents the OpenSpec 1.4.1 reviewed baseline and adapter-only boundaries', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -780,21 +780,21 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
 
-    assert.equal(openspec.version, '1.4.0');
+    assert.equal(openspec.version, '1.4.1');
     assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
-    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0']);
+    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1']);
     assert.deepEqual(openspec.reviewedPrereleaseVersions, []);
     assert.equal(openspec.lastSync, '2026-08-09');
-    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.4.0', 'aifhub-extension.json');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.4.1', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec `1.4.0`', 'README.md');
-    assertIncludes(docsIndex, 'OpenSpec 1.4.0', 'docs/README.md');
+    assertIncludes(readme, 'OpenSpec `1.4.1`', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.4.1', 'docs/README.md');
 
     for (const expected of [
-      'OpenSpec 1.4.0 Reviewed Baseline',
-      'OpenSpec `1.4.0`',
+      'OpenSpec 1.4.1 Reviewed Baseline',
+      'OpenSpec `1.4.1`',
       'Baseline `1.3.1`',
       'Reviewed stable releases',
       'Kimi CLI',
@@ -802,6 +802,8 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'sync skills',
       'case-insensitive requirement headers',
       'clearer validation hints',
+      '`workspace.yaml`',
+      '`openspec update`',
       '.openspec-workspace/view.yaml',
       '/opsx:*',
       'adapter-only',
@@ -813,7 +815,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '`openspec update` is upstream OpenSpec behavior',
       '`/aif-mode sync` compiles AIFHub generated rules'
     ]) {
-      assertIncludes(combinedDocs, expected, 'OpenSpec 1.4.0 docs baseline');
+      assertIncludes(combinedDocs, expected, 'OpenSpec 1.4.1 docs baseline');
     }
 
     for (const forbiddenClaim of [
@@ -824,7 +826,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'AIFHub owns workspace beta state',
       'AIFHub runs openspec update'
     ]) {
-      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.4.0 docs ownership boundaries');
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.4.1 docs ownership boundaries');
     }
   });
 

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.5.0 reviewed baseline and adapter-only boundaries', async () => {
+  it('documents the OpenSpec 1.5.0 baseline, reviewed 1.6 beta, and adapter-only boundaries', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -784,7 +784,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
     assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0']);
-    assert.deepEqual(openspec.reviewedPrereleaseVersions, []);
+    assert.deepEqual(openspec.reviewedPrereleaseVersions, ['1.6.0-beta.1']);
     assert.equal(openspec.lastSync, '2026-08-09');
     assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.5.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
@@ -808,6 +808,12 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'config parsing',
       'CRLF',
       'additive `root`',
+      '`1.6.0-beta.1`',
+      'reviewed but unsupported',
+      'archive validation failures return a non-zero exit code',
+      '/opsx:update',
+      'Oh My Pi',
+      'Trae',
       '.openspec-workspace/view.yaml',
       '/opsx:*',
       'adapter-only',

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.5.0 baseline, reviewed 1.6 beta, and adapter-only boundaries', async () => {
+  it('documents the OpenSpec 1.6.0 reviewed baseline and adapter-only boundaries', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -780,21 +780,21 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
 
-    assert.equal(openspec.version, '1.5.0');
+    assert.equal(openspec.version, '1.6.0');
     assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
-    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0']);
+    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0']);
     assert.deepEqual(openspec.reviewedPrereleaseVersions, ['1.6.0-beta.1']);
     assert.equal(openspec.lastSync, '2026-08-09');
-    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.5.0', 'aifhub-extension.json');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.6.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec `1.5.0`', 'README.md');
-    assertIncludes(docsIndex, 'OpenSpec 1.5.0', 'docs/README.md');
+    assertIncludes(readme, 'OpenSpec `1.6.0`', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.6.0', 'docs/README.md');
 
     for (const expected of [
-      'OpenSpec 1.5.0 Reviewed Baseline',
-      'OpenSpec `1.5.0`',
+      'OpenSpec 1.6.0 Reviewed Baseline',
+      'OpenSpec `1.6.0`',
       'Baseline `1.3.1`',
       'Reviewed stable releases',
       'Kimi CLI',
@@ -814,6 +814,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '/opsx:update',
       'Oh My Pi',
       'Trae',
+      'nested specs and task files',
       '.openspec-workspace/view.yaml',
       '/opsx:*',
       'adapter-only',

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.4.1 reviewed baseline and adapter-only boundaries', async () => {
+  it('documents the OpenSpec 1.5.0 reviewed baseline and adapter-only boundaries', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -780,21 +780,21 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
 
-    assert.equal(openspec.version, '1.4.1');
+    assert.equal(openspec.version, '1.5.0');
     assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
-    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1']);
+    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0']);
     assert.deepEqual(openspec.reviewedPrereleaseVersions, []);
     assert.equal(openspec.lastSync, '2026-08-09');
-    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.4.1', 'aifhub-extension.json');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.5.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec `1.4.1`', 'README.md');
-    assertIncludes(docsIndex, 'OpenSpec 1.4.1', 'docs/README.md');
+    assertIncludes(readme, 'OpenSpec `1.5.0`', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.5.0', 'docs/README.md');
 
     for (const expected of [
-      'OpenSpec 1.4.1 Reviewed Baseline',
-      'OpenSpec `1.4.1`',
+      'OpenSpec 1.5.0 Reviewed Baseline',
+      'OpenSpec `1.5.0`',
       'Baseline `1.3.1`',
       'Reviewed stable releases',
       'Kimi CLI',
@@ -804,6 +804,10 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'clearer validation hints',
       '`workspace.yaml`',
       '`openspec update`',
+      'Stores',
+      'config parsing',
+      'CRLF',
+      'additive `root`',
       '.openspec-workspace/view.yaml',
       '/opsx:*',
       'adapter-only',
@@ -815,7 +819,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '`openspec update` is upstream OpenSpec behavior',
       '`/aif-mode sync` compiles AIFHub generated rules'
     ]) {
-      assertIncludes(combinedDocs, expected, 'OpenSpec 1.4.1 docs baseline');
+      assertIncludes(combinedDocs, expected, 'OpenSpec 1.5.0 docs baseline');
     }
 
     for (const forbiddenClaim of [
@@ -826,7 +830,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'AIFHub owns workspace beta state',
       'AIFHub runs openspec update'
     ]) {
-      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.4.1 docs ownership boundaries');
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.5.0 docs ownership boundaries');
     }
   });
 

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.4.1 reviewed baseline and adapter-only boundaries', async () => {
+  it('documents the OpenSpec 1.4.0 reviewed baseline and adapter-only boundaries', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -780,19 +780,23 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
 
-    assert.equal(openspec.version, '1.4.1');
+    assert.equal(openspec.version, '1.4.0');
+    assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
-    assert.equal(openspec.lastSync, '2026-06-10');
-    assertIncludes(openspec.notes, 'upstream OpenSpec 1.4.1', 'aifhub-extension.json');
+    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0']);
+    assert.deepEqual(openspec.reviewedPrereleaseVersions, []);
+    assert.equal(openspec.lastSync, '2026-08-09');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.4.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec 1.4.1', 'README.md');
-    assertIncludes(docsIndex, 'OpenSpec 1.4.1', 'docs/README.md');
+    assertIncludes(readme, 'OpenSpec `1.4.0`', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.4.0', 'docs/README.md');
 
     for (const expected of [
-      'OpenSpec 1.4.1 Reviewed Baseline',
-      'OpenSpec `1.4.1`',
-      '`openspec update`',
+      'OpenSpec 1.4.0 Reviewed Baseline',
+      'OpenSpec `1.4.0`',
+      'Baseline `1.3.1`',
+      'Reviewed stable releases',
       'Kimi CLI',
       'Mistral Vibe',
       'sync skills',
@@ -809,7 +813,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '`openspec update` is upstream OpenSpec behavior',
       '`/aif-mode sync` compiles AIFHub generated rules'
     ]) {
-      assertIncludes(combinedDocs, expected, 'OpenSpec 1.4.1 docs baseline');
+      assertIncludes(combinedDocs, expected, 'OpenSpec 1.4.0 docs baseline');
     }
 
     for (const forbiddenClaim of [
@@ -820,7 +824,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'AIFHub owns workspace beta state',
       'AIFHub runs openspec update'
     ]) {
-      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.4.1 docs ownership boundaries');
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.4.0 docs ownership boundaries');
     }
   });
 

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.7.0 reviewed baseline and native lifecycle metadata', async () => {
+  it('documents the OpenSpec 1.8.0 reviewed baseline and safe lifecycle metadata', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -780,21 +780,21 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
 
-    assert.equal(openspec.version, '1.7.0');
+    assert.equal(openspec.version, '1.8.0');
     assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
-    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0', '1.7.0']);
+    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0', '1.7.0', '1.8.0']);
     assert.deepEqual(openspec.reviewedPrereleaseVersions, ['1.6.0-beta.1']);
     assert.equal(openspec.lastSync, '2026-08-09');
-    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.7.0', 'aifhub-extension.json');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.8.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec `1.7.0`', 'README.md');
-    assertIncludes(docsIndex, 'OpenSpec 1.7.0', 'docs/README.md');
+    assertIncludes(readme, 'OpenSpec `1.8.0`', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.8.0', 'docs/README.md');
 
     for (const expected of [
-      'OpenSpec 1.7.0 Reviewed Baseline',
-      'OpenSpec `1.7.0`',
+      'OpenSpec 1.8.0 Reviewed Baseline',
+      'OpenSpec `1.8.0`',
       'Baseline `1.3.1`',
       'Reviewed stable releases',
       'Kimi CLI',
@@ -821,6 +821,12 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'leading digits',
       'nested spec folders',
       'UTF-8 BOM',
+      '`retire_capabilities: true`',
+      'scenario loss',
+      'nested task progress',
+      'agents target',
+      'MiniMax Code',
+      'Rovo Dev CLI',
       '.openspec-workspace/view.yaml',
       '/opsx:*',
       'adapter-only',
@@ -832,7 +838,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '`openspec update` is upstream OpenSpec behavior',
       '`/aif-mode sync` compiles AIFHub generated rules'
     ]) {
-      assertIncludes(combinedDocs, expected, 'OpenSpec 1.7.0 docs baseline');
+      assertIncludes(combinedDocs, expected, 'OpenSpec 1.8.0 docs baseline');
     }
 
     for (const forbiddenClaim of [
@@ -843,7 +849,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'AIFHub owns workspace beta state',
       'AIFHub runs openspec update'
     ]) {
-      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.7.0 docs ownership boundaries');
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.8.0 docs ownership boundaries');
     }
   });
 

--- a/scripts/docs-workflow-contract.test.mjs
+++ b/scripts/docs-workflow-contract.test.mjs
@@ -772,7 +772,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
     }
   });
 
-  it('documents the OpenSpec 1.6.0 reviewed baseline and adapter-only boundaries', async () => {
+  it('documents the OpenSpec 1.7.0 reviewed baseline and native lifecycle metadata', async () => {
     const metadata = JSON.parse(await readRepoFile('aifhub-extension.json'));
     const readme = await readRepoFile('README.md');
     const compatibility = await readRepoFile('docs/openspec-compatibility.md');
@@ -780,21 +780,21 @@ describe('complete OpenSpec workflow documentation contract', () => {
     const openspec = metadata.sources.openspec;
     const combinedDocs = [readme, compatibility, docsIndex].join('\n');
 
-    assert.equal(openspec.version, '1.6.0');
+    assert.equal(openspec.version, '1.7.0');
     assert.equal(openspec.baselineVersion, '1.3.1');
     assert.equal(openspec.supportedRange, '>=1.3.1 <2.0.0');
-    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0']);
+    assert.deepEqual(openspec.reviewedStableVersions, ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0', '1.7.0']);
     assert.deepEqual(openspec.reviewedPrereleaseVersions, ['1.6.0-beta.1']);
     assert.equal(openspec.lastSync, '2026-08-09');
-    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.6.0', 'aifhub-extension.json');
+    assertIncludes(openspec.notes, 'upstream OpenSpec 1.3.1 through 1.7.0', 'aifhub-extension.json');
     assertIncludes(openspec.notes, 'adapter-only', 'aifhub-extension.json');
 
-    assertIncludes(readme, 'OpenSpec `1.6.0`', 'README.md');
-    assertIncludes(docsIndex, 'OpenSpec 1.6.0', 'docs/README.md');
+    assertIncludes(readme, 'OpenSpec `1.7.0`', 'README.md');
+    assertIncludes(docsIndex, 'OpenSpec 1.7.0', 'docs/README.md');
 
     for (const expected of [
-      'OpenSpec 1.6.0 Reviewed Baseline',
-      'OpenSpec `1.6.0`',
+      'OpenSpec 1.7.0 Reviewed Baseline',
+      'OpenSpec `1.7.0`',
       'Baseline `1.3.1`',
       'Reviewed stable releases',
       'Kimi CLI',
@@ -815,6 +815,12 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'Oh My Pi',
       'Trae',
       'nested specs and task files',
+      '.openspec.yaml',
+      '`skip_specs: true`',
+      '`openspec instructions archive --change <id> --json`',
+      'leading digits',
+      'nested spec folders',
+      'UTF-8 BOM',
       '.openspec-workspace/view.yaml',
       '/opsx:*',
       'adapter-only',
@@ -826,7 +832,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       '`openspec update` is upstream OpenSpec behavior',
       '`/aif-mode sync` compiles AIFHub generated rules'
     ]) {
-      assertIncludes(combinedDocs, expected, 'OpenSpec 1.5.0 docs baseline');
+      assertIncludes(combinedDocs, expected, 'OpenSpec 1.7.0 docs baseline');
     }
 
     for (const forbiddenClaim of [
@@ -837,7 +843,7 @@ describe('complete OpenSpec workflow documentation contract', () => {
       'AIFHub owns workspace beta state',
       'AIFHub runs openspec update'
     ]) {
-      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.5.0 docs ownership boundaries');
+      assertNotIncludes(combinedDocs, forbiddenClaim, 'OpenSpec 1.7.0 docs ownership boundaries');
     }
   });
 

--- a/scripts/openspec-artifact-validator.mjs
+++ b/scripts/openspec-artifact-validator.mjs
@@ -19,6 +19,9 @@ import {
 import {
   getLatestGateResult
 } from './aif-gate-result.mjs';
+import {
+  readOpenSpecSkipSpecsMarker
+} from './openspec-change-metadata.mjs';
 
 export const ARTIFACT_CONTRACT_SCHEMA_VERSION = 1;
 export const ARTIFACT_CONTRACT_VALIDATOR = 'aifhub-openspec-artifact-contract';
@@ -81,10 +84,11 @@ export async function validateOpenSpecArtifactContract(options = {}) {
     rootDir
   });
   const artifacts = canonical.canonicalArtifacts ?? {};
+  const skipSpecs = await readOpenSpecSkipSpecsMarker(changeDir);
 
   checks.push(...inspectRequiredArtifacts(artifacts));
   checks.push(inspectDesignArtifact(artifacts.design, config.requireDesign));
-  checks.push(inspectDeltaSpecs(artifacts, config));
+  checks.push(inspectDeltaSpecs(artifacts, config, skipSpecs, rootDir));
   checks.push(...await inspectRuntimeFiles(rootDir, changeDir));
   checks.push(...await inspectVerificationEvidence(changeId, {
     ...options,
@@ -225,7 +229,7 @@ function inspectDesignArtifact(design, requireDesign) {
   });
 }
 
-function inspectDeltaSpecs(artifacts, config) {
+function inspectDeltaSpecs(artifacts, config, skipSpecs, rootDir) {
   const deltaSpecs = Array.isArray(artifacts.deltaSpecs) ? artifacts.deltaSpecs : [];
   const proposal = artifacts.proposal;
   const hasSkipReason = proposal?.exists && hasExplicitSkipSpecsReason(proposal.content);
@@ -236,6 +240,24 @@ function inspectDeltaSpecs(artifacts, config) {
       status: 'pass',
       path: deltaSpecs[0].path,
       message: `Found ${deltaSpecs.length} OpenSpec delta spec file(s).`
+    });
+  }
+
+  if (skipSpecs?.declared) {
+    return createCheck({
+      id: 'delta-specs-present',
+      status: 'pass',
+      path: toPosix(path.relative(rootDir, skipSpecs.metadataPath)),
+      message: 'No delta specs are required because .openspec.yaml declares native skip_specs: true.'
+    });
+  }
+
+  if (skipSpecs?.valid === false) {
+    return createCheck({
+      id: 'delta-specs-present',
+      status: 'fail',
+      path: toPosix(path.relative(rootDir, skipSpecs.metadataPath)),
+      message: `OpenSpec skip_specs metadata is invalid: ${skipSpecs.invalidReason}`
     });
   }
 
@@ -252,7 +274,7 @@ function inspectDeltaSpecs(artifacts, config) {
     id: 'delta-specs-present',
     status: config.allowMissingSpecs ? 'warn' : 'fail',
     path: `openspec/changes/${config.changeIdPlaceholder ?? '<change-id>'}/specs/**/spec.md`,
-    message: 'OpenSpec changes must include specs/**/spec.md unless proposal.md has an explicit docs/tooling-only skip-specs reason.'
+    message: 'OpenSpec changes must include specs/**/spec.md unless .openspec.yaml declares skip_specs: true or proposal.md preserves an explicit legacy docs/tooling-only skip-specs reason.'
   });
 }
 
@@ -708,7 +730,7 @@ function chooseSuggestedNext(changeId, checks) {
   if (failing?.id === 'delta-specs-present') {
     return {
       command: `/aif-mode sync --change ${changeId}`,
-      reason: 'add delta specs or document an explicit docs/tooling-only skip-specs reason before syncing again'
+      reason: 'add delta specs or declare native skip_specs: true in .openspec.yaml before syncing again'
     };
   }
 

--- a/scripts/openspec-artifact-validator.test.mjs
+++ b/scripts/openspec-artifact-validator.test.mjs
@@ -184,6 +184,56 @@ describe('OpenSpec artifact contract validator', () => {
     assert.equal(getCheck(result, 'delta-specs-present').status, 'fail');
   });
 
+  it('accepts native OpenSpec skip_specs metadata when delta specs are intentionally absent', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await rm(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'specs'), {
+      recursive: true,
+      force: true
+    });
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/.openspec.yaml', [
+      'schema: spec-driven',
+      'created: 2026-08-09',
+      'skip_specs: true',
+      ''
+    ].join('\n'));
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.notEqual(result.status, 'fail');
+    assert.equal(result.blocking, false);
+    assert.equal(getCheck(result, 'delta-specs-present').status, 'pass');
+    assert.equal(getCheck(result, 'delta-specs-present').path, 'openspec/changes/add-oauth/.openspec.yaml');
+    assert.match(getCheck(result, 'delta-specs-present').message, /skip_specs: true/);
+  });
+
+  it('fails closed when native skip_specs metadata is not boolean', async () => {
+    const rootDir = await createTempRoot();
+    await createValidChange(rootDir);
+    await rm(path.join(rootDir, 'openspec', 'changes', 'add-oauth', 'specs'), {
+      recursive: true,
+      force: true
+    });
+    await writeFixture(rootDir, 'openspec/changes/add-oauth/.openspec.yaml', [
+      'schema: spec-driven',
+      'skip_specs: "true"',
+      ''
+    ].join('\n'));
+
+    const result = await validateOpenSpecArtifactContract({
+      rootDir,
+      changeId: 'add-oauth'
+    });
+
+    assert.equal(result.status, 'fail');
+    assert.equal(result.blocking, true);
+    assert.equal(getCheck(result, 'delta-specs-present').path, 'openspec/changes/add-oauth/.openspec.yaml');
+    assert.match(getCheck(result, 'delta-specs-present').message, /boolean true or false/);
+  });
+
   it('warns when generated rules are stale and suggests sync', async () => {
     const rootDir = await createTempRoot();
     await createValidChange(rootDir);

--- a/scripts/openspec-change-metadata.mjs
+++ b/scripts/openspec-change-metadata.mjs
@@ -1,0 +1,148 @@
+// openspec-change-metadata.mjs - bounded readers for OpenSpec per-change metadata
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const OPENSPEC_CHANGE_METADATA_FILE = '.openspec.yaml';
+
+export async function readOpenSpecSkipSpecsMarker(changeDir, options = {}) {
+  const metadataPath = path.join(changeDir, OPENSPEC_CHANGE_METADATA_FILE);
+  const read = options.readFile ?? readFile;
+  let raw;
+
+  try {
+    raw = await read(metadataPath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return createMarker({ metadataPath, exists: false });
+    }
+
+    return createMarker({
+      metadataPath,
+      exists: true,
+      mentioned: true,
+      valid: false,
+      invalidReason: `Unable to read ${OPENSPEC_CHANGE_METADATA_FILE}.`
+    });
+  }
+
+  const normalized = String(raw ?? '').replace(/^\uFEFF/, '');
+  const jsonMarker = parseJsonContainer(normalized, metadataPath);
+  if (jsonMarker !== null) {
+    return jsonMarker;
+  }
+
+  const declarations = [];
+  for (const rawLine of normalized.split(/\r?\n/)) {
+    const match = rawLine.match(/^(?:skip_specs|(['"])skip_specs\1)\s*:\s*(.*?)\s*$/);
+    if (match) {
+      declarations.push(stripInlineComment(match[2]).trim());
+    }
+  }
+
+  if (declarations.length === 0) {
+    return createMarker({ metadataPath, exists: true });
+  }
+
+  if (declarations.length !== 1) {
+    return createMarker({
+      metadataPath,
+      exists: true,
+      mentioned: true,
+      valid: false,
+      invalidReason: 'skip_specs must be declared exactly once.'
+    });
+  }
+
+  return markerFromValue(declarations[0], metadataPath, { allowStringBoolean: true });
+}
+
+function parseJsonContainer(raw, metadataPath) {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{')) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
+      return createMarker({ metadataPath, exists: true });
+    }
+    if (!Object.hasOwn(parsed, 'skip_specs')) {
+      return createMarker({ metadataPath, exists: true });
+    }
+    return markerFromValue(parsed.skip_specs, metadataPath);
+  } catch {
+    return /["']?skip_specs["']?\s*:/.test(trimmed)
+      ? createMarker({
+        metadataPath,
+        exists: true,
+        mentioned: true,
+        valid: false,
+        invalidReason: `${OPENSPEC_CHANGE_METADATA_FILE} is not valid JSON/YAML metadata.`
+      })
+      : null;
+  }
+}
+
+function markerFromValue(value, metadataPath, options = {}) {
+  if (value === true || (options.allowStringBoolean && value === 'true')) {
+    return createMarker({
+      metadataPath,
+      exists: true,
+      mentioned: true,
+      declared: true
+    });
+  }
+
+  if (value === false || (options.allowStringBoolean && value === 'false')) {
+    return createMarker({
+      metadataPath,
+      exists: true,
+      mentioned: true
+    });
+  }
+
+  return createMarker({
+    metadataPath,
+    exists: true,
+    mentioned: true,
+    valid: false,
+    invalidReason: 'skip_specs must be the boolean true or false.'
+  });
+}
+
+function createMarker({
+  metadataPath,
+  exists,
+  mentioned = false,
+  declared = false,
+  valid = true,
+  invalidReason = null
+}) {
+  return {
+    metadataPath,
+    exists,
+    mentioned,
+    declared,
+    valid,
+    invalidReason
+  };
+}
+
+function stripInlineComment(value) {
+  let quote = null;
+  const text = String(value ?? '');
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if ((char === '"' || char === "'") && (index === 0 || text[index - 1] !== '\\')) {
+      quote = quote === char ? null : quote ?? char;
+      continue;
+    }
+    if (char === '#' && quote === null) {
+      return text.slice(0, index);
+    }
+  }
+
+  return text;
+}

--- a/scripts/openspec-change-metadata.test.mjs
+++ b/scripts/openspec-change-metadata.test.mjs
@@ -1,0 +1,83 @@
+// openspec-change-metadata.test.mjs - OpenSpec per-change metadata compatibility tests
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  OPENSPEC_CHANGE_METADATA_FILE,
+  readOpenSpecSkipSpecsMarker
+} from './openspec-change-metadata.mjs';
+
+const changeDir = 'C:/repo/openspec/changes/docs-only';
+
+describe('OpenSpec change metadata', () => {
+  it('recognizes native skip_specs true with BOM and an inline comment', async () => {
+    const result = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => '\uFEFFschema: spec-driven\r\nskip_specs: true # docs only\r\n'
+    });
+
+    assert.equal(result.exists, true);
+    assert.equal(result.mentioned, true);
+    assert.equal(result.declared, true);
+    assert.equal(result.valid, true);
+    assert.equal(result.invalidReason, null);
+    assert.equal(result.metadataPath.endsWith(OPENSPEC_CHANGE_METADATA_FILE), true);
+  });
+
+  it('keeps an explicit false marker undeclared', async () => {
+    const result = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => 'schema: spec-driven\nskip_specs: false\n'
+    });
+
+    assert.equal(result.mentioned, true);
+    assert.equal(result.declared, false);
+    assert.equal(result.valid, true);
+  });
+
+  it('accepts a boolean marker in a JSON-compatible YAML container', async () => {
+    const result = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => '{"schema":"spec-driven","skip_specs":true}\n'
+    });
+
+    assert.equal(result.declared, true);
+    assert.equal(result.valid, true);
+  });
+
+  it('fails closed for a string marker instead of treating it as boolean', async () => {
+    const yaml = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => 'schema: spec-driven\nskip_specs: "true"\n'
+    });
+    const json = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => '{"schema":"spec-driven","skip_specs":"true"}\n'
+    });
+
+    for (const result of [yaml, json]) {
+      assert.equal(result.mentioned, true);
+      assert.equal(result.declared, false);
+      assert.equal(result.valid, false);
+      assert.match(result.invalidReason, /boolean true or false/);
+    }
+  });
+
+  it('distinguishes missing metadata from an unreadable metadata file', async () => {
+    const missing = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => {
+        const error = new Error('missing');
+        error.code = 'ENOENT';
+        throw error;
+      }
+    });
+    const unreadable = await readOpenSpecSkipSpecsMarker(changeDir, {
+      readFile: async () => {
+        const error = new Error('denied');
+        error.code = 'EACCES';
+        throw error;
+      }
+    });
+
+    assert.equal(missing.exists, false);
+    assert.equal(missing.valid, true);
+    assert.equal(unreadable.exists, true);
+    assert.equal(unreadable.mentioned, true);
+    assert.equal(unreadable.valid, false);
+  });
+});

--- a/scripts/openspec-coverage-matrix.test.mjs
+++ b/scripts/openspec-coverage-matrix.test.mjs
@@ -37,7 +37,7 @@ async function createChange(rootDir, changeId = 'add-oauth') {
     '# Tasks',
     '',
     '- [x] 1.1 Implement OAuth login in src/auth/login.ts and src/auth/session.ts.',
-    '- [x] 1.2 Add regression coverage in tests/auth/login.test.ts.',
+    '  - [x] 1.2 Add nested regression coverage in tests/auth/login.test.ts.',
     ''
   ].join('\n'));
   await writeFixture(rootDir, `openspec/changes/${changeId}/specs/auth/spec.md`, [
@@ -117,7 +117,7 @@ afterEach(async () => {
 });
 
 describe('OpenSpec coverage matrix', () => {
-  it('builds requirement-to-task-to-code coverage and writes a stable QA artifact', async () => {
+  it('builds requirement-to-nested-task-to-code coverage and writes a stable QA artifact', async () => {
     const rootDir = await createTempRoot();
     await createChange(rootDir);
     const generatedRules = await createGeneratedRules(rootDir);

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -2151,11 +2151,9 @@ function boundedPublicText(value, maxLength) {
 
 function redactAbsolutePaths(value) {
   return String(value)
-    .replace(/"[A-Za-z]:[\\/][^"]+"/g, '"[path]"')
-    .replace(/'[A-Za-z]:[\\/][^']+'/g, "'[path]'")
-    .replace(/"\/(?:[^"]*\/)+[^"]*"/g, '"[path]"')
-    .replace(/'\/(?:[^']*\/)+[^']*'/g, "'[path]'")
-    .replace(/\\\\[^\\/\s]+[\\/].*$/g, '[path]')
+    .replace(/"(?:[A-Za-z]:[\\/]|\\\\|\/)[^"]*"/g, '"[path]"')
+    .replace(/'(?:[A-Za-z]:[\\/]|\\\\|\/)[^']*'/g, "'[path]'")
+    .replace(/\\\\[^\\/\s"']+(?:[\\/].*)?$/g, '[path]')
     .replace(/[A-Za-z]:[\\/].*$/g, '[path]')
     .replace(/(^|[\s(])\/(?:[^/\s)]+\/).*$/g, '$1[path]');
 }

--- a/scripts/openspec-done-finalizer.mjs
+++ b/scripts/openspec-done-finalizer.mjs
@@ -1,8 +1,10 @@
+#!/usr/bin/env node
 // openspec-done-finalizer.mjs - shared OpenSpec done/finalization runtime helpers
 import { execFile } from 'node:child_process';
 import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 import {
@@ -50,6 +52,147 @@ const DEFAULT_QA_DIR = path.join('.ai-factory', 'qa');
 const ARCHIVE_JSON = 'openspec-archive.json';
 const DONE_MARKDOWN = 'done.md';
 const FINAL_SUMMARY_MARKDOWN = 'final-summary.md';
+const PUBLIC_COMMAND_SOURCES = new Set(['explicit', 'project-local', 'path']);
+const FINALIZER_BYPASS_OPTIONS = new Set([
+  '--force',
+  '--no-validate',
+  '--skip-archive',
+  '--dry-run',
+  '--summary-only'
+]);
+const MAX_PUBLIC_DIAGNOSTICS = 50;
+
+export function parseDoneFinalizerArgs(argv) {
+  const args = Array.from(argv ?? []);
+  const parsed = {
+    ok: true,
+    changeId: null,
+    skipSpecs: false,
+    recordDirtyState: false,
+    json: false
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--change') {
+      const value = args[index + 1];
+      if (value === undefined || String(value).trim().length === 0 || String(value).startsWith('--')) {
+        return invalidFinalizerArgs('Missing value for --change.');
+      }
+      parsed.changeId = String(value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--skip-specs') {
+      parsed.skipSpecs = true;
+      continue;
+    }
+
+    if (arg === '--record-dirty-state') {
+      parsed.recordDirtyState = true;
+      continue;
+    }
+
+    if (arg === '--json') {
+      parsed.json = true;
+      continue;
+    }
+
+    if (FINALIZER_BYPASS_OPTIONS.has(arg)) {
+      return invalidFinalizerArgs(`Unsupported finalizer option: ${arg}.`);
+    }
+
+    return invalidFinalizerArgs(`Unknown option: ${arg}.`);
+  }
+
+  return parsed;
+}
+
+export async function runDoneFinalizerCommand(argv, options = {}) {
+  const parsed = parseDoneFinalizerArgs(argv);
+  if (!parsed.ok) {
+    return {
+      exitCode: 2,
+      stdout: '',
+      stderr: `${parsed.error}\n`
+    };
+  }
+
+  const finalize = options.finalizeOpenSpecChange ?? finalizeOpenSpecChange;
+  const finalizerOptions = {
+    ...options,
+    changeId: parsed.changeId ?? options.changeId,
+    skipSpecs: parsed.skipSpecs || Boolean(options.skipSpecs),
+    recordDirtyState: parsed.recordDirtyState || Boolean(options.recordDirtyState)
+  };
+  delete finalizerOptions.finalizeOpenSpecChange;
+  delete finalizerOptions.force;
+  delete finalizerOptions.noValidate;
+  delete finalizerOptions.skipArchive;
+  delete finalizerOptions.dryRun;
+  delete finalizerOptions.summaryOnly;
+
+  let result;
+  try {
+    result = await finalize(finalizerOptions);
+  } catch {
+    return {
+      exitCode: 2,
+      stdout: '',
+      stderr: 'Done finalizer command failed unexpectedly.\n'
+    };
+  }
+
+  const unresolved = result?.changeId === null || result?.changeId === undefined;
+  const stdout = parsed.json
+    ? `${JSON.stringify(projectDoneFinalizerResult(result), null, 2)}\n`
+    : `${summarizeDoneResult(result, { includeErrors: !result?.ok })}\n`;
+
+  return {
+    exitCode: unresolved ? 2 : result?.ok ? 0 : 1,
+    stdout,
+    stderr: ''
+  };
+}
+
+export function projectDoneFinalizerResult(result) {
+  const command = selectOpenSpecCommandDiagnostic(result);
+  const readiness = result?.readiness ?? null;
+  const workingTree = result?.workingTree ?? null;
+  const archive = result?.archive ?? null;
+
+  return {
+    ok: Boolean(result?.ok),
+    mode: boundedPublicText(result?.mode ?? MODE, 80),
+    change_id: normalizePublicChangeId(result?.changeId),
+    status: boundedPublicText(result?.status ?? (result?.ok ? 'PASS' : 'FAIL'), 40),
+    readiness: readiness === null ? null : {
+      status: boundedPublicText(readiness.status ?? 'unknown', 40),
+      blocking: Boolean(readiness.blocking),
+      suggested_next: normalizeSuggestedNext(readiness.suggested_next)
+    },
+    working_tree: workingTree === null ? null : {
+      ok: Boolean(workingTree.ok),
+      is_git_repo: Boolean(workingTree.isGitRepo),
+      dirty: Boolean(workingTree.dirty),
+      recorded: isDirtyStateRecorded(workingTree),
+      entry_count: Math.min(Array.isArray(workingTree.entries) ? workingTree.entries.length : 0, 1000000)
+    },
+    archive: archive === null ? null : {
+      status: boundedPublicText(archive.status ?? 'unknown', 40),
+      archived: Boolean(archive.archived),
+      skip_specs: Boolean(archive.skipSpecs),
+      command: command.command,
+      command_source: command.commandSource
+    },
+    summary_files: normalizePublicPaths(result?.summaryFiles),
+    commit_message: boundedPublicText(result?.commitMessage ?? '', 300),
+    warnings: normalizePublicDiagnostics(result?.warnings),
+    errors: normalizePublicDiagnostics(result?.errors)
+  };
+}
 
 export async function finalizeOpenSpecChange(options = {}) {
   const rootDir = resolveRootDir(options);
@@ -756,6 +899,7 @@ export async function archiveChangeWithOpenSpec(changeId, options = {}) {
       archived: false,
       skipSpecs,
       command: null,
+      commandSource: null,
       args: [],
       exitCode: null,
       rawStdoutPath: null,
@@ -960,30 +1104,43 @@ export function summarizeDoneResult(result, options = {}) {
   const archived = result?.archive?.archived ? 'yes' : 'no';
   const skipSpecs = result?.archive?.skipSpecs ? 'yes' : 'no';
   const readinessStatus = result?.readiness?.status ? String(result.readiness.status).toUpperCase() : null;
+  const command = selectOpenSpecCommandDiagnostic(result);
   const lines = [
-    `Finalization status: ${status}`,
-    `Change: ${changeId}`,
+    `Finalization status: ${boundedPublicText(status, 40)}`,
+    `Change: ${boundedPublicText(changeId, 200)}`,
     `Archived: ${archived}`,
     `Skip specs: ${skipSpecs}`
   ];
 
   if (readinessStatus !== null) {
-    lines.push(`Done readiness: ${readinessStatus}`);
+    lines.push(`Done readiness: ${boundedPublicText(readinessStatus, 40)}`);
+  }
+
+  if (command.command !== null) {
+    const source = command.commandSource === null ? '' : ` (${command.commandSource})`;
+    lines.push(`OpenSpec command: ${command.command}${source}`);
   }
 
   if (Array.isArray(result?.summaryFiles) && result.summaryFiles.length > 0) {
-    lines.push('Summary files:');
-    lines.push(...result.summaryFiles.map((file) => `- ${file}`));
+    const summaryFiles = normalizePublicPaths(result.summaryFiles);
+    if (summaryFiles.length > 0) {
+      lines.push('Summary files:');
+      lines.push(...summaryFiles.map((file) => `- ${file}`));
+    }
   }
 
   if (result?.readiness?.suggested_next) {
-    lines.push(`Suggested next: ${result.readiness.suggested_next.command}`);
-    lines.push(`Reason: ${result.readiness.suggested_next.reason}`);
+    const suggestedNext = normalizeSuggestedNext(result.readiness.suggested_next);
+    if (suggestedNext !== null) {
+      lines.push(`Suggested next: ${suggestedNext.command}`);
+      lines.push(`Reason: ${suggestedNext.reason}`);
+    }
   }
 
   if (options.includeErrors && Array.isArray(result?.errors) && result.errors.length > 0) {
+    const errors = normalizePublicDiagnostics(result.errors);
     lines.push('Errors:');
-    lines.push(...result.errors.map((error) => `- ${error.code}: ${error.message}`));
+    lines.push(...errors.map((error) => `- ${error.code}: ${error.message}`));
   }
 
   return lines.join('\n');
@@ -1019,6 +1176,7 @@ async function writeArchiveEvidence(changeId, archive, options = {}) {
     archived: Boolean(archive.archived),
     skipSpecs: Boolean(archive.skipSpecs),
     command: archive.command,
+    commandSource: archive.commandSource ?? null,
     args: Array.from(archive.args ?? []),
     exitCode: archive.exitCode ?? null,
     ok: Boolean(archive.ok),
@@ -1050,6 +1208,7 @@ async function readPreArchiveStatus(changeId, options, rootDir) {
     return {
       ok: Boolean(status?.ok),
       command: status?.command ?? null,
+      commandSource: normalizeCommandSource(status?.commandSource),
       args: Array.from(status?.args ?? []),
       exitCode: status?.exitCode ?? null,
       json: status?.json ?? null,
@@ -1061,6 +1220,7 @@ async function readPreArchiveStatus(changeId, options, rootDir) {
     return {
       ok: false,
       command: 'openspec',
+      commandSource: 'path',
       args: ['status', '--change', changeId, '--json', '--no-color'],
       exitCode: null,
       json: null,
@@ -1094,6 +1254,7 @@ function normalizeArchiveResult(changeId, result, { skipSpecs, preArchiveStatus 
     archived: ok,
     skipSpecs,
     command: result?.command ?? 'openspec',
+    commandSource: normalizeCommandSource(result?.commandSource) ?? 'path',
     args: Array.from(result?.args ?? []),
     exitCode: result?.exitCode ?? null,
     stdout: normalizeOutput(result?.stdout),
@@ -1120,6 +1281,7 @@ function createArchiveFailure({ changeId, skipSpecs, error }) {
     archived: false,
     skipSpecs,
     command: null,
+    commandSource: null,
     args: [],
     exitCode: null,
     stdout: '',
@@ -1141,6 +1303,7 @@ function createSkippedArchiveSummary(changeId, options, reason) {
     archived: false,
     skipSpecs: Boolean(options?.skipSpecs),
     command: null,
+    commandSource: null,
     args: [],
     exitCode: null,
     rawStdoutPath: null,
@@ -1308,6 +1471,7 @@ async function detectOpenSpecCapability(options, rootDir) {
         canValidate: Boolean(detection?.canValidate),
         version: detection?.version ?? null,
         command: detection?.command ?? 'openspec',
+        commandSource: normalizeCommandSource(detection?.commandSource) ?? 'path',
         reason: detection?.reason ?? null,
         errors: detection?.errors ?? []
       },
@@ -1322,6 +1486,7 @@ async function detectOpenSpecCapability(options, rootDir) {
         canValidate: false,
         version: null,
         command: 'openspec',
+        commandSource: 'path',
         reason: 'detection-failed',
         errors: [
           {
@@ -1716,7 +1881,11 @@ function createRunOptions(options, rootDir) {
     command: options.command,
     env: options.env,
     executor: options.executor,
-    nodeVersion: options.nodeVersion
+    nodeVersion: options.nodeVersion,
+    platform: options.platform,
+    candidateExists: options.candidateExists,
+    execFile: options.execFile,
+    comSpec: options.comSpec
   };
 
   for (const key of Object.keys(runOptions)) {
@@ -1846,4 +2015,182 @@ function dedupeDiagnostics(diagnostics) {
   }
 
   return result;
+}
+
+function selectOpenSpecCommandDiagnostic(result) {
+  const preArchive = result?.context?.openspec
+    ?? result?.openspec
+    ?? result?.readiness?.context?.openspec
+    ?? null;
+  const archiveCommand = normalizePublicCommand(result?.archive?.command);
+
+  if (archiveCommand !== null) {
+    return {
+      command: archiveCommand,
+      commandSource: normalizeCommandSource(result?.archive?.commandSource)
+        ?? normalizeCommandSource(preArchive?.commandSource)
+    };
+  }
+
+  return {
+    command: normalizePublicCommand(preArchive?.command),
+    commandSource: normalizeCommandSource(preArchive?.commandSource)
+  };
+}
+
+function normalizeCommandSource(value) {
+  const source = String(value ?? '');
+  return PUBLIC_COMMAND_SOURCES.has(source) ? source : null;
+}
+
+function normalizePublicCommand(value) {
+  if (value === undefined || value === null || String(value).trim().length === 0) {
+    return null;
+  }
+
+  const command = String(value).trim();
+  if (path.win32.isAbsolute(command)) {
+    return boundedPublicText(path.win32.basename(command), 240);
+  }
+  if (path.posix.isAbsolute(command)) {
+    return boundedPublicText(path.posix.basename(command), 240);
+  }
+
+  return boundedPublicText(command.replaceAll('\\', '/'), 240);
+}
+
+function normalizePublicChangeId(value) {
+  const normalized = normalizeChangeId(value);
+  return normalized.ok ? normalized.changeId : null;
+}
+
+function normalizePublicPaths(values) {
+  const result = [];
+  const seen = new Set();
+
+  for (const value of Array.isArray(values) ? values.slice(0, 100) : []) {
+    const normalized = normalizePublicPath(value);
+    if (normalized !== null && !seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+
+  return result;
+}
+
+function normalizePublicPath(value) {
+  const normalized = String(value ?? '')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replaceAll('\\', '/')
+    .trim();
+
+  if (normalized.length === 0
+    || normalized.length > 512
+    || path.posix.isAbsolute(normalized)
+    || path.win32.isAbsolute(normalized)
+    || normalized.split('/').includes('..')) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function normalizeSuggestedNext(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const command = boundedPublicText(value.command ?? '', 500);
+  if (command.length === 0) {
+    return null;
+  }
+
+  return {
+    command,
+    reason: boundedPublicText(value.reason ?? '', 500)
+  };
+}
+
+function normalizePublicDiagnostics(values) {
+  return (Array.isArray(values) ? values : [])
+    .slice(0, MAX_PUBLIC_DIAGNOSTICS)
+    .map((diagnostic) => {
+      const rawCode = boundedPublicText(diagnostic?.code ?? '', 100);
+      const code = /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(rawCode)
+        ? rawCode
+        : 'finalization-diagnostic';
+      const result = {
+        code,
+        message: boundedPublicText(
+          diagnostic?.message ?? 'Done finalization reported a diagnostic.',
+          500
+        )
+      };
+      const diagnosticPath = normalizePublicPath(diagnostic?.path);
+
+      if (diagnosticPath !== null) {
+        result.path = diagnosticPath;
+      }
+
+      return result;
+    });
+}
+
+function boundedPublicText(value, maxLength) {
+  const normalized = redactAbsolutePaths(
+    String(value ?? '').replace(/[\u0000-\u001f\u007f]/g, ' ')
+  )
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return normalized.length <= maxLength
+    ? normalized
+    : `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function redactAbsolutePaths(value) {
+  return String(value)
+    .replace(/"[A-Za-z]:[\\/][^"]+"/g, '"[path]"')
+    .replace(/'[A-Za-z]:[\\/][^']+'/g, "'[path]'")
+    .replace(/"\/(?:[^"]*\/)+[^"]*"/g, '"[path]"')
+    .replace(/'\/(?:[^']*\/)+[^']*'/g, "'[path]'")
+    .replace(/\\\\[^\\/\s]+[\\/].*$/g, '[path]')
+    .replace(/[A-Za-z]:[\\/].*$/g, '[path]')
+    .replace(/(^|[\s(])\/(?:[^/\s)]+\/).*$/g, '$1[path]');
+}
+
+function isDirtyStateRecorded(workingTree) {
+  return Boolean(workingTree?.recorded)
+    || (Boolean(workingTree?.dirty)
+      && Boolean(workingTree?.ok)
+      && (workingTree?.warnings ?? []).some((warning) => warning?.code === 'dirty-working-tree-recorded'));
+}
+
+function invalidFinalizerArgs(error) {
+  return {
+    ok: false,
+    error
+  };
+}
+
+async function main() {
+  const result = await runDoneFinalizerCommand(process.argv.slice(2));
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  process.exitCode = result.exitCode;
+}
+
+const isDirect = process.argv[1] !== undefined
+  && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirect) {
+  main().catch(() => {
+    process.stderr.write('Done finalizer command failed unexpectedly.\n');
+    process.exitCode = 2;
+  });
 }

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -13,6 +13,9 @@ import {
   buildDoneContext,
   detectWorkingTreeState,
   finalizeOpenSpecChange,
+  parseDoneFinalizerArgs,
+  projectDoneFinalizerResult,
+  runDoneFinalizerCommand,
   summarizeDoneResult,
   writeDoneSummary
 } from './openspec-done-finalizer.mjs';
@@ -109,6 +112,7 @@ function availableCliDetection() {
     canValidate: true,
     version: '1.3.1',
     command: 'openspec',
+    commandSource: 'path',
     reason: null,
     errors: []
   };
@@ -121,6 +125,7 @@ function missingCliDetection() {
     canValidate: false,
     version: null,
     command: 'openspec',
+    commandSource: 'path',
     reason: 'missing-cli',
     errors: [
       {
@@ -135,6 +140,7 @@ function archiveResult(overrides = {}) {
   return {
     ok: overrides.ok ?? true,
     command: 'openspec',
+    commandSource: overrides.commandSource ?? 'path',
     args: overrides.args ?? ['archive', 'add-oauth', '--yes', '--no-color'],
     exitCode: overrides.exitCode ?? 0,
     stdout: overrides.stdout ?? 'Archived add-oauth\n',
@@ -149,6 +155,7 @@ function statusResult(overrides = {}) {
   return {
     ok: overrides.ok ?? true,
     command: 'openspec',
+    commandSource: overrides.commandSource ?? 'path',
     args: ['status', '--change', 'add-oauth', '--json', '--no-color'],
     exitCode: overrides.exitCode ?? 0,
     stdout: overrides.stdout ?? '{"change":"add-oauth"}',
@@ -259,11 +266,293 @@ function coverageEvidence(overrides = {}) {
   };
 }
 
+function finalizerCommandResult(overrides = {}) {
+  return {
+    ok: overrides.ok ?? true,
+    mode: 'openspec-native',
+    changeId: Object.prototype.hasOwnProperty.call(overrides, 'changeId')
+      ? overrides.changeId
+      : 'add-oauth',
+    status: overrides.status ?? (overrides.ok === false ? 'FAIL' : 'PASS'),
+    readiness: overrides.readiness ?? {
+      status: 'pass',
+      blocking: false,
+      suggested_next: null,
+      context: {
+        private: 'verification contents must not escape'
+      }
+    },
+    workingTree: overrides.workingTree ?? {
+      ok: true,
+      isGitRepo: true,
+      dirty: false,
+      entries: [],
+      warnings: [],
+      errors: []
+    },
+    archive: overrides.archive ?? {
+      ok: true,
+      status: 'PASS',
+      archived: true,
+      skipSpecs: false,
+      command: 'node_modules/.bin/openspec.cmd',
+      commandSource: 'project-local',
+      stdout: 'raw archive output must not escape',
+      stderr: 'raw archive error must not escape'
+    },
+    context: overrides.context ?? {
+      openspec: {
+        command: 'node_modules/.bin/openspec.cmd',
+        commandSource: 'project-local'
+      },
+      verification: {
+        content: 'verification contents must not escape'
+      },
+      runtimeTraces: [{ content: 'runtime contents must not escape' }]
+    },
+    verification: {
+      content: 'verification contents must not escape'
+    },
+    summaryFiles: overrides.summaryFiles ?? [
+      '.ai-factory/qa/add-oauth/done.md',
+      '.ai-factory/state/add-oauth/final-summary.md'
+    ],
+    commitMessage: overrides.commitMessage ?? 'feat: finalize add-oauth',
+    warnings: overrides.warnings ?? [],
+    errors: overrides.errors ?? []
+  };
+}
+
 afterEach(async () => {
   await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, {
     recursive: true,
     force: true
   })));
+});
+
+describe('OpenSpec done finalizer command', () => {
+  it('parses only the public finalizer flags', () => {
+    assert.deepEqual(
+      parseDoneFinalizerArgs([
+        '--change',
+        'add-oauth',
+        '--skip-specs',
+        '--record-dirty-state',
+        '--json'
+      ]),
+      {
+        ok: true,
+        changeId: 'add-oauth',
+        skipSpecs: true,
+        recordDirtyState: true,
+        json: true
+      }
+    );
+  });
+
+  it('rejects missing, unknown, and bypass flags before calling the finalizer API', async () => {
+    const invalidArgv = [
+      ['--change'],
+      ['--unknown'],
+      ['--force'],
+      ['--no-validate'],
+      ['--skip-archive'],
+      ['--dry-run'],
+      ['--summary-only']
+    ];
+
+    for (const argv of invalidArgv) {
+      let calls = 0;
+      const command = await runDoneFinalizerCommand(argv, {
+        finalizeOpenSpecChange: async () => {
+          calls += 1;
+          return finalizerCommandResult();
+        }
+      });
+
+      assert.equal(command.exitCode, 2, `${argv.join(' ')} should be a command error`);
+      assert.equal(command.stdout, '');
+      assert.match(command.stderr, /Missing value|Unknown option|Unsupported finalizer option/);
+      assert.equal(calls, 0, `${argv.join(' ')} must not call finalizer API`);
+    }
+  });
+
+  it('maps public flags and strips internal bypass options from the API call', async () => {
+    const calls = [];
+    const command = await runDoneFinalizerCommand([
+      '--change',
+      'add-oauth',
+      '--skip-specs',
+      '--record-dirty-state'
+    ], {
+      noValidate: true,
+      skipArchive: true,
+      dryRun: true,
+      summaryOnly: true,
+      finalizeOpenSpecChange: async (options) => {
+        calls.push(options);
+        return finalizerCommandResult();
+      }
+    });
+
+    assert.equal(command.exitCode, 0);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].changeId, 'add-oauth');
+    assert.equal(calls[0].skipSpecs, true);
+    assert.equal(calls[0].recordDirtyState, true);
+    for (const key of ['noValidate', 'skipArchive', 'dryRun', 'summaryOnly']) {
+      assert.equal(Object.hasOwn(calls[0], key), false, `${key} must not reach public finalizer execution`);
+    }
+  });
+
+  it('renders bounded human output with pre-archive command diagnostics and errors', async () => {
+    const command = await runDoneFinalizerCommand([], {
+      finalizeOpenSpecChange: async () => finalizerCommandResult({
+        ok: false,
+        readiness: {
+          status: 'fail',
+          blocking: true,
+          suggested_next: {
+            command: '/aif-fix add-oauth',
+            reason: 'fix the blocking gate'
+          }
+        },
+        archive: {
+          status: 'SKIPPED',
+          archived: false,
+          skipSpecs: false,
+          command: null,
+          commandSource: null,
+          stdout: 'raw archive output must not escape'
+        },
+        errors: [{
+          code: 'verification-failed',
+          message: 'Verification failed at C:\\Users\\private name\\verify.md before archive.',
+          detail: 'raw detail must not escape'
+        }]
+      })
+    });
+
+    assert.equal(command.exitCode, 1);
+    assert.match(command.stdout, /Finalization status: FAIL/);
+    assert.match(command.stdout, /OpenSpec command: node_modules\/\.bin\/openspec\.cmd \(project-local\)/);
+    assert.match(command.stdout, /Suggested next: \/aif-fix add-oauth/);
+    assert.match(command.stdout, /verification-failed:/);
+    assert.doesNotMatch(command.stdout, /Users|private name|raw archive|raw detail|verification contents/);
+  });
+
+  it('projects JSON through an allowlist and uses pre-archive command context', async () => {
+    const result = finalizerCommandResult({
+      ok: false,
+      readiness: {
+        status: 'fail',
+        blocking: true,
+        suggested_next: {
+          command: '/aif-fix add-oauth',
+          reason: 'fix the blocking gate'
+        }
+      },
+      workingTree: {
+        ok: true,
+        isGitRepo: true,
+        dirty: true,
+        entries: [' M private-file.md'],
+        warnings: [{ code: 'dirty-working-tree-recorded', message: 'recorded' }],
+        errors: []
+      },
+      archive: {
+        status: 'SKIPPED',
+        archived: false,
+        skipSpecs: true,
+        command: null,
+        commandSource: null,
+        stdout: 'raw archive output must not escape',
+        stderr: 'raw archive error must not escape'
+      },
+      summaryFiles: [
+        '.ai-factory/qa/add-oauth/done.md',
+        'C:\\Users\\private\\secret.md'
+      ],
+      warnings: [{
+        code: 'safe-warning',
+        message: 'Inspect C:\\Users\\private name\\warning.txt before retrying.',
+        path: '.ai-factory/qa/add-oauth/done.md',
+        detail: 'raw warning detail must not escape'
+      }],
+      errors: [{
+        code: 'safe-error',
+        message: 'Finalization blocked.',
+        path: 'C:\\Users\\private\\error.txt',
+        detail: 'raw error detail must not escape'
+      }]
+    });
+    const projection = projectDoneFinalizerResult(result);
+    const serialized = JSON.stringify(projection);
+
+    assert.deepEqual(Object.keys(projection), [
+      'ok',
+      'mode',
+      'change_id',
+      'status',
+      'readiness',
+      'working_tree',
+      'archive',
+      'summary_files',
+      'commit_message',
+      'warnings',
+      'errors'
+    ]);
+    assert.equal(projection.archive.command, 'node_modules/.bin/openspec.cmd');
+    assert.equal(projection.archive.command_source, 'project-local');
+    assert.equal(projection.working_tree.recorded, true);
+    assert.equal(projection.working_tree.entry_count, 1);
+    assert.equal(Object.hasOwn(projection.working_tree, 'entries'), false);
+    assert.deepEqual(projection.summary_files, ['.ai-factory/qa/add-oauth/done.md']);
+    assert.equal(projection.warnings[0].path, '.ai-factory/qa/add-oauth/done.md');
+    assert.equal(Object.hasOwn(projection.errors[0], 'path'), false);
+    for (const forbidden of [
+      'context',
+      'verification contents',
+      'runtime contents',
+      'raw archive',
+      'raw warning detail',
+      'raw error detail',
+      'C:\\\\Users',
+      'private-file.md'
+    ]) {
+      assert.equal(serialized.includes(forbidden), false, `JSON projection must omit ${forbidden}`);
+    }
+
+    const command = await runDoneFinalizerCommand(['--json'], {
+      finalizeOpenSpecChange: async () => result
+    });
+    assert.equal(command.exitCode, 1);
+    assert.deepEqual(JSON.parse(command.stdout), projection);
+  });
+
+  it('classifies success, blockers, unresolved scope, and unexpected exceptions', async () => {
+    const success = await runDoneFinalizerCommand([], {
+      finalizeOpenSpecChange: async () => finalizerCommandResult({ status: 'WARN' })
+    });
+    const blocker = await runDoneFinalizerCommand([], {
+      finalizeOpenSpecChange: async () => finalizerCommandResult({ ok: false })
+    });
+    const unresolved = await runDoneFinalizerCommand([], {
+      finalizeOpenSpecChange: async () => finalizerCommandResult({ ok: false, changeId: null })
+    });
+    const unexpected = await runDoneFinalizerCommand([], {
+      finalizeOpenSpecChange: async () => {
+        throw new Error('C:\\Users\\private\\secret');
+      }
+    });
+
+    assert.equal(success.exitCode, 0);
+    assert.equal(blocker.exitCode, 1);
+    assert.equal(unresolved.exitCode, 2);
+    assert.equal(unexpected.exitCode, 2);
+    assert.equal(unexpected.stdout, '');
+    assert.equal(unexpected.stderr, 'Done finalizer command failed unexpectedly.\n');
+  });
 });
 
 describe('OpenSpec done finalizer API', () => {
@@ -277,6 +566,9 @@ describe('OpenSpec done finalizer API', () => {
       archiveChangeWithOpenSpec,
       writeDoneSummary,
       detectWorkingTreeState,
+      parseDoneFinalizerArgs,
+      projectDoneFinalizerResult,
+      runDoneFinalizerCommand,
       summarizeDoneResult
     ]) {
       assert.equal(typeof fn, 'function', 'done finalizer public API should export functions');

--- a/scripts/openspec-done-finalizer.test.mjs
+++ b/scripts/openspec-done-finalizer.test.mjs
@@ -530,6 +530,35 @@ describe('OpenSpec done finalizer command', () => {
     assert.deepEqual(JSON.parse(command.stdout), projection);
   });
 
+  it('redacts quoted root paths and UNC server roots while preserving slash commands', () => {
+    const projection = projectDoneFinalizerResult(finalizerCommandResult({
+      readiness: {
+        status: 'fail',
+        blocking: true,
+        suggested_next: {
+          command: '/aif-fix add-oauth',
+          reason: 'Inspect "/секрет" before retrying.'
+        }
+      },
+      errors: [
+        {
+          code: 'quoted-root',
+          message: 'Inspect "/секрет" before retrying.'
+        },
+        {
+          code: 'unc-root',
+          message: 'Inspect "\\\\сервер" before retrying.'
+        }
+      ]
+    }));
+    const serialized = JSON.stringify(projection);
+
+    assert.equal(projection.readiness.suggested_next.command, '/aif-fix add-oauth');
+    assert.match(serialized, /\[path\]/);
+    assert.equal(serialized.includes('секрет'), false);
+    assert.equal(serialized.includes('сервер'), false);
+  });
+
   it('classifies success, blockers, unresolved scope, and unexpected exceptions', async () => {
     const success = await runDoneFinalizerCommand([], {
       finalizeOpenSpecChange: async () => finalizerCommandResult({ status: 'WARN' })

--- a/scripts/openspec-done-readiness.mjs
+++ b/scripts/openspec-done-readiness.mjs
@@ -375,6 +375,7 @@ async function inspectOpenSpecCapability(rootDir, options) {
       canArchive: Boolean(detection?.canArchive),
       version: detection?.version ?? null,
       command: detection?.command ?? 'openspec',
+      commandSource: detection?.commandSource ?? 'path',
       reason: detection?.reason ?? null,
       errors: detection?.errors ?? []
     };
@@ -385,6 +386,7 @@ async function inspectOpenSpecCapability(rootDir, options) {
       canArchive: false,
       version: null,
       command: 'openspec',
+      commandSource: 'path',
       reason: err?.code ?? 'openspec-detection-failed',
       errors: [{
         code: err?.code ?? 'openspec-detection-failed',
@@ -1016,6 +1018,7 @@ function normalizeCommandResult(result) {
   return {
     ok: Boolean(result?.ok),
     command: result?.command ?? 'openspec',
+    commandSource: result?.commandSource ?? 'path',
     args: Array.from(result?.args ?? []),
     exitCode: result?.exitCode ?? null,
     json: result?.json ?? null,
@@ -1047,7 +1050,11 @@ function createRunOptions(options, rootDir) {
     command: options.command,
     env: options.env,
     executor: options.executor,
-    nodeVersion: options.nodeVersion
+    nodeVersion: options.nodeVersion,
+    platform: options.platform,
+    candidateExists: options.candidateExists,
+    execFile: options.execFile,
+    comSpec: options.comSpec
   };
 
   for (const key of Object.keys(runOptions)) {

--- a/scripts/openspec-lifecycle-contract.test.mjs
+++ b/scripts/openspec-lifecycle-contract.test.mjs
@@ -222,8 +222,10 @@ describe('OpenSpec lifecycle CLI integration contract', () => {
     ]);
 
     for (const expected of [
+      'ai-factory aifhub-done-finalizer --change <change-id> --json',
       'archiveOpenSpecChange(changeId)',
       'scripts/openspec-runner.mjs',
+      'extension-local implementation',
       '--skip-specs',
       'If OpenSpec CLI is missing or unsupported and archive is required, fail',
       '/aif-verify does not archive',
@@ -236,5 +238,24 @@ describe('OpenSpec lifecycle CLI integration contract', () => {
 
     assert.match(done, /\/aif-done.*archive\/finalization|only OpenSpec-native archive\/finalization step/i);
     assertNotIncludes(nonDone, 'archiveOpenSpecChange(changeId)', 'non-done lifecycle assets');
+
+    for (const relativePath of LIFECYCLE_ASSETS.done) {
+      const asset = await readRepoFile(relativePath);
+      assertIncludes(
+        asset,
+        'ai-factory aifhub-done-finalizer --change <change-id> --json',
+        relativePath
+      );
+      assert.match(
+        asset,
+        /scripts\/openspec-(?:done-finalizer|done-readiness|runner)\.mjs[^\n]*(?:extension-local|implementation module)|(?:extension-local|implementation module)[^\n]*scripts\/openspec-(?:done-finalizer|done-readiness|runner)\.mjs/i,
+        `${relativePath} should label source-repository module references as extension-local implementation`
+      );
+      assert.doesNotMatch(
+        asset,
+        /\bnode(?:\.exe)?\s+(?:scripts[\\/]|[^\n]*\.ai-factory[\\/]extensions[\\/][^\n]*scripts[\\/])openspec-(?:done-finalizer|done-readiness|runner)\.mjs\b/i,
+        `${relativePath} should not expose an internal module as an installed-project executable`
+      );
+    }
   });
 });

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -996,7 +996,9 @@ describe('OpenSpec-native prompt asset contract', () => {
       const asset = stripFencedBlocks(await readRepoFile(relativePath));
 
       for (const expected of [
+        'ai-factory aifhub-done-finalizer --change <change-id> --json',
         'scripts/openspec-done-finalizer.mjs',
+        'extension-local',
         'archiveOpenSpecChange',
         '--skip-specs',
         '.ai-factory/qa/<change-id>/',
@@ -1027,6 +1029,11 @@ describe('OpenSpec-native prompt asset contract', () => {
         /archive integration (?:is )?deferred to issue #33|deferred archive status/i,
         `${relativePath} should no longer describe OpenSpec archive integration as deferred`
       );
+      assert.doesNotMatch(
+        asset,
+        /\bnode(?:\.exe)?\s+(?:scripts[\\/]|[^\n]*\.ai-factory[\\/]extensions[\\/][^\n]*scripts[\\/])openspec-(?:done-finalizer|done-readiness|runner)\.mjs\b/i,
+        `${relativePath} should not execute extension-local OpenSpec modules as installed-project commands`
+      );
     }
   });
 
@@ -1036,7 +1043,7 @@ describe('OpenSpec-native prompt asset contract', () => {
 
       for (const expected of [
         '--record-dirty-state',
-        '/aif-done <change-id> --record-dirty-state',
+        'ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json',
         'git status --short'
       ]) {
         assertIncludes(asset, expected, relativePath);

--- a/scripts/openspec-rules-compiler.mjs
+++ b/scripts/openspec-rules-compiler.mjs
@@ -47,7 +47,8 @@ export async function compileOpenSpecRules(changeId, options = {}) {
       mode: collected.mode,
       warnings: [...resolverResult.warnings, ...collected.warnings],
       errors: collected.errors,
-      sources: collected.sources
+      sources: collected.sources,
+      openspecCli: collected.openspecCli
     });
   }
 
@@ -68,7 +69,8 @@ export async function compileOpenSpecRules(changeId, options = {}) {
       warnings: [...resolverResult.warnings, ...collected.warnings, ...rendered.warnings, ...written.warnings],
       errors: written.errors,
       sources: collected.sources,
-      files: written.files
+      files: written.files,
+      openspecCli: collected.openspecCli
     });
   }
 
@@ -79,7 +81,8 @@ export async function compileOpenSpecRules(changeId, options = {}) {
     warnings: [...resolverResult.warnings, ...collected.warnings, ...rendered.warnings, ...written.warnings],
     errors: [],
     sources: collected.sources,
-    files: written.files
+    files: written.files,
+    openspecCli: collected.openspecCli
   });
 }
 
@@ -149,7 +152,8 @@ export async function collectOpenSpecRuleSources(changeId, options = {}) {
     ok: true,
     mode,
     warnings: dedupeDiagnostics(warnings),
-    sources: sortSources(sources)
+    sources: sortSources(sources),
+    openspecCli: summarizeOpenSpecDetection(cli.detection)
   });
 }
 
@@ -167,7 +171,8 @@ export async function compileOpenSpecBaseRules(options = {}) {
       mode: collected.mode,
       warnings: collected.warnings,
       errors: collected.errors,
-      sources: collected.sources
+      sources: collected.sources,
+      openspecCli: collected.openspecCli
     });
   }
 
@@ -193,7 +198,8 @@ export async function compileOpenSpecBaseRules(options = {}) {
       warnings: [...collected.warnings, ...written.warnings],
       errors: written.errors,
       sources: collected.sources,
-      files: written.files
+      files: written.files,
+      openspecCli: collected.openspecCli
     });
   }
 
@@ -204,7 +210,8 @@ export async function compileOpenSpecBaseRules(options = {}) {
     warnings: [...collected.warnings, ...written.warnings],
     errors: [],
     sources: collected.sources,
-    files: written.files
+    files: written.files,
+    openspecCli: collected.openspecCli
   });
 }
 
@@ -234,7 +241,8 @@ async function collectOpenSpecBaseRuleSources(options = {}) {
     ok: true,
     mode: chooseMode(sources, cli),
     warnings: dedupeDiagnostics(warnings),
-    sources: sortSources(sources)
+    sources: sortSources(sources),
+    openspecCli: summarizeOpenSpecDetection(cli.detection)
   });
 }
 
@@ -808,9 +816,14 @@ async function detectOpenSpecCapability(rootDir, options) {
   try {
     const detection = await detectOpenSpec({
       cwd: rootDir,
+      command: options.command,
       env: options.env,
       executor: options.executor,
-      nodeVersion: options.nodeVersion
+      nodeVersion: options.nodeVersion,
+      platform: options.platform,
+      candidateExists: options.candidateExists,
+      execFile: options.execFile,
+      comSpec: options.comSpec
     });
     const warnings = [];
 
@@ -825,7 +838,11 @@ async function detectOpenSpecCapability(rootDir, options) {
       runOptions: {
         command: options.command,
         env: options.env,
-        executor: options.executor
+        executor: options.executor,
+        platform: options.platform,
+        candidateExists: options.candidateExists,
+        execFile: options.execFile,
+        comSpec: options.comSpec
       },
       warnings
     };
@@ -837,7 +854,11 @@ async function detectOpenSpecCapability(rootDir, options) {
       runOptions: {
         command: options.command,
         env: options.env,
-        executor: options.executor
+        executor: options.executor,
+        platform: options.platform,
+        candidateExists: options.candidateExists,
+        execFile: options.execFile,
+        comSpec: options.comSpec
       },
       warnings: [
         {
@@ -1336,6 +1357,22 @@ function normalizeDetectionWarnings(detection) {
   ];
 }
 
+function summarizeOpenSpecDetection(detection) {
+  if (detection === null || detection === undefined) {
+    return null;
+  }
+
+  return {
+    available: Boolean(detection.available),
+    canValidate: Boolean(detection.canValidate),
+    canArchive: Boolean(detection.canArchive),
+    version: detection.version ?? null,
+    command: detection.command ?? null,
+    commandSource: detection.commandSource ?? null,
+    reason: detection.reason ?? null
+  };
+}
+
 function resolveGeneratedAt(options = {}) {
   if (typeof options.generatedAt === 'string' && options.generatedAt.trim().length > 0) {
     return options.generatedAt;
@@ -1355,7 +1392,8 @@ function createCompilerResult(overrides = {}) {
     warnings: dedupeDiagnostics(overrides.warnings ?? []),
     errors: overrides.errors ?? [],
     sources: overrides.sources ?? [],
-    files: overrides.files ?? []
+    files: overrides.files ?? [],
+    openspecCli: overrides.openspecCli ?? null
   };
 }
 
@@ -1365,7 +1403,8 @@ function createSourceResult(overrides = {}) {
     mode: overrides.mode ?? 'failed',
     warnings: dedupeDiagnostics(overrides.warnings ?? []),
     errors: overrides.errors ?? [],
-    sources: overrides.sources ?? []
+    sources: overrides.sources ?? [],
+    openspecCli: overrides.openspecCli ?? null
   };
 }
 

--- a/scripts/openspec-rules-compiler.test.mjs
+++ b/scripts/openspec-rules-compiler.test.mjs
@@ -66,11 +66,12 @@ function missingCliDetection() {
     nodeVersion: '20.19.0',
     nodeSupported: true,
     command: 'openspec',
+    commandSource: 'path',
     reason: 'missing-cli',
     errors: [
       {
         code: 'missing-cli',
-        message: 'OpenSpec CLI is not available on PATH.'
+        message: "Selected OpenSpec CLI 'openspec' (path) is unavailable."
       }
     ]
   };
@@ -158,6 +159,8 @@ describe('compileOpenSpecRules filesystem fallback', () => {
     assert.equal(result.ok, true);
     assert.equal(result.changeId, 'add-generated-rules');
     assert.equal(result.mode, 'filesystem-fallback');
+    assert.equal(result.openspecCli.command, 'openspec');
+    assert.equal(result.openspecCli.commandSource, 'path');
     assert.deepEqual(result.errors, []);
     assert.equal(result.files.length, 5);
     assert.deepEqual(result.files.map((file) => file.kind), ['base', 'change', 'merged', 'trace', 'index']);
@@ -436,9 +439,14 @@ The fallback parser SHOULD NOT be used when CLI JSON is complete.
 `
     });
     const calls = [];
+    const detectionCalls = [];
+    const explicitCommand = 'custom-openspec';
 
     const result = await compileOpenSpecRules('cli-rules', compilerOptions(rootDir, {
-      detectOpenSpec: async () => ({
+      command: explicitCommand,
+      detectOpenSpec: async (options) => {
+        detectionCalls.push(options);
+        return {
         available: true,
         canValidate: true,
         canArchive: true,
@@ -448,10 +456,12 @@ The fallback parser SHOULD NOT be used when CLI JSON is complete.
         requiresNode: '>=20.19.0',
         nodeVersion: '20.19.0',
         nodeSupported: true,
-        command: 'openspec',
+        command: explicitCommand,
+        commandSource: 'explicit',
         reason: null,
         errors: []
-      }),
+        };
+      },
       showOpenSpecItem: async (itemName, options) => {
         calls.push({ itemName, options });
         return {
@@ -477,10 +487,15 @@ The fallback parser SHOULD NOT be used when CLI JSON is complete.
 
     assert.equal(result.ok, true);
     assert.equal(result.mode, 'cli-json');
+    assert.equal(detectionCalls.length, 1);
+    assert.equal(detectionCalls[0].command, explicitCommand);
+    assert.equal(result.openspecCli.command, explicitCommand);
+    assert.equal(result.openspecCli.commandSource, 'explicit');
     assert.deepEqual(calls.map((call) => [call.itemName, call.options.deltasOnly]), [
       ['billing', false],
       ['auth', true]
     ]);
+    assert.equal(calls.every((call) => call.options.command === explicitCommand), true);
 
     const mergedRules = await readGenerated(rootDir, 'openspec-merged-cli-rules.md');
     assert.match(mergedRules, /Requirement: CLI billing/);

--- a/scripts/openspec-runner.mjs
+++ b/scripts/openspec-runner.mjs
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 
 export const OPENSPEC_SUPPORTED_RANGE = '>=1.3.1 <2.0.0';
 export const OPENSPEC_NODE_RANGE = '>=20.19.0';
+export const OPENSPEC_LATEST_REVIEWED_VERSION = '1.8.0';
 
 const execFileAsync = promisify(execFileCallback);
 const OPENSPEC_MIN_VERSION = '1.3.1';
@@ -631,6 +632,10 @@ function createDetectionResult(overrides = {}) {
   const versionSupported = overrides.versionSupported ?? false;
   const nodeVersion = overrides.nodeVersion ?? process.versions.node;
   const nodeSupported = overrides.nodeSupported ?? satisfiesGte(nodeVersion, NODE_MIN_VERSION);
+  const reviewedComparison = versionSupported
+    ? compareSemver(version, OPENSPEC_LATEST_REVIEWED_VERSION)
+    : null;
+  const versionOutdated = reviewedComparison === null ? null : reviewedComparison < 0;
 
   return {
     available: overrides.available ?? false,
@@ -639,6 +644,8 @@ function createDetectionResult(overrides = {}) {
     version,
     supportedRange: OPENSPEC_SUPPORTED_RANGE,
     versionSupported,
+    latestReviewedVersion: OPENSPEC_LATEST_REVIEWED_VERSION,
+    versionOutdated,
     requiresNode: OPENSPEC_NODE_RANGE,
     nodeVersion,
     nodeSupported,

--- a/scripts/openspec-runner.mjs
+++ b/scripts/openspec-runner.mjs
@@ -507,9 +507,11 @@ async function executeWindowsCommandScript({
   comSpec,
   originalError = null
 }) {
+  const commandInterpreter = validateWindowsCommandInterpreter(comSpec);
+
   try {
     const { stdout, stderr } = await execFileImplementation(
-      comSpec,
+      commandInterpreter,
       ['/d', '/s', '/v:off', '/c', quoteCmdCommand(commandPath, args)],
       {
         ...execOptions,
@@ -535,6 +537,19 @@ async function executeWindowsCommandScript({
 
     throw originalError ?? err;
   }
+}
+
+function validateWindowsCommandInterpreter(value) {
+  const commandInterpreter = String(value ?? '').trim();
+  if (
+    !path.win32.isAbsolute(commandInterpreter)
+    || path.win32.basename(commandInterpreter).toLowerCase() !== 'cmd.exe'
+  ) {
+    const error = new Error('Windows command scripts require ComSpec to be an absolute cmd.exe path.');
+    error.code = 'invalid-comspec';
+    throw error;
+  }
+  return commandInterpreter;
 }
 
 function findWindowsCommandScript(command, env, options = {}) {

--- a/scripts/openspec-runner.mjs
+++ b/scripts/openspec-runner.mjs
@@ -14,6 +14,7 @@ const OPENSPEC_MAX_VERSION = '2.0.0';
 const NODE_MIN_VERSION = '20.19.0';
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
 const WINDOWS_SCRIPT_EXTENSIONS = ['.cmd', '.bat'];
+const WINDOWS_CMD_META_CHARACTERS = /([()\][%!^"`<>&|;, *?])/g;
 const COMMAND_SOURCES = new Set(['explicit', 'project-local', 'path']);
 
 const ERRORS = {
@@ -509,7 +510,7 @@ async function executeWindowsCommandScript({
   try {
     const { stdout, stderr } = await execFileImplementation(
       comSpec,
-      ['/d', '/s', '/c', quoteCmdCommand(commandPath, args)],
+      ['/d', '/s', '/v:off', '/c', quoteCmdCommand(commandPath, args)],
       {
         ...execOptions,
         windowsVerbatimArguments: true
@@ -618,13 +619,26 @@ function isAccessibleFile(filePath) {
 }
 
 function quoteCmdCommand(commandPath, args) {
-  return `"${[commandPath, ...Array.from(args ?? [])]
-    .map(quoteCmdArg)
-    .join(' ')}"`;
+  return `"${[
+    escapeCmdMetaCharacters(commandPath),
+    ...Array.from(args ?? [], quoteCmdArg)
+  ].join(' ')}"`;
 }
 
 function quoteCmdArg(value) {
-  return `"${String(value).replaceAll('"', '""')}"`;
+  let argument = String(value);
+
+  argument = argument.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"');
+  argument = argument.replace(/(?=(\\+?)?)\1$/, '$1$1');
+  argument = `"${argument}"`;
+
+  // A command shim parses metacharacters once in cmd.exe and again when the
+  // batch file expands its forwarded arguments, so preserve them through both.
+  return escapeCmdMetaCharacters(escapeCmdMetaCharacters(argument));
+}
+
+function escapeCmdMetaCharacters(value) {
+  return String(value).replace(WINDOWS_CMD_META_CHARACTERS, '^$1');
 }
 
 function createDetectionResult(overrides = {}) {

--- a/scripts/openspec-runner.mjs
+++ b/scripts/openspec-runner.mjs
@@ -1,5 +1,5 @@
 // openspec-runner.mjs - shared OpenSpec CLI runner and capability detection
-import { execFile } from 'node:child_process';
+import { execFile as execFileCallback } from 'node:child_process';
 import { accessSync, constants } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -7,26 +7,29 @@ import { promisify } from 'node:util';
 export const OPENSPEC_SUPPORTED_RANGE = '>=1.3.1 <2.0.0';
 export const OPENSPEC_NODE_RANGE = '>=20.19.0';
 
-const execFileAsync = promisify(execFile);
+const execFileAsync = promisify(execFileCallback);
 const OPENSPEC_MIN_VERSION = '1.3.1';
 const OPENSPEC_MAX_VERSION = '2.0.0';
 const NODE_MIN_VERSION = '20.19.0';
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
 const WINDOWS_SCRIPT_EXTENSIONS = ['.cmd', '.bat'];
+const COMMAND_SOURCES = new Set(['explicit', 'project-local', 'path']);
 
 const ERRORS = {
   invalidJson: {
     code: 'invalid-json',
     message: 'OpenSpec command returned invalid JSON.'
   },
-  missingCli: {
-    code: 'missing-cli',
-    message: 'OpenSpec CLI is not available on PATH.'
+  missingCli(command, commandSource) {
+    return {
+      code: 'missing-cli',
+      message: `Selected OpenSpec CLI '${command}' (${commandSource}) is unavailable.`
+    };
   },
-  nonZeroExit(exitCode) {
+  nonZeroExit(exitCode, command, commandSource) {
     return {
       code: 'non-zero-exit',
-      message: `OpenSpec command failed with exit code ${exitCode}.`
+      message: `OpenSpec command '${command}' (${commandSource}) failed with exit code ${exitCode}.`
     };
   },
   unsupportedNode(nodeVersion) {
@@ -35,44 +38,144 @@ const ERRORS = {
       message: `Node ${nodeVersion} does not satisfy OpenSpec requirement ${OPENSPEC_NODE_RANGE}.`
     };
   },
-  unsupportedVersion(version) {
+  unsupportedVersion(version, command, commandSource) {
     return {
       code: 'unsupported-version',
-      message: `OpenSpec CLI version ${version} is outside supported range ${OPENSPEC_SUPPORTED_RANGE}.`
+      message: `OpenSpec CLI '${command}' (${commandSource}) reported version ${version}, outside supported range ${OPENSPEC_SUPPORTED_RANGE}.`
     };
   },
-  versionDetectionFailed: {
-    code: 'version-detection-failed',
-    message: 'OpenSpec version detection failed.'
+  versionDetectionFailed(command, commandSource) {
+    return {
+      code: 'version-detection-failed',
+      message: `OpenSpec version detection failed for '${command}' (${commandSource}).`
+    };
   }
 };
 
+export function resolveOpenSpecCommand(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const platform = options.platform ?? process.platform;
+  const pathApi = getPlatformPath(platform);
+  const candidateExists = options.candidateExists ?? isAccessibleFile;
+  const explicitCommand = getExplicitCommand(options);
+
+  if (explicitCommand !== null) {
+    return createCommandResolution({
+      executable: explicitCommand,
+      displayCommand: createSafeCommandDisplay(explicitCommand, cwd, pathApi),
+      commandSource: 'explicit'
+    });
+  }
+
+  const resolvedCwd = pathApi.resolve(String(cwd));
+  const localExecutable = pathApi.join(
+    resolvedCwd,
+    'node_modules',
+    '.bin',
+    platform === 'win32' ? 'openspec.cmd' : 'openspec'
+  );
+
+  if (candidateExists(localExecutable)) {
+    return createCommandResolution({
+      executable: localExecutable,
+      displayCommand: toPosix(pathApi.relative(resolvedCwd, localExecutable)),
+      commandSource: 'project-local'
+    });
+  }
+
+  return createCommandResolution({
+    executable: 'openspec',
+    displayCommand: 'openspec',
+    commandSource: 'path'
+  });
+}
+
+function getExplicitCommand(options) {
+  if (!Object.prototype.hasOwnProperty.call(options, 'command') || options.command === undefined) {
+    return null;
+  }
+
+  const command = String(options.command ?? '').trim();
+  return command.length > 0 ? command : null;
+}
+
+function createCommandResolution({ executable, displayCommand, commandSource }) {
+  if (!COMMAND_SOURCES.has(commandSource)) {
+    throw new Error(`Invalid OpenSpec command source: ${commandSource}.`);
+  }
+
+  return {
+    executable,
+    displayCommand: boundCommandDisplay(displayCommand),
+    commandSource
+  };
+}
+
+function createSafeCommandDisplay(command, cwd, pathApi) {
+  const commandText = String(command);
+
+  if (!pathApi.isAbsolute(commandText)) {
+    return toPosix(commandText);
+  }
+
+  const resolvedCwd = pathApi.resolve(String(cwd));
+  const resolvedCommand = pathApi.resolve(commandText);
+  const relative = pathApi.relative(resolvedCwd, resolvedCommand);
+
+  if (isSafeRelativePath(relative, pathApi)) {
+    return toPosix(relative || pathApi.basename(resolvedCommand));
+  }
+
+  return pathApi.basename(resolvedCommand) || 'openspec';
+}
+
+function isSafeRelativePath(relativePath, pathApi) {
+  return relativePath.length === 0
+    || (!relativePath.startsWith('..') && !pathApi.isAbsolute(relativePath));
+}
+
+function boundCommandDisplay(value) {
+  const normalized = String(value ?? 'openspec')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .trim();
+  const display = normalized.length > 0 ? normalized : 'openspec';
+  return display.length <= 240 ? display : `…${display.slice(-239)}`;
+}
+
+function getPlatformPath(platform) {
+  return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function toPosix(value) {
+  return String(value).replaceAll('\\', '/');
+}
+
 export async function detectOpenSpec(options = {}) {
   const {
-    command = 'openspec',
     cwd = process.cwd(),
     env = process.env,
-    executor = defaultExecutor,
     nodeVersion = process.versions.node
   } = options;
 
   const nodeSupported = satisfiesGte(nodeVersion, NODE_MIN_VERSION);
   const versionResult = await runOpenSpec(['--version'], {
-    command,
+    ...options,
     cwd,
     env,
-    executor,
     expectJson: false
   });
+  const command = versionResult.command;
+  const commandSource = versionResult.commandSource;
 
   if (versionResult.error?.code === 'missing-cli') {
     return createDetectionResult({
       available: false,
       command,
+      commandSource,
       nodeVersion,
       nodeSupported,
       reason: 'missing-cli',
-      errors: [ERRORS.missingCli]
+      errors: [ERRORS.missingCli(command, commandSource)]
     });
   }
 
@@ -80,10 +183,11 @@ export async function detectOpenSpec(options = {}) {
     return createDetectionResult({
       available: true,
       command,
+      commandSource,
       nodeVersion,
       nodeSupported,
       reason: 'version-detection-failed',
-      errors: [ERRORS.versionDetectionFailed]
+      errors: [ERRORS.versionDetectionFailed(command, commandSource)]
     });
   }
 
@@ -93,10 +197,11 @@ export async function detectOpenSpec(options = {}) {
     return createDetectionResult({
       available: true,
       command,
+      commandSource,
       nodeVersion,
       nodeSupported,
       reason: 'version-detection-failed',
-      errors: [ERRORS.versionDetectionFailed]
+      errors: [ERRORS.versionDetectionFailed(command, commandSource)]
     });
   }
 
@@ -108,7 +213,7 @@ export async function detectOpenSpec(options = {}) {
   }
 
   if (!versionSupported) {
-    errors.push(ERRORS.unsupportedVersion(version));
+    errors.push(ERRORS.unsupportedVersion(version, command, commandSource));
   }
 
   const capabilitiesEnabled = errors.length === 0;
@@ -119,6 +224,7 @@ export async function detectOpenSpec(options = {}) {
     canArchive: capabilitiesEnabled,
     version,
     command,
+    commandSource,
     nodeVersion,
     nodeSupported,
     versionSupported,
@@ -129,18 +235,30 @@ export async function detectOpenSpec(options = {}) {
 
 export async function runOpenSpec(args, options = {}) {
   const {
-    command = 'openspec',
     cwd = process.cwd(),
     env = process.env,
-    executor = defaultExecutor,
     expectJson = false
   } = options;
+  const resolution = resolveOpenSpecCommand({
+    command: options.command,
+    cwd,
+    platform: options.platform,
+    candidateExists: options.candidateExists
+  });
+  const executor = options.executor ?? ((call) => executeOpenSpecCommand({
+    ...call,
+    platform: options.platform,
+    execFile: options.execFile,
+    comSpec: options.comSpec,
+    candidateExists: options.candidateExists
+  }));
 
   const normalizedArgs = Array.from(args ?? []);
   const base = {
     ok: false,
     exitCode: null,
-    command,
+    command: resolution.displayCommand,
+    commandSource: resolution.commandSource,
     args: normalizedArgs,
     cwd,
     stdout: '',
@@ -154,7 +272,7 @@ export async function runOpenSpec(args, options = {}) {
 
   try {
     execution = await executor({
-      command,
+      command: resolution.executable,
       args: normalizedArgs,
       cwd,
       env
@@ -162,7 +280,7 @@ export async function runOpenSpec(args, options = {}) {
   } catch (err) {
     return {
       ...base,
-      ...normalizeThrownExecutionError(err)
+      ...normalizeThrownExecutionError(err, resolution)
     };
   }
 
@@ -176,7 +294,11 @@ export async function runOpenSpec(args, options = {}) {
       exitCode,
       stdout,
       stderr,
-      error: ERRORS.nonZeroExit(exitCode)
+      error: ERRORS.nonZeroExit(
+        exitCode,
+        resolution.displayCommand,
+        resolution.commandSource
+      )
     };
   }
 
@@ -302,7 +424,20 @@ export async function archiveOpenSpecChange(changeId, options = {}) {
   });
 }
 
-async function defaultExecutor({ command, args, cwd, env }) {
+export async function executeOpenSpecCommand(options = {}) {
+  const {
+    command,
+    args = [],
+    cwd = process.cwd(),
+    env = process.env
+  } = options;
+  const platform = options.platform ?? process.platform;
+  const execFileImplementation = options.execFile ?? execFileAsync;
+  const candidateExists = options.candidateExists ?? isAccessibleFile;
+  const comSpec = options.comSpec
+    ?? getEnvValue(env, 'ComSpec')
+    ?? process.env.ComSpec
+    ?? 'cmd.exe';
   const execOptions = {
     cwd,
     env,
@@ -310,8 +445,18 @@ async function defaultExecutor({ command, args, cwd, env }) {
     windowsHide: true
   };
 
+  if (platform === 'win32' && isWindowsCommandScript(command)) {
+    return executeWindowsCommandScript({
+      commandPath: command,
+      args,
+      execOptions,
+      execFileImplementation,
+      comSpec
+    });
+  }
+
   try {
-    const { stdout, stderr } = await execFileAsync(command, args, execOptions);
+    const { stdout, stderr } = await execFileImplementation(command, args, execOptions);
 
     return {
       exitCode: 0,
@@ -320,9 +465,19 @@ async function defaultExecutor({ command, args, cwd, env }) {
     };
   } catch (err) {
     if (err.code === 'ENOENT') {
-      const windowsShim = findWindowsCommandScript(command, env);
+      const windowsShim = findWindowsCommandScript(command, env, {
+        platform,
+        candidateExists
+      });
       if (windowsShim !== null) {
-        return executeWindowsCommandScript(windowsShim, args, execOptions, err);
+        return executeWindowsCommandScript({
+          commandPath: windowsShim,
+          args,
+          execOptions,
+          execFileImplementation,
+          comSpec,
+          originalError: err
+        });
       }
 
       throw err;
@@ -342,10 +497,17 @@ async function defaultExecutor({ command, args, cwd, env }) {
   }
 }
 
-async function executeWindowsCommandScript(commandPath, args, execOptions, originalError) {
+async function executeWindowsCommandScript({
+  commandPath,
+  args,
+  execOptions,
+  execFileImplementation,
+  comSpec,
+  originalError = null
+}) {
   try {
-    const { stdout, stderr } = await execFileAsync(
-      process.env.ComSpec ?? 'cmd.exe',
+    const { stdout, stderr } = await execFileImplementation(
+      comSpec,
       ['/d', '/s', '/c', quoteCmdCommand(commandPath, args)],
       {
         ...execOptions,
@@ -369,12 +531,15 @@ async function executeWindowsCommandScript(commandPath, args, execOptions, origi
       };
     }
 
-    throw originalError;
+    throw originalError ?? err;
   }
 }
 
-function findWindowsCommandScript(command, env) {
-  if (process.platform !== 'win32') {
+function findWindowsCommandScript(command, env, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const candidateExists = options.candidateExists ?? isAccessibleFile;
+
+  if (platform !== 'win32') {
     return null;
   }
 
@@ -384,11 +549,11 @@ function findWindowsCommandScript(command, env) {
   }
 
   if (hasPathSeparator(commandText)) {
-    return resolveWindowsScriptCandidate(commandText);
+    return resolveWindowsScriptCandidate(commandText, candidateExists);
   }
 
-  for (const directory of getWindowsPathEntries(env)) {
-    const resolved = resolveWindowsScriptCandidate(path.join(directory, commandText));
+  for (const directory of getWindowsPathEntries(env, platform)) {
+    const resolved = resolveWindowsScriptCandidate(path.win32.join(directory, commandText), candidateExists);
     if (resolved !== null) {
       return resolved;
     }
@@ -397,23 +562,27 @@ function findWindowsCommandScript(command, env) {
   return null;
 }
 
-function resolveWindowsScriptCandidate(candidateBase) {
-  const extension = path.extname(candidateBase).toLowerCase();
+function resolveWindowsScriptCandidate(candidateBase, candidateExists = isAccessibleFile) {
+  const extension = path.win32.extname(candidateBase).toLowerCase();
   const candidates = WINDOWS_SCRIPT_EXTENSIONS.includes(extension)
     ? [candidateBase]
     : WINDOWS_SCRIPT_EXTENSIONS.map((suffix) => `${candidateBase}${suffix}`);
 
-  return candidates.find(isAccessibleFile) ?? null;
+  return candidates.find(candidateExists) ?? null;
 }
 
-function getWindowsPathEntries(env) {
+function isWindowsCommandScript(command) {
+  return WINDOWS_SCRIPT_EXTENSIONS.includes(path.win32.extname(String(command ?? '')).toLowerCase());
+}
+
+function getWindowsPathEntries(env, platform = process.platform) {
   const pathValue = getEnvValue(env, 'PATH');
   if (pathValue === null) {
     return [];
   }
 
   return pathValue
-    .split(path.delimiter)
+    .split(platform === 'win32' ? path.win32.delimiter : path.delimiter)
     .filter((item) => item.trim().length > 0);
 }
 
@@ -474,15 +643,19 @@ function createDetectionResult(overrides = {}) {
     nodeVersion,
     nodeSupported,
     command: overrides.command ?? 'openspec',
+    commandSource: overrides.commandSource ?? 'path',
     reason: overrides.reason ?? null,
     errors: overrides.errors ?? []
   };
 }
 
-function normalizeThrownExecutionError(err) {
+function normalizeThrownExecutionError(err, resolution) {
   if (err?.code === 'ENOENT') {
     return {
-      error: ERRORS.missingCli
+      error: ERRORS.missingCli(
+        resolution.displayCommand,
+        resolution.commandSource
+      )
     };
   }
 

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -69,6 +69,21 @@ describe('detectOpenSpec', () => {
     assert.deepEqual(result.errors, []);
   });
 
+  it('returns available capabilities for reviewed version 1.4.0 on supported Node', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.4.0\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.4.0');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.reason, null);
+  });
+
   it('returns available capabilities for version 1.4.1 on supported Node', async () => {
     const result = await detectOpenSpec({
       executor: async () => ({ exitCode: 0, stdout: 'openspec 1.4.1\n', stderr: '' }),

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -129,6 +129,21 @@ describe('detectOpenSpec', () => {
     assert.equal(result.reason, null);
   });
 
+  it('returns available capabilities for reviewed version 1.7.0 on supported Node', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.7.0\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.7.0');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.reason, null);
+  });
+
   it('returns degraded capabilities when CLI is missing', async () => {
     const result = await detectOpenSpec({
       executor: async () => {
@@ -676,6 +691,29 @@ describe('OpenSpec command wrappers', () => {
     assert.deepEqual(calls[0].args, [
       'instructions',
       'apply',
+      '--change',
+      'add-oauth',
+      '--json',
+      '--no-color'
+    ]);
+  });
+
+  it('getOpenSpecInstructions supports the OpenSpec 1.7 archive artifact', async () => {
+    const { executor, calls } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: '{"changeName":"add-oauth"}',
+      stderr: ''
+    });
+
+    const result = await getOpenSpecInstructions('archive', {
+      change: 'add-oauth',
+      executor
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls[0].args, [
+      'instructions',
+      'archive',
       '--change',
       'add-oauth',
       '--json',

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -84,7 +84,7 @@ describe('detectOpenSpec', () => {
     assert.equal(result.reason, null);
   });
 
-  it('returns available capabilities for version 1.4.1 on supported Node', async () => {
+  it('returns available capabilities for reviewed version 1.4.1 on supported Node', async () => {
     const result = await detectOpenSpec({
       executor: async () => ({ exitCode: 0, stdout: 'openspec 1.4.1\n', stderr: '' }),
       nodeVersion: '20.19.0'

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -589,10 +589,67 @@ describe('runOpenSpec', () => {
     assert.equal(result.commandSource, 'project-local');
     assert.equal(calls.length, 1);
     assert.equal(calls[0][0], 'C:\\Windows\\System32\\cmd.exe');
-    assert.deepEqual(calls[0][1].slice(0, 3), ['/d', '/s', '/c']);
-    assert.match(calls[0][1][3], /"C:\\Work Space\\repo\\node_modules\\\.bin\\openspec\.cmd"/);
-    assert.match(calls[0][1][3], /"value & more"/);
+    assert.deepEqual(calls[0][1].slice(0, 4), ['/d', '/s', '/v:off', '/c']);
+    assert.match(calls[0][1][4], /C:\\Work\^ Space\\repo\\node_modules\\\.bin\\openspec\.cmd/);
+    assert.match(calls[0][1][4], /\^\^\^&/);
+    assert.doesNotMatch(calls[0][1][4], /"value & more"/);
     assert.equal(calls[0][2].windowsVerbatimArguments, true);
+  });
+
+  it('preserves shell metacharacters through a real Windows project-local cmd shim', { skip: process.platform !== 'win32' }, async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'openspec-%PATH%-&-args-'));
+    const binDir = path.join(tempDir, 'node_modules', '.bin');
+    const captureScript = path.join(tempDir, 'capture-args.mjs');
+    const localCommand = path.join(binDir, 'openspec.cmd');
+    const args = [
+      'show',
+      'value & more',
+      'value | more',
+      'value > more',
+      'value < more',
+      'value %PATH% more',
+      'value ^ more',
+      'value !AIFHUB_CMD_TEST! more',
+      'value "quoted" more',
+      'value with trailing slash\\'
+    ];
+
+    try {
+      await mkdir(binDir, { recursive: true });
+      await writeFile(
+        captureScript,
+        'process.stdout.write(JSON.stringify(process.argv.slice(2)));\n',
+        'utf8'
+      );
+      await writeFile(
+        localCommand,
+        `@echo off\r\n"${process.execPath.replaceAll('%', '%%')}" "${captureScript.replaceAll('%', '%%')}" %*\r\n`,
+        'utf8'
+      );
+
+      const result = await runOpenSpec(args, {
+        cwd: tempDir,
+        platform: 'win32',
+        candidateExists: (candidate) => candidate === localCommand,
+        env: {
+          ...process.env,
+          AIFHUB_CMD_TEST: 'expanded-value'
+        }
+      });
+
+      assert.equal(result.ok, true, result.error?.message);
+      const receivedArgs = JSON.parse(result.stdout);
+      assert.equal(receivedArgs.length, args.length, 'cmd shim should preserve the argv length');
+      for (const [index, expected] of args.entries()) {
+        assert.equal(
+          receivedArgs[index] === expected,
+          true,
+          `cmd shim should preserve argv[${index}] without environment expansion`
+        );
+      }
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -596,6 +596,30 @@ describe('runOpenSpec', () => {
     assert.equal(calls[0][2].windowsVerbatimArguments, true);
   });
 
+  it('rejects a relative or non-cmd ComSpec before executing Windows shims', async () => {
+    const cwd = 'C:\\workspace';
+    const localCommand = 'C:\\workspace\\node_modules\\.bin\\openspec.cmd';
+
+    for (const comSpec of ['cmd.exe', 'C:\\Windows\\System32\\WindowsPowerShell.exe']) {
+      let calls = 0;
+      const result = await runOpenSpec(['--version'], {
+        cwd,
+        platform: 'win32',
+        candidateExists: (candidate) => candidate === localCommand,
+        comSpec,
+        execFile: async () => {
+          calls += 1;
+          return { stdout: '1.8.0', stderr: '' };
+        }
+      });
+
+      assert.equal(result.ok, false, `${comSpec} must be rejected`);
+      assert.equal(result.error?.code, 'invalid-comspec');
+      assert.match(result.error?.message ?? '', /absolute cmd\.exe path/);
+      assert.equal(calls, 0, 'unsafe ComSpec must not be executed');
+    }
+  });
+
   it('preserves shell metacharacters through a real Windows project-local cmd shim', { skip: process.platform !== 'win32' }, async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), 'openspec-%PATH%-&-args-'));
     const binDir = path.join(tempDir, 'node_modules', '.bin');

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -99,6 +99,21 @@ describe('detectOpenSpec', () => {
     assert.equal(result.reason, null);
   });
 
+  it('returns available capabilities for reviewed version 1.5.0 on supported Node', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.5.0\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.5.0');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.reason, null);
+  });
+
   it('returns degraded capabilities when CLI is missing', async () => {
     const result = await detectOpenSpec({
       executor: async () => {
@@ -552,6 +567,24 @@ describe('OpenSpec command wrappers', () => {
       '--no-color'
     ]);
     assert.deepEqual(result.json, { valid: true });
+  });
+
+  it('preserves additive OpenSpec 1.5.0 root diagnostics in parsed JSON', async () => {
+    const { executor } = createRecordingExecutor({
+      exitCode: 0,
+      stdout: '{"items":[],"summary":{"total":0},"version":"1.5.0","root":"C:/repo/openspec"}',
+      stderr: ''
+    });
+
+    const result = await validateOpenSpecChange('add-oauth', { executor });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.json, {
+      items: [],
+      summary: { total: 0 },
+      version: '1.5.0',
+      root: 'C:/repo/openspec'
+    });
   });
 
   it('getOpenSpecStatus builds the expected args', async () => {

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -144,6 +144,21 @@ describe('detectOpenSpec', () => {
     assert.equal(result.reason, null);
   });
 
+  it('returns available capabilities for reviewed version 1.8.0 on supported Node', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.8.0\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.8.0');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.reason, null);
+  });
+
   it('returns degraded capabilities when CLI is missing', async () => {
     const result = await detectOpenSpec({
       executor: async () => {

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -1,7 +1,7 @@
 // openspec-runner.test.mjs - tests for OpenSpec CLI runner and capability detection
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -10,6 +10,7 @@ import {
   detectOpenSpec,
   getOpenSpecInstructions,
   getOpenSpecStatus,
+  resolveOpenSpecCommand,
   runOpenSpec,
   showOpenSpecItem,
   validateOpenSpecChange
@@ -63,6 +64,7 @@ describe('detectOpenSpec', () => {
     assert.equal(result.nodeVersion, '20.19.0');
     assert.equal(result.nodeSupported, true);
     assert.equal(result.command, 'openspec');
+    assert.equal(result.commandSource, 'path');
     assert.equal(result.reason, null);
     assert.deepEqual(result.errors, []);
   });
@@ -100,7 +102,7 @@ describe('detectOpenSpec', () => {
     assert.deepEqual(result.errors, [
       {
         code: 'missing-cli',
-        message: 'OpenSpec CLI is not available on PATH.'
+        message: "Selected OpenSpec CLI 'openspec' (path) is unavailable."
       }
     ]);
   });
@@ -186,10 +188,147 @@ describe('detectOpenSpec', () => {
       assert.equal(result.canValidate, true);
       assert.equal(result.canArchive, true);
       assert.equal(result.version, '1.3.1');
+      assert.equal(result.command, 'openspec');
+      assert.equal(result.commandSource, 'path');
       assert.equal(result.reason, null);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it('prefers a newer project-local CLI over an older global CLI', async () => {
+    const localCommand = '/workspace/node_modules/.bin/openspec';
+    const calls = [];
+    const result = await detectOpenSpec({
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: (candidate) => candidate === localCommand,
+      executor: async (call) => {
+        calls.push(call);
+        return {
+          exitCode: 0,
+          stdout: call.command === localCommand ? 'openspec 1.4.1' : 'openspec 1.2.0',
+          stderr: ''
+        };
+      },
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, localCommand);
+    assert.equal(result.version, '1.4.1');
+    assert.equal(result.command, 'node_modules/.bin/openspec');
+    assert.equal(result.commandSource, 'project-local');
+    assert.equal(result.canValidate, true);
+  });
+
+  it('does not replace an unsupported project-local CLI with a supported global CLI', async () => {
+    const localCommand = '/workspace/node_modules/.bin/openspec';
+    const calls = [];
+    const result = await detectOpenSpec({
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: (candidate) => candidate === localCommand,
+      executor: async (call) => {
+        calls.push(call);
+        return {
+          exitCode: 0,
+          stdout: call.command === localCommand ? 'openspec 1.2.0' : 'openspec 1.4.1',
+          stderr: ''
+        };
+      },
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, localCommand);
+    assert.equal(result.version, '1.2.0');
+    assert.equal(result.commandSource, 'project-local');
+    assert.equal(result.reason, 'unsupported-version');
+    assert.match(result.errors[0].message, /node_modules\/\.bin\/openspec.*project-local/);
+  });
+
+  it('uses a project-local Windows shim on the current Windows runtime', { skip: process.platform !== 'win32' }, async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'openspec-local-shim-'));
+    const binDir = path.join(tempDir, 'node_modules', '.bin');
+
+    try {
+      await mkdir(binDir, { recursive: true });
+      await writeFile(
+        path.join(binDir, 'openspec.cmd'),
+        '@echo off\r\necho 1.4.1\r\n',
+        'utf8'
+      );
+
+      const result = await detectOpenSpec({
+        cwd: tempDir,
+        nodeVersion: '20.19.0'
+      });
+
+      assert.equal(result.available, true);
+      assert.equal(result.version, '1.4.1');
+      assert.equal(result.command, 'node_modules/.bin/openspec.cmd');
+      assert.equal(result.commandSource, 'project-local');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('resolveOpenSpecCommand', () => {
+  it('selects an explicit command before project-local and PATH candidates', () => {
+    const result = resolveOpenSpecCommand({
+      command: '/workspace/tools/openspec',
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: () => true
+    });
+
+    assert.deepEqual(result, {
+      executable: '/workspace/tools/openspec',
+      displayCommand: 'tools/openspec',
+      commandSource: 'explicit'
+    });
+  });
+
+  it('treats an undefined command as absent and selects project-local', () => {
+    const result = resolveOpenSpecCommand({
+      command: undefined,
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: (candidate) => candidate === '/workspace/node_modules/.bin/openspec'
+    });
+
+    assert.equal(result.executable, '/workspace/node_modules/.bin/openspec');
+    assert.equal(result.displayCommand, 'node_modules/.bin/openspec');
+    assert.equal(result.commandSource, 'project-local');
+  });
+
+  it('uses the global PATH command only when project-local is absent', () => {
+    const result = resolveOpenSpecCommand({
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: () => false
+    });
+
+    assert.deepEqual(result, {
+      executable: 'openspec',
+      displayCommand: 'openspec',
+      commandSource: 'path'
+    });
+  });
+
+  it('bounds an explicit absolute command outside cwd to its basename', () => {
+    const result = resolveOpenSpecCommand({
+      command: '/private/tools/custom-openspec',
+      cwd: '/workspace',
+      platform: 'linux'
+    });
+
+    assert.equal(result.executable, '/private/tools/custom-openspec');
+    assert.equal(result.displayCommand, 'custom-openspec');
+    assert.equal(result.commandSource, 'explicit');
+    assert.doesNotMatch(result.displayCommand, /private|workspace/);
   });
 });
 
@@ -254,7 +393,7 @@ describe('runOpenSpec', () => {
     assert.equal(result.jsonParseError, null);
     assert.deepEqual(result.error, {
       code: 'non-zero-exit',
-      message: 'OpenSpec command failed with exit code 1.'
+      message: "OpenSpec command 'openspec' (path) failed with exit code 1."
     });
   });
 
@@ -273,12 +412,110 @@ describe('runOpenSpec', () => {
     assert.equal(result.jsonParseError, null);
     assert.deepEqual(result.error, {
       code: 'missing-cli',
-      message: 'OpenSpec CLI is not available on PATH.'
+      message: "Selected OpenSpec CLI 'openspec' (path) is unavailable."
     });
+  });
+
+  it('does not fall back after an explicit command is selected and missing', async () => {
+    const calls = [];
+    const result = await runOpenSpec(['--version'], {
+      command: '/workspace/tools/openspec',
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: () => true,
+      executor: async (call) => {
+        calls.push(call);
+        throw missingCliError();
+      }
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, '/workspace/tools/openspec');
+    assert.equal(result.command, 'tools/openspec');
+    assert.equal(result.commandSource, 'explicit');
+    assert.equal(result.error.code, 'missing-cli');
+    assert.match(result.error.message, /tools\/openspec.*explicit/);
+  });
+
+  it('executes a POSIX project-local shim directly with separate argv', async () => {
+    const calls = [];
+    const result = await runOpenSpec(['show', 'item with spaces'], {
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: (candidate) => candidate === '/workspace/node_modules/.bin/openspec',
+      execFile: async (...call) => {
+        calls.push(call);
+        return { stdout: 'ok', stderr: '' };
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.commandSource, 'project-local');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], '/workspace/node_modules/.bin/openspec');
+    assert.deepEqual(calls[0][1], ['show', 'item with spaces']);
+    assert.equal(calls[0][2].cwd, '/workspace');
+    assert.equal(calls[0][2].windowsVerbatimArguments, undefined);
+  });
+
+  it('routes a synthetic Windows project-local shim directly through ComSpec', async () => {
+    const calls = [];
+    const cwd = 'C:\\Work Space\\repo';
+    const localCommand = 'C:\\Work Space\\repo\\node_modules\\.bin\\openspec.cmd';
+    const result = await runOpenSpec(['show', 'value & more'], {
+      cwd,
+      platform: 'win32',
+      candidateExists: (candidate) => candidate === localCommand,
+      comSpec: 'C:\\Windows\\System32\\cmd.exe',
+      execFile: async (...call) => {
+        calls.push(call);
+        return { stdout: 'ok', stderr: '' };
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.command, 'node_modules/.bin/openspec.cmd');
+    assert.equal(result.commandSource, 'project-local');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], 'C:\\Windows\\System32\\cmd.exe');
+    assert.deepEqual(calls[0][1].slice(0, 3), ['/d', '/s', '/c']);
+    assert.match(calls[0][1][3], /"C:\\Work Space\\repo\\node_modules\\\.bin\\openspec\.cmd"/);
+    assert.match(calls[0][1][3], /"value & more"/);
+    assert.equal(calls[0][2].windowsVerbatimArguments, true);
   });
 });
 
 describe('OpenSpec command wrappers', () => {
+  it('uses the same project-local resolver semantics for every operation', async () => {
+    const localCommand = '/workspace/node_modules/.bin/openspec';
+    const calls = [];
+    const options = {
+      cwd: '/workspace',
+      platform: 'linux',
+      candidateExists: (candidate) => candidate === localCommand,
+      executor: async (call) => {
+        calls.push(call);
+        return {
+          exitCode: 0,
+          stdout: call.args[0] === 'archive' ? 'archived' : '{}',
+          stderr: ''
+        };
+      }
+    };
+
+    const results = await Promise.all([
+      validateOpenSpecChange('add-oauth', options),
+      getOpenSpecStatus('add-oauth', options),
+      showOpenSpecItem('add-oauth', options),
+      getOpenSpecInstructions('apply', { ...options, change: 'add-oauth' }),
+      archiveOpenSpecChange('add-oauth', options)
+    ]);
+
+    assert.deepEqual(calls.map((call) => call.command), Array(5).fill(localCommand));
+    assert.equal(results.every((result) => result.command === 'node_modules/.bin/openspec'), true);
+    assert.equal(results.every((result) => result.commandSource === 'project-local'), true);
+  });
+
   it('validateOpenSpecChange builds the expected args', async () => {
     const { executor, calls } = createRecordingExecutor({
       exitCode: 0,

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -81,6 +81,8 @@ describe('detectOpenSpec', () => {
     assert.equal(result.version, '1.4.0');
     assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
     assert.equal(result.versionSupported, true);
+    assert.equal(result.latestReviewedVersion, '1.8.0');
+    assert.equal(result.versionOutdated, true);
     assert.equal(result.reason, null);
   });
 
@@ -156,6 +158,21 @@ describe('detectOpenSpec', () => {
     assert.equal(result.version, '1.8.0');
     assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
     assert.equal(result.versionSupported, true);
+    assert.equal(result.latestReviewedVersion, '1.8.0');
+    assert.equal(result.versionOutdated, false);
+    assert.equal(result.reason, null);
+  });
+
+  it('does not mark a newer supported version as outdated or recommend a downgrade signal', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.9.0\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.latestReviewedVersion, '1.8.0');
+    assert.equal(result.versionOutdated, false);
     assert.equal(result.reason, null);
   });
 
@@ -172,6 +189,8 @@ describe('detectOpenSpec', () => {
     assert.equal(result.canArchive, false);
     assert.equal(result.version, null);
     assert.equal(result.versionSupported, false);
+    assert.equal(result.latestReviewedVersion, '1.8.0');
+    assert.equal(result.versionOutdated, null);
     assert.equal(result.nodeSupported, true);
     assert.equal(result.reason, 'missing-cli');
     assert.deepEqual(result.errors, [
@@ -193,6 +212,8 @@ describe('detectOpenSpec', () => {
     assert.equal(result.canArchive, false);
     assert.equal(result.version, '1.2.0');
     assert.equal(result.versionSupported, false);
+    assert.equal(result.latestReviewedVersion, '1.8.0');
+    assert.equal(result.versionOutdated, null);
     assert.equal(result.nodeSupported, true);
     assert.equal(result.reason, 'unsupported-version');
     assert.equal(result.errors[0].code, 'unsupported-version');

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -169,6 +169,21 @@ describe('detectOpenSpec', () => {
     assert.equal(result.errors[0].code, 'unsupported-version');
   });
 
+  it('keeps reviewed prerelease 1.6.0-beta.1 unavailable for production capabilities', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.6.0-beta.1', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, false);
+    assert.equal(result.canArchive, false);
+    assert.equal(result.version, '1.6.0-beta.1');
+    assert.equal(result.versionSupported, false);
+    assert.equal(result.reason, 'unsupported-version');
+    assert.equal(result.errors[0].code, 'unsupported-version');
+  });
+
   it('returns unsupported-node when injected Node version is below 20.19.0', async () => {
     const result = await detectOpenSpec({
       executor: async () => ({ exitCode: 0, stdout: '@fission-ai/openspec 1.3.1', stderr: '' }),

--- a/scripts/openspec-runner.test.mjs
+++ b/scripts/openspec-runner.test.mjs
@@ -114,6 +114,21 @@ describe('detectOpenSpec', () => {
     assert.equal(result.reason, null);
   });
 
+  it('returns available capabilities for reviewed version 1.6.0 on supported Node', async () => {
+    const result = await detectOpenSpec({
+      executor: async () => ({ exitCode: 0, stdout: 'openspec 1.6.0\n', stderr: '' }),
+      nodeVersion: '20.19.0'
+    });
+
+    assert.equal(result.available, true);
+    assert.equal(result.canValidate, true);
+    assert.equal(result.canArchive, true);
+    assert.equal(result.version, '1.6.0');
+    assert.equal(result.supportedRange, '>=1.3.1 <2.0.0');
+    assert.equal(result.versionSupported, true);
+    assert.equal(result.reason, null);
+  });
+
   it('returns degraded capabilities when CLI is missing', async () => {
     const result = await detectOpenSpec({
       executor: async () => {

--- a/scripts/openspec-verification-context.mjs
+++ b/scripts/openspec-verification-context.mjs
@@ -39,6 +39,7 @@ const GENERATED_RULES_DIR = path.join('.ai-factory', 'rules', 'generated');
 const VALIDATION_FILE = 'openspec-validation.json';
 const STATUS_FILE = 'openspec-status.json';
 const VERIFY_FILE = 'verify.md';
+const COMMAND_SOURCES = new Set(['explicit', 'project-local', 'path']);
 
 export async function buildVerificationContext(options = {}) {
   return runOpenSpecVerification(options.changeId, options);
@@ -723,6 +724,7 @@ function createOpenSpecSummary(detection) {
     canValidate: Boolean(detection?.canValidate),
     version: detection?.version ?? null,
     command: detection?.command ?? 'openspec',
+    commandSource: normalizeCommandSource(detection?.commandSource),
     reason: detection?.reason ?? null,
     errors: detection?.errors ?? []
   };
@@ -754,6 +756,7 @@ function normalizeCommandResult(result, options = {}) {
   return {
     ok,
     command: result?.command ?? null,
+    commandSource: normalizeCommandSource(result?.commandSource),
     args: Array.from(result?.args ?? []),
     exitCode: result?.exitCode ?? null,
     parsedJson: result?.json ?? parsed.parsedJson,
@@ -783,6 +786,7 @@ function normalizeEvidenceCommand({ changeId, result, rootDir, qaPath, stdoutFil
   return {
     changeId,
     command: normalized.command ?? null,
+    commandSource: normalizeCommandSource(normalized.commandSource),
     args: Array.from(normalized.args ?? []),
     exitCode: normalized.exitCode ?? null,
     ok: Boolean(normalized.ok),
@@ -839,6 +843,7 @@ function createSkippedCommand({ ok, reason, message }) {
     reason,
     message,
     command: null,
+    commandSource: null,
     args: [],
     exitCode: null,
     parsedJson: null,
@@ -850,6 +855,10 @@ function createSkippedCommand({ ok, reason, message }) {
       message
     }
   };
+}
+
+function normalizeCommandSource(value) {
+  return COMMAND_SOURCES.has(value) ? value : null;
 }
 
 async function writeRawCommandStreams(command, rawDir) {

--- a/scripts/openspec-verification-context.test.mjs
+++ b/scripts/openspec-verification-context.test.mjs
@@ -206,6 +206,52 @@ describe('OpenSpec verification context API', () => {
     assert.match(verifySummary, /## Coverage/);
   });
 
+  it('preserves bounded project-local command diagnostics in runtime and QA evidence', async () => {
+    const rootDir = await createTempRoot();
+    const command = 'node_modules/.bin/openspec.cmd';
+    const commandSource = 'project-local';
+    await createOpenSpecChange(rootDir);
+    await createGeneratedRules(rootDir);
+
+    const result = await buildVerificationContext({
+      rootDir,
+      changeId: 'add-oauth',
+      detectOpenSpec: async () => ({
+        ...availableCliDetection(),
+        command,
+        commandSource
+      }),
+      validateOpenSpecChange: async () => ({
+        ...validationResult(),
+        command,
+        commandSource
+      }),
+      getOpenSpecStatus: async () => ({
+        ...statusResult(),
+        command,
+        commandSource
+      })
+    });
+
+    assert.equal(result.openspec.command, command);
+    assert.equal(result.openspec.commandSource, commandSource);
+    assert.equal(result.openspec.validation.command, command);
+    assert.equal(result.openspec.validation.commandSource, commandSource);
+    assert.equal(result.openspec.status.command, command);
+    assert.equal(result.openspec.status.commandSource, commandSource);
+
+    const qaPath = path.join(rootDir, '.ai-factory', 'qa', 'add-oauth');
+    const validationEvidence = await readJson(path.join(qaPath, 'openspec-validation.json'));
+    const statusEvidence = await readJson(path.join(qaPath, 'openspec-status.json'));
+
+    assert.equal(validationEvidence.command, command);
+    assert.equal(validationEvidence.commandSource, commandSource);
+    assert.equal(statusEvidence.command, command);
+    assert.equal(statusEvidence.commandSource, commandSource);
+    assert.equal(path.posix.isAbsolute(validationEvidence.command), false);
+    assert.equal(path.win32.isAbsolute(validationEvidence.command), false);
+  });
+
   it('skips OpenSpec status warning for numeric-leading change ids rejected by status CLI', async () => {
     const rootDir = await createTempRoot();
     const changeId = '81-command-wrappers';

--- a/scripts/openspec-verification-context.test.mjs
+++ b/scripts/openspec-verification-context.test.mjs
@@ -452,6 +452,42 @@ describe('OpenSpec verification context API', () => {
     });
   });
 
+  it('preserves OpenSpec 1.8 scenario-loss diagnostics while failing fast', async () => {
+    const rootDir = await createTempRoot();
+    await createOpenSpecChange(rootDir);
+    const scenarioLoss = 'MODIFIED "Widget state" omits scenario(s) the current spec still has: "Second scenario".';
+
+    const result = await runOpenSpecVerification('add-oauth', {
+      rootDir,
+      detectOpenSpec: async () => ({ ...availableCliDetection(), version: '1.8.0' }),
+      validateOpenSpecChange: async () => validationResult({
+        ok: false,
+        exitCode: 1,
+        stdout: JSON.stringify({
+          items: [{
+            id: 'add-oauth',
+            valid: false,
+            issues: [{ level: 'ERROR', path: 'widgets/spec.md', message: scenarioLoss }]
+          }]
+        }),
+        stderr: '',
+        json: null,
+        error: {
+          code: 'non-zero-exit',
+          message: 'OpenSpec command failed with exit code 1.'
+        }
+      }),
+      getOpenSpecStatus: async () => statusResult()
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.shouldRunCodeVerification, false);
+    assert.equal(result.openspec.validation.parsedJson.items[0].issues[0].message, scenarioLoss);
+    const evidence = await readJson(path.join(rootDir, '.ai-factory', 'qa', 'add-oauth', 'openspec-validation.json'));
+    assert.equal(evidence.parsedJson.items[0].issues[0].path, 'widgets/spec.md');
+    assert.equal(evidence.parsedJson.items[0].issues[0].message, scenarioLoss);
+  });
+
   it('uses degraded missing-CLI mode unless strict config requires CLI', async () => {
     const rootDir = await createTempRoot();
     await createOpenSpecChange(rootDir);

--- a/scripts/validate-extension.mjs
+++ b/scripts/validate-extension.mjs
@@ -33,6 +33,8 @@ const SOURCE_METADATA_KEYS = new Set([
   'version',
   'baselineVersion',
   'supportedRange',
+  'reviewedStableVersions',
+  'reviewedPrereleaseVersions',
   'lastSync',
   'optional',
   'requiresNode',
@@ -420,9 +422,91 @@ async function validateAifhubMetadata(metadata, repoRoot) {
       log('ERROR', 'Source metadata optional must be boolean', { source: sourceName });
       hasErrors = true;
     }
+
+    if (sourceName === 'openspec' && validateOpenSpecReviewMetadata(source)) {
+      hasErrors = true;
+    }
   }
 
   return hasErrors;
+}
+
+function validateOpenSpecReviewMetadata(source) {
+  let hasErrors = false;
+  const stable = source.reviewedStableVersions;
+  const prerelease = source.reviewedPrereleaseVersions;
+
+  if (typeof source.baselineVersion !== 'string' || !source.baselineVersion) {
+    log('ERROR', 'OpenSpec source metadata requires baselineVersion');
+    hasErrors = true;
+  }
+
+  if (!Array.isArray(stable) || stable.length === 0) {
+    log('ERROR', 'OpenSpec source metadata requires reviewedStableVersions');
+    hasErrors = true;
+  } else {
+    const invalid = stable.find((version) => !/^\d+\.\d+\.\d+$/.test(version));
+    const duplicate = stable.find((version, index) => stable.indexOf(version) !== index);
+    const outOfOrder = stable.find((version, index) => (
+      index > 0 && compareStableVersions(stable[index - 1], version) >= 0
+    ));
+
+    if (invalid) {
+      log('ERROR', 'OpenSpec reviewed stable version must be stable semver', { version: invalid });
+      hasErrors = true;
+    }
+    if (duplicate) {
+      log('ERROR', 'OpenSpec reviewed stable versions must be unique', { version: duplicate });
+      hasErrors = true;
+    }
+    if (outOfOrder) {
+      log('ERROR', 'OpenSpec reviewed stable versions must be strictly increasing', { version: outOfOrder });
+      hasErrors = true;
+    }
+    if (source.baselineVersion && stable[0] !== source.baselineVersion) {
+      log('ERROR', 'OpenSpec reviewed stable versions must start with baselineVersion', {
+        baselineVersion: source.baselineVersion,
+        firstReviewedVersion: stable[0]
+      });
+      hasErrors = true;
+    }
+    if (source.version && stable.at(-1) !== source.version) {
+      log('ERROR', 'OpenSpec source version must equal the latest reviewed stable version', {
+        sourceVersion: source.version,
+        latestReviewedVersion: stable.at(-1)
+      });
+      hasErrors = true;
+    }
+  }
+
+  if (!Array.isArray(prerelease)) {
+    log('ERROR', 'OpenSpec source metadata requires reviewedPrereleaseVersions');
+    hasErrors = true;
+  } else {
+    const invalid = prerelease.find((version) => !/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(version));
+    const duplicate = prerelease.find((version, index) => prerelease.indexOf(version) !== index);
+    if (invalid) {
+      log('ERROR', 'OpenSpec reviewed prerelease version must be prerelease semver', { version: invalid });
+      hasErrors = true;
+    }
+    if (duplicate) {
+      log('ERROR', 'OpenSpec reviewed prerelease versions must be unique', { version: duplicate });
+      hasErrors = true;
+    }
+  }
+
+  return hasErrors;
+}
+
+function compareStableVersions(left, right) {
+  const leftParts = String(left).split('.').map(Number);
+  const rightParts = String(right).split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
 }
 
 async function validateManifestPaths(manifest, repoRoot) {

--- a/scripts/validate-extension.mjs
+++ b/scripts/validate-extension.mjs
@@ -5,6 +5,8 @@
 import { readFile, stat } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 
+import { OPENSPEC_LATEST_REVIEWED_VERSION } from './openspec-runner.mjs';
+
 const LOG_LEVEL = process.env.LOG_LEVEL || 'INFO';
 const LEVELS = { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 };
 
@@ -474,6 +476,13 @@ function validateOpenSpecReviewMetadata(source) {
       log('ERROR', 'OpenSpec source version must equal the latest reviewed stable version', {
         sourceVersion: source.version,
         latestReviewedVersion: stable.at(-1)
+      });
+      hasErrors = true;
+    }
+    if (source.version && source.version !== OPENSPEC_LATEST_REVIEWED_VERSION) {
+      log('ERROR', 'OpenSpec source version must match the runner reviewed-version diagnostic', {
+        sourceVersion: source.version,
+        runnerReviewedVersion: OPENSPEC_LATEST_REVIEWED_VERSION
       });
       hasErrors = true;
     }

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -82,7 +82,7 @@ function validAifhubMetadata(extra = {}) {
         baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
         reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0'],
-        reviewedPrereleaseVersions: [],
+        reviewedPrereleaseVersions: ['1.6.0-beta.1'],
         lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,16 +78,16 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.5.0',
+        version: '1.6.0',
         baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0'],
+        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0'],
         reviewedPrereleaseVersions: ['1.6.0-beta.1'],
         lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'Validated against upstream OpenSpec 1.5.0; AIFHub remains adapter-only.'
+        notes: 'Validated against upstream OpenSpec 1.6.0; AIFHub remains adapter-only.'
       }
     },
     ...extra
@@ -265,7 +265,7 @@ describe('validate-extension.mjs', () => {
 
   it('fails when the latest reviewed OpenSpec stable version differs from source version', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
-    parsed.sources.openspec.version = '1.6.0';
+    parsed.sources.openspec.version = '1.7.0';
     await writeValidProject({ metadata: JSON.stringify(parsed) });
 
     const code = await runValidatorExitCode(tmpDir);

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -272,6 +272,16 @@ describe('validate-extension.mjs', () => {
     assert.equal(code, 1);
   });
 
+  it('fails when OpenSpec metadata advances without the runtime reviewed-version diagnostic', async () => {
+    const parsed = JSON.parse(validAifhubMetadata());
+    parsed.sources.openspec.version = '1.9.0';
+    parsed.sources.openspec.reviewedStableVersions.push('1.9.0');
+    await writeValidProject({ metadata: JSON.stringify(parsed) });
+
+    const code = await runValidatorExitCode(tmpDir);
+    assert.equal(code, 1);
+  });
+
   it('fails when an OpenSpec prerelease is listed as reviewed stable', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
     parsed.sources.openspec.reviewedStableVersions.push('1.6.0-beta.1');

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,16 +78,16 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.4.0',
+        version: '1.4.1',
         baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        reviewedStableVersions: ['1.3.1', '1.4.0'],
+        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1'],
         reviewedPrereleaseVersions: [],
         lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'Validated against upstream OpenSpec 1.4.0; AIFHub remains adapter-only.'
+        notes: 'Validated against upstream OpenSpec 1.4.1; AIFHub remains adapter-only.'
       }
     },
     ...extra
@@ -265,7 +265,7 @@ describe('validate-extension.mjs', () => {
 
   it('fails when the latest reviewed OpenSpec stable version differs from source version', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
-    parsed.sources.openspec.version = '1.4.1';
+    parsed.sources.openspec.version = '1.5.0';
     await writeValidProject({ metadata: JSON.stringify(parsed) });
 
     const code = await runValidatorExitCode(tmpDir);

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,16 +78,16 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.4.1',
+        version: '1.5.0',
         baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1'],
+        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0'],
         reviewedPrereleaseVersions: [],
         lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'Validated against upstream OpenSpec 1.4.1; AIFHub remains adapter-only.'
+        notes: 'Validated against upstream OpenSpec 1.5.0; AIFHub remains adapter-only.'
       }
     },
     ...extra
@@ -265,7 +265,7 @@ describe('validate-extension.mjs', () => {
 
   it('fails when the latest reviewed OpenSpec stable version differs from source version', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
-    parsed.sources.openspec.version = '1.5.0';
+    parsed.sources.openspec.version = '1.6.0';
     await writeValidProject({ metadata: JSON.stringify(parsed) });
 
     const code = await runValidatorExitCode(tmpDir);

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,16 +78,16 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.6.0',
+        version: '1.7.0',
         baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0'],
+        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0', '1.7.0'],
         reviewedPrereleaseVersions: ['1.6.0-beta.1'],
         lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'Validated against upstream OpenSpec 1.6.0; AIFHub remains adapter-only.'
+        notes: 'Validated against upstream OpenSpec 1.7.0; AIFHub remains adapter-only.'
       }
     },
     ...extra
@@ -265,7 +265,7 @@ describe('validate-extension.mjs', () => {
 
   it('fails when the latest reviewed OpenSpec stable version differs from source version', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
-    parsed.sources.openspec.version = '1.7.0';
+    parsed.sources.openspec.version = '1.8.0';
     await writeValidProject({ metadata: JSON.stringify(parsed) });
 
     const code = await runValidatorExitCode(tmpDir);

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -118,6 +118,15 @@ async function writeValidProject({
 }
 
 describe('validate-extension.mjs', () => {
+  it('requires baselineVersion for every source metadata entry in the JSON Schema', async () => {
+    const schema = JSON.parse(await readFile(join(REPO_ROOT, 'schemas/aifhub-extension.schema.json'), 'utf-8'));
+
+    assert.ok(
+      schema.$defs.SourceMetadata.required.includes('baselineVersion'),
+      'SourceMetadata.required should match the validator baselineVersion contract'
+    );
+  });
+
   it('passes with upstream extension manifest, AIFHub metadata, and all files present', async () => {
     await writeValidProject();
 

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,16 +78,16 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.7.0',
+        version: '1.8.0',
         baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0', '1.7.0'],
+        reviewedStableVersions: ['1.3.1', '1.4.0', '1.4.1', '1.5.0', '1.6.0', '1.7.0', '1.8.0'],
         reviewedPrereleaseVersions: ['1.6.0-beta.1'],
         lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'Validated against upstream OpenSpec 1.7.0; AIFHub remains adapter-only.'
+        notes: 'Validated against upstream OpenSpec 1.8.0; AIFHub remains adapter-only.'
       }
     },
     ...extra
@@ -265,7 +265,7 @@ describe('validate-extension.mjs', () => {
 
   it('fails when the latest reviewed OpenSpec stable version differs from source version', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
-    parsed.sources.openspec.version = '1.8.0';
+    parsed.sources.openspec.version = '1.9.0';
     await writeValidProject({ metadata: JSON.stringify(parsed) });
 
     const code = await runValidatorExitCode(tmpDir);

--- a/scripts/validate-extension.test.mjs
+++ b/scripts/validate-extension.test.mjs
@@ -78,13 +78,16 @@ function validAifhubMetadata(extra = {}) {
       },
       openspec: {
         url: 'https://github.com/Fission-AI/OpenSpec',
-        version: '1.4.1',
+        version: '1.4.0',
+        baselineVersion: '1.3.1',
         supportedRange: '>=1.3.1 <2.0.0',
-        lastSync: '2026-06-10',
+        reviewedStableVersions: ['1.3.1', '1.4.0'],
+        reviewedPrereleaseVersions: [],
+        lastSync: '2026-08-09',
         optional: true,
         requiresNode: '>=20.19.0',
         mode: 'optional-cli-adapter',
-        notes: 'Validated against upstream OpenSpec 1.4.1; AIFHub remains adapter-only.'
+        notes: 'Validated against upstream OpenSpec 1.4.0; AIFHub remains adapter-only.'
       }
     },
     ...extra
@@ -254,6 +257,25 @@ describe('validate-extension.mjs', () => {
   it('fails when AIFHub metadata violates the local schema', async () => {
     const parsed = JSON.parse(validAifhubMetadata());
     parsed.sources['ai-factory'].notes = 42;
+    await writeValidProject({ metadata: JSON.stringify(parsed) });
+
+    const code = await runValidatorExitCode(tmpDir);
+    assert.equal(code, 1);
+  });
+
+  it('fails when the latest reviewed OpenSpec stable version differs from source version', async () => {
+    const parsed = JSON.parse(validAifhubMetadata());
+    parsed.sources.openspec.version = '1.4.1';
+    await writeValidProject({ metadata: JSON.stringify(parsed) });
+
+    const code = await runValidatorExitCode(tmpDir);
+    assert.equal(code, 1);
+  });
+
+  it('fails when an OpenSpec prerelease is listed as reviewed stable', async () => {
+    const parsed = JSON.parse(validAifhubMetadata());
+    parsed.sources.openspec.reviewedStableVersions.push('1.6.0-beta.1');
+    parsed.sources.openspec.version = '1.6.0-beta.1';
     await writeValidProject({ metadata: JSON.stringify(parsed) });
 
     const code = await runValidatorExitCode(tmpDir);

--- a/skills/aif-analyze/SKILL.md
+++ b/skills/aif-analyze/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: aif-analyze
 description: Bootstrap project context. Resolves localization and stack, creates/updates config.yaml and rules/base.md, then checks DESCRIPTION and guides core skill execution.
-version: 0.9.3
+allowed-tools: Read Write Edit Glob Grep Bash(mkdir *) Bash(ai-factory aifhub-memory-tools *) Bash(ai-factory aifhub-mode status --json) Bash(node --input-type=module -e *openspec-runner.mjs*) Bash(rg --version) Bash(uv --version) Bash(graphify --version) Bash(graphify --help) Bash(codex-agent-mem-policy --help) Bash(codex-agent-mem-smoke --help) Bash(codegraph --version) Bash(codegraph --help) Bash(codegraph status) Bash(ctx7 --version) Bash(npx --no-install ctx7 --help) Bash(openspec init --tools none) Skill AskUserQuestion Questions
+version: 0.10.0
 author: ichi
 ---
 
@@ -398,14 +399,22 @@ openspec:
   canArchive: boolean
   version: string | null
   supportedRange: ">=1.3.1 <2.0.0"
+  latestReviewedVersion: "1.8.0"
+  versionOutdated: boolean | null
   requiresNode: ">=20.19.0"
   nodeSupported: boolean
   versionSupported: boolean
 ```
 
-- The runner may also return `nodeVersion`, `command`, `reason`, and `errors`; include those when useful for troubleshooting.
+- The runner may also return `nodeVersion`, `command`, `commandSource`, `reason`, and `errors`; include those when useful for troubleshooting.
 - Do not print raw command output unless troubleshooting requires it.
 - If the OpenSpec CLI is compatible, prefer or recommend `openspec init --tools none`.
+- When `versionSupported: true` and `versionOutdated: true`, the selected CLI is compatible but older than the latest reviewed stable version. Keep `canValidate` and `canArchive` unchanged and emit a non-blocking update recommendation that names the installed version, `latestReviewedVersion`, and safe `commandSource`.
+- Scope the recommendation to the user-owned installation selected by `commandSource`: update the project dependency for `project-local`, the existing PATH/global installation for `path`, or the caller-owned executable for `explicit`.
+- Do not guess a package manager. Recommend using the package manager or install method that already owns the selected CLI and rerunning `ai-factory aifhub-mode status --json` afterward.
+- Do not install, update, replace, or re-resolve OpenSpec automatically. Do not invoke `npx`, a package manager, network access, or `openspec update` from this skill.
+- When `versionOutdated: false`, do not recommend a downgrade, including when the supported selected version is newer than `latestReviewedVersion`.
+- When `versionOutdated: null`, do not invent a freshness verdict; follow the missing, unsupported, or version-detection guidance below.
 - If the OpenSpec CLI is missing or unsupported, continue bootstrap with `canValidate: false` and `canArchive: false`.
 - Missing or unsupported OpenSpec CLI is a degraded capability state, not a bootstrap failure.
 - If `reason` is `unsupported-version`, recommend installing or updating OpenSpec CLI to `>=1.3.1 <2.0.0`.
@@ -484,7 +493,7 @@ openspec init --tools none
 - Report the backward-compatible Graphify utility setting and `uv` availability only as compatibility context. If `utilities.graphify.enabled` is missing or `false`, Graphify may still be recommended only through local metadata; show manual setup commands only as explicit opt-in guidance: `uv --version`, `uv tool install graphifyy`, `graphify install`, and `graphify .`.
 - If autonomous/subagent mode defaulted to legacy `ai-factory` because the artifact protocol question could not be asked, report OpenSpec-native mode selection as an open question/blocker.
 - Report the active path set.
-- In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.
+- In `openspec-native` mode, include the OpenSpec capability object, degraded reason when present, version freshness (`version`, `latestReviewedVersion`, and `versionOutdated`), any non-blocking update recommendation, created/preserved skeleton directories, and the statement that OpenSpec skill installation was skipped by design.
 - In `openspec-native` mode, explicitly report whether `.ai-factory/state`, `.ai-factory/qa`, and `.ai-factory/rules/generated` were created or preserved.
 - Report what was invoked automatically versus what remains as manual next command.
 - If DESCRIPTION is missing, first recommended command must use the selected runtime invocation style: `$aif` for `codex-app`, `/aif` for slash-command runtimes.

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: aif-done
 description: Finalize a verified OpenSpec-native change or legacy AI Factory-only plan, prepare commit/PR summaries, and drive evidence-backed follow-ups.
-version: 1.2.0
+argument-hint: "[change-id|plan-id] [--skip-specs] [--record-dirty-state]"
+allowed-tools: Read Write Edit Glob Grep Bash(ai-factory aifhub-done-finalizer *) Bash(git status *) Bash(git branch --show-current) Bash(git diff *) Bash(git log *) Bash(gh --version)
+version: 1.3.0
 author: ichi
 ---
 

--- a/skills/aif-done/SKILL.md
+++ b/skills/aif-done/SKILL.md
@@ -19,7 +19,7 @@ Resolve mode from `.ai-factory/config.yaml`:
 
 ## OpenSpec-native mode
 
-OpenSpec-native mode finalizes the verified change state through `scripts/openspec-done-finalizer.mjs`. It is the only OpenSpec-native archive/finalization step after `/aif-verify` passes.
+OpenSpec-native mode runs verified installed-project finalization through `ai-factory aifhub-done-finalizer --change <change-id> --json`. The wrapper resolves the extension-local `scripts/openspec-done-finalizer.mjs` implementation module; never execute that module from the consumer project root or an internal installed path. This remains the only OpenSpec-native archive/finalization step after `/aif-verify` passes.
 
 ### Preconditions
 
@@ -31,14 +31,14 @@ OpenSpec-native mode finalizes the verified change state through `scripts/opensp
 - Require `.ai-factory/qa/<change-id>/coverage.json` to exist, be current, and have coverage status `pass` or policy-accepted `warn`.
 - Require generated rules and durable rules gate evidence according to `requireGeneratedRulesForDone` and `requireRulesPassForDone`; generated rules readiness does not satisfy rules gate pass.
 - Apply `allowWarnOnDone.rules`, `allowWarnOnDone.coverage`, and `allowWarnOnDone.openspecStatus` before accepting warning-only finalization evidence.
-- Always run the pre-archive readiness gate through `scripts/openspec-done-readiness.mjs` before archive and persist `.ai-factory/qa/<change-id>/done-readiness.json`.
+- The installed finalizer must always run its extension-local `scripts/openspec-done-readiness.mjs` implementation module before archive and persist `.ai-factory/qa/<change-id>/done-readiness.json`; do not invoke that module as an installed-project command.
 - If verification has not run or verdict is `fail`, stop and suggest `/aif-verify` or `/aif-fix`.
 - If the verify gate result is missing, invalid, or `fail`, stop and suggest rerunning `/aif-verify <change-id>` or `/aif-fix <change-id>`.
 - If coverage, generated rules, or rules gate evidence is missing, invalid, stale, failed, or warning-only when policy does not allow the warning, stop on the readiness result and show its `suggested_next.command` and `suggested_next.reason` exactly. For rules gate blockers, the command may be the installed durable evidence writer, not `/aif-rules-check` alone.
 - If readiness reports a blocking failure, refuse archive and show `suggested_next.command` and `suggested_next.reason` exactly.
 - Refuse unverified changes; do not accept `Code verification: PENDING` as final verification.
-- Dirty workspace state is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun the public route `/aif-done <change-id> --record-dirty-state` to record dirty state in final QA evidence before archive.
-- For docs/tooling-only changes that also need explicit dirty-state recording, preserve both flags with `/aif-done <change-id> --skip-specs --record-dirty-state`.
+- Dirty workspace state is blocking by default before archive. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` to record dirty state in final QA evidence before archive.
+- For docs/tooling-only changes that also need explicit dirty-state recording, preserve both flags with `ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json`.
 
 ### Canonical Context
 
@@ -64,9 +64,9 @@ Runtime state and QA evidence live outside canonical changes:
 
 ### Archive Policy
 
-- Archive through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs`; this corresponds to `openspec archive <change-id> --yes`.
-- Use `archiveOpenSpecChange(changeId)` for normal finalization.
-- Use `archiveOpenSpecChange(changeId, { skipSpecs: true })` for docs/tooling-only finalization; this corresponds to `openspec archive <change-id> --yes --skip-specs --no-color`.
+- Use `ai-factory aifhub-done-finalizer --change <change-id> --json` as the installed executable route. Add `--skip-specs` only for docs/tooling-only finalization and never add `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, or `--summary-only`.
+- Inside the extension implementation only, archive through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs`; this corresponds to `openspec archive <change-id> --yes`.
+- The extension-local implementation uses `archiveOpenSpecChange(changeId)` for normal finalization and `archiveOpenSpecChange(changeId, { skipSpecs: true })` for docs/tooling-only finalization; the latter corresponds to `openspec archive <change-id> --yes --skip-specs --no-color`.
 - Support the user-facing `--skip-specs` path while still writing final QA evidence and final summaries.
 - If OpenSpec CLI is missing or unsupported and archive is required, fail with an explicit OpenSpec CLI requirement.
 - Do not archive in `/aif-verify`; `/aif-verify` does not archive and only records verification evidence.
@@ -85,6 +85,7 @@ Normal output must report:
 - verification status and refusal reason when unverified;
 - dirty working tree state;
 - archive result;
+- bounded selected OpenSpec command/source from archive or pre-archive context;
 - canonical artifacts inspected;
 - generated rules state when relevant;
 - effective policy summary and policy-derived finalization blockers;
@@ -206,6 +207,8 @@ Legacy AI Factory-only mode preserves the verified plan finalization contract ba
 - In OpenSpec-native mode, never treat generated rules as a substitute for durable `rules` gate evidence.
 - In OpenSpec-native mode, obey `allowWarnOnDone` before accepting warning-only rules, coverage, or OpenSpec status evidence.
 - In OpenSpec-native mode, archive only through `archiveOpenSpecChange`; never use custom OpenSpec archive logic.
+- In installed OpenSpec-native projects, execute finalization only through `ai-factory aifhub-done-finalizer`; treat `scripts/openspec-done-finalizer.mjs`, `scripts/openspec-done-readiness.mjs`, and `scripts/openspec-runner.mjs` as extension-local implementation modules, not project-root commands.
+- Reject `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, `--summary-only`, and unknown finalizer options.
 - In OpenSpec-native mode, never silently archive through legacy `.ai-factory/specs`.
 - Never invent governance changes without evidence from the verified plan.
 - When governance updates belong to another owner, use the owning path or return an exact handoff instead of silently skipping the change.

--- a/skills/aif-done/references/finalization-contract.md
+++ b/skills/aif-done/references/finalization-contract.md
@@ -21,7 +21,7 @@ Reference for the `aif-done` skill and `aifhub-done-finalizer` agents.
 - Missing, invalid, stale, or failed coverage refuses finalization and requires `/aif-verify`.
 - Missing, invalid, stale, failed, or disallowed warning rules gate evidence refuses finalization when policy requires rules pass.
 - `Code verification: PENDING` is ambiguous and must refuse finalization.
-- Dirty workspace state is empty, or explicit dirty-state recording is enabled through `/aif-done <change-id> --record-dirty-state`.
+- Dirty workspace state is empty, or explicit dirty-state recording is enabled through `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json`.
 
 ### Canonical Context
 
@@ -44,23 +44,23 @@ openspec/changes/<change-id>/specs/**/spec.md
 
 ### Archive Policy
 
-OpenSpec-native `/aif-done` uses `scripts/openspec-done-finalizer.mjs`. Archive lifecycle mutation must happen through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs` and never through custom folder movement or direct `openspec/specs` edits. Normal archive is `openspec archive <change-id> --yes`.
+The installed executable route is `ai-factory aifhub-done-finalizer --change <change-id> --json`. It resolves the extension-local `scripts/openspec-done-finalizer.mjs` implementation module and must not require a consumer-root copy or an internal installed-path command. Archive lifecycle mutation inside the extension must happen through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs` and never through custom folder movement or direct `openspec/specs` edits.
 
-Normal archival corresponds to:
+Normal installed finalization:
 
 ```bash
-openspec archive <change-id> --yes
+ai-factory aifhub-done-finalizer --change <change-id> --json
 ```
 
 Docs/tooling-only archival uses `--skip-specs`:
 
 ```bash
-openspec archive <change-id> --yes --skip-specs --no-color
+ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --json
 ```
 
-`--skip-specs` still writes final QA evidence and final summaries. Missing or unsupported OpenSpec CLI fails when archive is required. `/aif-verify` does not archive.
+The extension-local implementation maps those commands to `openspec archive <change-id> --yes` or `openspec archive <change-id> --yes --skip-specs --no-color`. `--skip-specs` still writes final QA evidence and final summaries. Missing or unsupported OpenSpec CLI fails when archive is required. `/aif-verify` does not archive. Public finalization rejects `--force`, `--no-validate`, `--skip-archive`, `--dry-run`, `--summary-only`, and unknown options before calling the finalizer API.
 
-Dirty workspace state is blocking by default. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `/aif-done <change-id> --record-dirty-state` to record dirty state in final QA evidence before archive. For docs/tooling-only changes, combine the public flags as `/aif-done <change-id> --skip-specs --record-dirty-state`.
+Dirty workspace state is blocking by default. Inspect with `git status --short`; commit or stash unrelated changes, or rerun `ai-factory aifhub-done-finalizer --change <change-id> --record-dirty-state --json` to record dirty state in final QA evidence before archive. For docs/tooling-only changes, combine the public flags as `ai-factory aifhub-done-finalizer --change <change-id> --skip-specs --record-dirty-state --json`.
 
 OpenSpec-native mode does not use legacy `.ai-factory/specs` archive.
 
@@ -80,7 +80,9 @@ Do not write runtime-only files into `openspec/changes/<change-id>/`.
 
 ### Output
 
-Report selected `change-id`, effective policy summary, verification status, coverage matrix status, rules gate status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, `--skip-specs` state, commit draft, PR draft, and next steps: `/aif-mode sync`, `/aif-commit`, and optional `/aif-evolve`.
+Report selected `change-id`, effective policy summary, verification status, coverage matrix status, rules gate status, dirty working tree state, QA evidence path, `.ai-factory/qa/<change-id>/` final evidence path, `.ai-factory/state/<change-id>/` final summary path, canonical artifacts inspected, generated rules state, archive result, bounded OpenSpec command/source, `--skip-specs` state, commit draft, PR draft, and next steps: `/aif-mode sync`, `/aif-commit`, and optional `/aif-evolve`.
+
+Command exit codes are `0` for successful or policy-accepted warning finalization, `1` for a resolved blocking failure, and `2` for invalid arguments, unresolved or ambiguous scope, or an unexpected command failure.
 
 After successful finalization:
 

--- a/skills/aif-done/references/finalization-contract.md
+++ b/skills/aif-done/references/finalization-contract.md
@@ -46,6 +46,8 @@ openspec/changes/<change-id>/specs/**/spec.md
 
 The installed executable route is `ai-factory aifhub-done-finalizer --change <change-id> --json`. It resolves the extension-local `scripts/openspec-done-finalizer.mjs` implementation module and must not require a consumer-root copy or an internal installed-path command. Archive lifecycle mutation inside the extension must happen through `archiveOpenSpecChange(changeId, options)` from `scripts/openspec-runner.mjs` and never through custom folder movement or direct `openspec/specs` edits.
 
+Omitting `--change` delegates to the active-change resolver: exactly one resolvable active change may be selected, while missing or ambiguous scope exits with code `2` before finalization. Automation must always pass an explicit `--change <change-id>`.
+
 Normal installed finalization:
 
 ```bash


### PR DESCRIPTION
## Summary

- prefer an explicit or project-local OpenSpec CLI before the global PATH candidate
- execute project-local Windows shims through the platform-correct route and preserve bounded command-source diagnostics
- expose installed-project done finalization through the extension-owned `ai-factory aifhub-done-finalizer` wrapper
- declare the installed finalizer skill arguments and bounded tool permissions
- serialize same-process context-dedup ledger transactions to prevent verification-time lost updates

## Why

Installed projects do not own the extension's root helper scripts and could accidentally run a stale global OpenSpec CLI instead of the version declared by the project. Verification also exposed a same-process ledger race that could lose one concurrent context-dedup update.

## Impact

Installed OpenSpec-native projects can finalize changes through a stable public wrapper, consistently select the intended CLI on POSIX and Windows, and retain safe `commandSource` evidence without exposing private absolute paths.

## Validation

- `npm run validate`
- focused runtime and contract suite: 228/228 passed
- full `npm test`: 781/781 passed
- changed ESM syntax checks: 18/18 passed
- strict current-change OpenSpec validation: 1/1 passed
- aggregate strict OpenSpec validation: 37/37 passed
- rules gate: PASS
- verify gate: PASS with 0 warnings and 0 errors
- coverage: 5/5 requirements covered
- `git diff --check main...HEAD`
- `git diff --check`

Closes #145