### PR TITLE
fix(guidance): make rules-check and verify next-step routing one-way

### DIFF
--- a/agent-files/claude/aifhub-verifier.md
+++ b/agent-files/claude/aifhub-verifier.md
@@ -35,7 +35,7 @@ Use this mode when config declares `aifhub.artifactProtocol: openspec`.
 - Return findings first, then a gate result: `PASS`, `PASS with notes`, or `FAIL`.
 - Include active OpenSpec change, canonical artifacts inspected, effective policy summary, generated rules state, runtime state path, QA evidence path, validation status, `shouldRunCodeVerification`, coverage summary, code verification status, counts for blocking/important/optional findings, and next recommended command.
 - Recommend `/aif-fix <change-id>` when validation or verification fails, and `/aif-done <change-id>` only after passing verification.
-- Optional read-only gates before or during verification are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
+- Optional read-only gates are available before verification starts: `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`. Routing is one-way with terminal states: after passing verification suggest `/aif-done <change-id>`, never `/aif-rules-check` or another `/aif-verify` rerun; after failing verification route to `/aif-fix <change-id>`.
 - End with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase `status`: `pass`, `warn`, or `fail`. Write the same final block into `.ai-factory/qa/<change-id>/verify.md`.
 
 ## Legacy AI Factory-only mode

--- a/agent-files/codex/aifhub-verifier.toml
+++ b/agent-files/codex/aifhub-verifier.toml
@@ -32,7 +32,7 @@ Use this mode when config declares aifhub.artifactProtocol: openspec.
 - Return findings first, then a gate result: PASS, PASS with notes, or FAIL.
 - Include active OpenSpec change, canonical artifacts inspected, effective policy summary, generated rules state, runtime state path, QA evidence path, validation status, shouldRunCodeVerification, coverage summary, code verification status, counts for blocking/important/optional findings, and next recommended command.
 - Recommend /aif-fix <change-id> when validation or verification fails, and /aif-done <change-id> only after passing verification.
-- Optional read-only gates before or during verification are /aif-rules-check, /aif-review, and /aif-security-checklist. The authoritative final verification remains /aif-verify <change-id>.
+- Optional read-only gates are available before verification starts: /aif-rules-check, /aif-review, and /aif-security-checklist. The authoritative final verification remains /aif-verify <change-id>. Routing is one-way with terminal states: after passing verification suggest /aif-done <change-id>, never /aif-rules-check or another /aif-verify rerun; after failing verification route to /aif-fix <change-id>.
 - End with exactly one final fenced aif-gate-result JSON block using "gate": "verify" and lowercase status pass, warn, or fail. Write the same final block into .ai-factory/qa/<change-id>/verify.md.
 
 ## Legacy AI Factory-only mode

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -693,6 +693,8 @@ After implementation, optional read-only gates are available before final verifi
 
 The authoritative final verification remains `/aif-verify <change-id>`.
 
+Next-step routing between the gates and verification is one-way with terminal states: when `/aif-verify <change-id>` passes, the suggested next step is `/aif-done <change-id>` — a rerun of `/aif-rules-check` or `/aif-verify` is not suggested after a passing verification; when verification fails, the route is `/aif-fix <change-id>`. A passing `/aif-rules-check` suggests `/aif-verify <change-id>` only when verification has not already passed for the current change state; a failing `/aif-rules-check` routes to `/aif-mode sync --change <change-id>` and a rerun, never to `/aif-verify`.
+
 ### `/aif-rules-check`
 
 Reads:

--- a/injections/core/aif-rules-check-openspec-generated-rules.md
+++ b/injections/core/aif-rules-check-openspec-generated-rules.md
@@ -67,6 +67,13 @@ Runtime state and QA evidence are external context only:
 
 The final response must still follow the upstream rules-check output contract and end with exactly one final machine-readable `aif-gate-result` fenced JSON block. Use `"gate": "rules"` and lowercase JSON `status`: `pass`, `warn`, or `fail`.
 
+Next-step routing is one-way with terminal states and wins over any upstream next-step suggestion that would loop this gate with `/aif-verify`:
+
+- When this gate passes and `/aif-verify <change-id>` has not already passed for the current change state, the suggested next step is `/aif-verify <change-id>`.
+- When this gate passes and `/aif-verify <change-id>` has already passed for the current change state, the suggested next step is `/aif-done <change-id>`; do not suggest another `/aif-verify` run.
+- When this gate fails or generated rules are missing, stale, or invalid, follow the regeneration route above (`/aif-mode sync --change <change-id>`, then rerun `/aif-rules-check`); do not suggest `/aif-verify` as remediation for a failing rules gate.
+- Do not suggest rerunning this gate after it has already passed for the current change state.
+
 ### Legacy AI Factory-only mode
 
 When OpenSpec-native mode is not active, do not add OpenSpec generated-rule requirements. Follow the upstream `/aif-rules-check` behavior for `.ai-factory/RULES.md`, `rules.base`, named `rules.<area>`, optional plan context, changed files, and the final `aif-gate-result` block.

--- a/injections/core/aif-verify-plan-folder.md
+++ b/injections/core/aif-verify-plan-folder.md
@@ -117,7 +117,7 @@ Normal verification responses should report:
 - fix guidance `/aif-fix <change-id>` when verification fails;
 - optional finalization guidance `/aif-done <change-id>` when verification passes.
 
-Optional read-only gates before or during verification are `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`.
+Optional read-only gates are available before verification starts: `/aif-rules-check`, `/aif-review`, and `/aif-security-checklist`. The authoritative final verification remains `/aif-verify <change-id>`. This next-step routing is one-way with terminal states: when verification passes, suggest `/aif-done <change-id>` and do not suggest a rerun of `/aif-rules-check` or `/aif-verify`; when verification fails, route to `/aif-fix <change-id>`; do not suggest `/aif-rules-check` as remediation after verification has already run.
 
 End verification output and `.ai-factory/qa/<change-id>/verify.md` with exactly one final fenced `aif-gate-result` JSON block using `"gate": "verify"` and lowercase JSON `status`: `pass`, `warn`, or `fail`. Use `fail` for blocking OpenSpec validation, coverage, generated-rules, test, lint, build, review, security, or rules failures; use `warn` only for non-blocking notes after verification completes.
 

--- a/scripts/openspec-prompt-assets.test.mjs
+++ b/scripts/openspec-prompt-assets.test.mjs
@@ -1531,6 +1531,46 @@ describe('OpenSpec-native prompt asset contract', () => {
     }
   });
 
+  it('keeps verify and rules-check next-step guidance one-way with terminal states', async () => {
+    for (const relativePath of VERIFY_PROMPT_ASSETS) {
+      const asset = stripFencedBlocks(await readRepoFile(relativePath));
+
+      assert.doesNotMatch(
+        asset,
+        /before or during verification/i,
+        `${relativePath} should not invite a rules gate during or after verification`
+      );
+      for (const expected of [
+        'one-way',
+        'before verification starts',
+        '/aif-done <change-id>',
+        '/aif-fix <change-id>'
+      ]) {
+        assertIncludes(asset, expected, `${relativePath} one-way terminal routing`);
+      }
+    }
+
+    const rulesAsset = await readRepoFile('injections/core/aif-rules-check-openspec-generated-rules.md');
+    const rulesOpenspec = extractMarkdownSection(rulesAsset, 'OpenSpec-native mode');
+
+    for (const expected of [
+      'one-way',
+      'has not already passed',
+      '/aif-verify <change-id>',
+      '/aif-done <change-id>',
+      'do not suggest `/aif-verify` as remediation'
+    ]) {
+      assertIncludes(rulesOpenspec, expected, 'rules-check injection one-way terminal routing');
+    }
+
+    const usage = await readRepoFile('docs/usage.md');
+    assertIncludes(
+      usage,
+      'one-way with terminal states',
+      'docs/usage.md terminal routing statement'
+    );
+  });
+
   it('keeps planning-mode guidance capability-gated across active planning prompts', async () => {
     for (const relativePath of PLANNING_RUNTIME_PROMPT_ASSETS) {
       const asset = stripFencedBlocks(await readRepoFile(relativePath));


### PR DESCRIPTION
## Что делает

Устраняет цикл рекомендаций между `/aif-rules-check` и `/aif-verify` (issue #155): verify-инъекция приглашала optional rules gate «before **or during** verification», а upstream-тело rules-check-скилла предлагало `/aif-verify` — агент гонял пользователя по кругу вместо продвижения к `/aif-done`.

## Решение

Однонаправленная маршрутизация next-step guidance с терминальными состояниями, выровненная на машинный контракт `SUGGESTED_COMMANDS_BY_GATE` (`scripts/aif-gate-result.mjs`):

- verify PASS → `/aif-done <change-id>` (повторный rules-check/verify не предлагается)
- verify FAIL → `/aif-fix <change-id>`
- rules-check PASS без пройденного verify → `/aif-verify <change-id>`
- rules-check PASS при уже пройденном verify → `/aif-done <change-id>`
- rules-check FAIL/missing/stale receipts → `/aif-mode sync --change <change-id>` + rerun

## Изменения (6 файлов, +52/−3)

- `injections/core/aif-verify-plan-folder.md` — точечная правка: оборот «or during verification» удалён, добавлено явное one-way правило; контрактные фразы и строки 117–118 сохранены
- `injections/core/aif-rules-check-openspec-generated-rules.md` — секция next-step boundary в prepend-блоке (перекрывает upstream cross-suggestions)
- `agent-files/claude/aifhub-verifier.md`, `agent-files/codex/aifhub-verifier.toml` — зеркала синхронизированы (паритет claude/codex)
- `docs/usage.md` — терминальная маршрутизация в разделе optional gates
- `scripts/openspec-prompt-assets.test.mjs` — новый тест one-way контракта (`VERIFY_PROMPT_ASSETS` + PASS-маршрутизация rules-check)

## Evidence

- `npm run validate` PASS; `npm test` 939/939 PASS (127 suites)
- Coverage matrix PASS (1/1, policy strict); durable rules gate PASS
- OpenSpec change `fix-rules-check-verify-guidance-loop-issue-155` верифицирован (warn без блокеров; strict CLI-валидация env-degraded) и заархивирован; требование `Verify and rules-check guidance follows one-way terminal routing` принято в `openspec/specs/validation-gates/spec.md`
- Roadmap lifecycle: milestone v1.1 AIFHub Validation Layer, статус finalized

Fixes #155
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ichinya/aifhub-extension/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->